### PR TITLE
Remove DefinePlugin to fix undefined SDK_VERSION

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@
 /node_modules
 Gruntfile.js
 *.config.js
+writeConfig.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -7,4 +7,3 @@
 /node_modules
 Gruntfile.js
 *.config.js
-writeConfig.js

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/*
 build2
 test/SpecRunner.html
 npm-debug.log
+lib/config.json

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,15 +1,15 @@
-/* globals SDK_VERSION, STATE_TOKEN_COOKIE_NAME */
 /* eslint-disable complexity */
 var util = require('./util');
 var cookies = require('./cookies');
 var Q = require('q');
 var AuthApiError = require('./errors/AuthApiError');
+var config = require('./config.json');
 
 function httpRequest(sdk, url, method, args, dontSaveResponse) {
   var headers = {
     'Accept': 'application/json',
     'Content-Type': 'application/json',
-    'X-Okta-SDK': 'okta-auth-js-' + SDK_VERSION
+    'X-Okta-SDK': 'okta-auth-js-' + config.SDK_VERSION
   };
   util.extend(headers, sdk.options.headers || {});
 
@@ -28,12 +28,12 @@ function httpRequest(sdk, url, method, args, dontSaveResponse) {
 
       if (!dontSaveResponse) {
         if (!res.stateToken) {
-          cookies.deleteCookie(STATE_TOKEN_COOKIE_NAME);
+          cookies.deleteCookie(config.STATE_TOKEN_COOKIE_NAME);
         }
       }
 
       if (res && res.stateToken && res.expiresAt) {
-        cookies.setCookie(STATE_TOKEN_COOKIE_NAME, res.stateToken, res.expiresAt);
+        cookies.setCookie(config.STATE_TOKEN_COOKIE_NAME, res.stateToken, res.expiresAt);
       }
 
       return res;
@@ -61,7 +61,7 @@ function httpRequest(sdk, url, method, args, dontSaveResponse) {
       err = new AuthApiError(serverErr, resp);
 
       if (err.errorCode === 'E0000011') {
-        cookies.deleteCookie(STATE_TOKEN_COOKIE_NAME);
+        cookies.deleteCookie(config.STATE_TOKEN_COOKIE_NAME);
       }
 
       throw err;

--- a/lib/token.js
+++ b/lib/token.js
@@ -1,4 +1,3 @@
-/* globals FRAME_ID */
 /* eslint-disable complexity, max-statements */
 var http          = require('./http');
 var util          = require('./util');
@@ -6,6 +5,7 @@ var Q             = require('q');
 var sdkCrypto     = require('./crypto');
 var AuthSdkError  = require('./errors/AuthSdkError');
 var OAuthError    = require('./errors/OAuthError');
+var config        = require('./config.json');
 
 function getWellKnown(sdk) {
   return http.get(sdk, sdk.options.url + '/.well-known/openid-configuration');
@@ -410,7 +410,7 @@ function getIdToken(sdk, oauthOptions, options) {
   switch (flowType) {
     case 'IFRAME':
       var iframePromise = addPostMessageListener(sdk, options.timeout);
-      var iframeEl = loadFrame(requestUrl, FRAME_ID);
+      var iframeEl = loadFrame(requestUrl, config.FRAME_ID);
       return iframePromise
         .then(handleOAuthResponse)
         .fin(function() {

--- a/lib/tx.js
+++ b/lib/tx.js
@@ -1,10 +1,10 @@
-/* globals STATE_TOKEN_COOKIE_NAME, DEFAULT_POLLING_DELAY */
 /* eslint-disable complexity */
 var http              = require('./http');
 var util              = require('./util');
 var Q                 = require('q');
 var AuthSdkError      = require('./errors/AuthSdkError');
 var AuthPollStopError = require('./errors/AuthPollStopError');
+var config            = require('./config.json');
 
 function addStateToken(res, options) {
   var builtArgs = util.clone(options) || {};
@@ -28,7 +28,7 @@ function transactionStatus(sdk, args) {
 
 function resumeTransaction(sdk, args) {
   if (!args || !args.stateToken) {
-    var stateToken = sdk.tx.exists._getCookie(STATE_TOKEN_COOKIE_NAME);
+    var stateToken = sdk.tx.exists._getCookie(config.STATE_TOKEN_COOKIE_NAME);
     if (stateToken) {
       args = {
         stateToken: stateToken
@@ -45,7 +45,7 @@ function resumeTransaction(sdk, args) {
 
 function transactionExists(sdk) {
   // We have a cookie state token
-  return !!sdk.tx.exists._getCookie(STATE_TOKEN_COOKIE_NAME);
+  return !!sdk.tx.exists._getCookie(config.STATE_TOKEN_COOKIE_NAME);
 }
 
 function postToTransaction(sdk, url, options) {
@@ -68,7 +68,7 @@ function getPollFn(sdk, res, ref) {
     }
 
     if (!delay && delay !== 0) {
-      delay = DEFAULT_POLLING_DELAY;
+      delay = config.DEFAULT_POLLING_DELAY;
     }
 
     // Get the poll function

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "build:tests": "webpack --config webpack.test.config.js",
     "package": "grunt",
     "ci-update-package": "./node_modules/@okta/ci-update-package/bin/ci-update-package.js",
-    "ci-pkginfo:dataload": "./node_modules/@okta/ci-pkginfo/bin/ci-pkginfo.js -t dataload"
+    "ci-pkginfo:dataload": "./node_modules/@okta/ci-pkginfo/bin/ci-pkginfo.js -t dataload",
+    "prepublish": "node ./writeConfig.js"
   },
   "author": "Okta",
   "keywords": [
@@ -49,6 +50,7 @@
     "grunt-contrib-jasmine": "0.9.2",
     "grunt-shell": "1.3.0",
     "jquery": "2.1.4",
+    "json-loader": "0.5.4",
     "lodash": "4.10.0",
     "moment": "2.12.0",
     "normalize-url": "1.4.1",

--- a/test/spec/general.js
+++ b/test/spec/general.js
@@ -1,9 +1,9 @@
-/* globals SDK_VERSION */
 define(function(require) {
   var OktaAuth = require('OktaAuth');
   var Q = require('q');
   var util = require('../util/util');
   var _ = require('lodash');
+  var packageJson = require('../../package.json');
 
   describe('General Methods', function () {
 
@@ -439,7 +439,7 @@ define(function(require) {
               'X-Custom-Header': 'custom',
               'Accept': 'application/json',
               'Content-Type': 'application/json',
-              'X-Okta-SDK': 'okta-auth-js-' + SDK_VERSION
+              'X-Okta-SDK': 'okta-auth-js-' + packageJson.version
             }
           },
           response: 'session'

--- a/webpack.AMDJqueryQ.config.js
+++ b/webpack.AMDJqueryQ.config.js
@@ -5,11 +5,10 @@
 
 var path    = require('path');
 var webpack = require('webpack');
-var packageJson = require('./package.json');
+var _ = require('lodash');
+var commonConfig = require('./webpack.common.config');
 
-var oktaAuthConfig = packageJson['okta-auth-js'];
-
-module.exports = {
+module.exports = _.extend(commonConfig, {
   entry: './jquery/index.js',
   output: {
     path: path.join(__dirname, 'dist', 'browser'),
@@ -19,13 +18,5 @@ module.exports = {
   externals: [
     'jquery',
     'q'
-  ],
-  plugins: [
-    new webpack.DefinePlugin({
-      SDK_VERSION: JSON.stringify(packageJson.version),
-      STATE_TOKEN_COOKIE_NAME: JSON.stringify(oktaAuthConfig.STATE_TOKEN_COOKIE_NAME),
-      DEFAULT_POLLING_DELAY: oktaAuthConfig.DEFAULT_POLLING_DELAY,
-      FRAME_ID: JSON.stringify(oktaAuthConfig.FRAME_ID)
-    })
   ]
-};
+});

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -1,0 +1,12 @@
+// This is the base webpack config that other configs build upon
+
+// Write a config.json to lib containing globals like SDK_VERSION
+require('./writeConfig');
+
+module.exports = {
+  module: {
+    loaders: [
+      { test: /\.json$/, loader: 'json' }
+    ]
+  }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,12 +7,12 @@
 var path    = require('path');
 var webpack = require('webpack');
 var fs      = require('fs');
-var packageJson = require('./package.json');
+var _ = require('lodash');
+var commonConfig = require('./webpack.common.config');
 
-var oktaAuthConfig = packageJson['okta-auth-js'];
 var license = fs.readFileSync('lib/license-header.txt', 'utf8');
 
-module.exports = {
+module.exports = _.extend(commonConfig, {
   entry: './lib/index.js',
   output: {
     path: path.join(__dirname, 'dist', 'browser'),
@@ -21,13 +21,6 @@ module.exports = {
     libraryTarget: 'umd'
   },
   plugins: [
-    new webpack.DefinePlugin({
-      SDK_VERSION: JSON.stringify(packageJson.version),
-      STATE_TOKEN_COOKIE_NAME: JSON.stringify(oktaAuthConfig.STATE_TOKEN_COOKIE_NAME),
-      DEFAULT_POLLING_DELAY: oktaAuthConfig.DEFAULT_POLLING_DELAY,
-      FRAME_ID: JSON.stringify(oktaAuthConfig.FRAME_ID)
-    }),
-
     new webpack.optimize.UglifyJsPlugin({
       compress: {
         warnings: false
@@ -44,4 +37,4 @@ module.exports = {
     // Add a single Okta license after removing others
     new webpack.BannerPlugin(license)
   ]
-};
+});

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -1,16 +1,13 @@
 /*
- * This config builds a minified version that can be imported
- * anywhere without any dependencies. It packages the SDK
- * with reqwest and Q. It also preserves license comments.
+ * This config builds tests against the jQuery version of the module
  */
 
 var path    = require('path');
 var webpack = require('webpack');
-var packageJson = require('./package.json');
+var _ = require('lodash');
+var commonConfig = require('./webpack.common.config');
 
-var oktaAuthConfig = packageJson['okta-auth-js'];
-
-module.exports = {
+module.exports = _.extend(commonConfig, {
   entry: './test/main.js',
   output: {
     path: path.join(__dirname, 'dist', 'test'),
@@ -20,10 +17,5 @@ module.exports = {
     alias: {
       'OktaAuth$': path.join(__dirname, 'dist', 'browser', 'OktaAuthRequireJquery.js')
     }
-  },
-  plugins: [
-    new webpack.DefinePlugin({
-      SDK_VERSION: JSON.stringify(packageJson.version)
-    })
-  ]
-};
+  }
+});

--- a/writeConfig.js
+++ b/writeConfig.js
@@ -1,0 +1,17 @@
+/*
+ * This builds a config file that is imported by each module
+ * that needs access to a global variable like SDK_VERSION.
+ * The DefinePlugin in webpack is insufficient, because it
+ * restricts the sdk to only being used in a webpack config.
+ */
+
+var packageJson = require('./package.json');
+var fs = require('fs');
+
+var oktaAuthConfig = packageJson['okta-auth-js'];
+oktaAuthConfig.SDK_VERSION = packageJson.version;
+
+var configDest = __dirname + '/lib/config.json';
+
+console.log('Writing config to', configDest);
+fs.writeFileSync(configDest, JSON.stringify(oktaAuthConfig, null, 2));

--- a/writeConfig.js
+++ b/writeConfig.js
@@ -1,3 +1,5 @@
+/* globals __dirname */
+/* eslint-disable no-console */
 /*
  * This builds a config file that is imported by each module
  * that needs access to a global variable like SDK_VERSION.


### PR DESCRIPTION
Resolves: OKTA-94206

This fixes an issue where simply calling 'require' on the npm version of the sdk causes SDK_VERSION and other globals variables to be undefined. Webpack usually defines these variables using the DefinePlugin; now we build a config that can be 'require'd without webpack.

@rchild-okta 
@alexeystadnikov-okta 