### PR TITLE
Generate config.js instead of config.json

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,4 @@
 /node_modules
 Gruntfile.js
 *.config.js
+/lib/config.js

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ node_modules/*
 build2
 test/SpecRunner.html
 npm-debug.log
-lib/config.json
+lib/config.js

--- a/lib/http.js
+++ b/lib/http.js
@@ -3,7 +3,7 @@ var util = require('./util');
 var cookies = require('./cookies');
 var Q = require('q');
 var AuthApiError = require('./errors/AuthApiError');
-var config = require('./config.json');
+var config = require('./config');
 
 function httpRequest(sdk, url, method, args, dontSaveResponse) {
   var headers = {

--- a/lib/token.js
+++ b/lib/token.js
@@ -5,7 +5,7 @@ var Q             = require('q');
 var sdkCrypto     = require('./crypto');
 var AuthSdkError  = require('./errors/AuthSdkError');
 var OAuthError    = require('./errors/OAuthError');
-var config        = require('./config.json');
+var config        = require('./config');
 var cookies       = require('./cookies');
 
 function getWellKnown(sdk) {

--- a/lib/tx.js
+++ b/lib/tx.js
@@ -4,7 +4,7 @@ var util              = require('./util');
 var Q                 = require('q');
 var AuthSdkError      = require('./errors/AuthSdkError');
 var AuthPollStopError = require('./errors/AuthPollStopError');
-var config            = require('./config.json');
+var config            = require('./config');
 
 function addStateToken(res, options) {
   var builtArgs = util.clone(options) || {};

--- a/writeConfig.js
+++ b/writeConfig.js
@@ -13,7 +13,7 @@ var fs = require('fs');
 var oktaAuthConfig = packageJson['okta-auth-js'];
 oktaAuthConfig.SDK_VERSION = packageJson.version;
 
-var configDest = __dirname + '/lib/config.json';
+var configDest = __dirname + '/lib/config.js';
 
 console.log('Writing config to', configDest);
-fs.writeFileSync(configDest, JSON.stringify(oktaAuthConfig, null, 2));
+fs.writeFileSync(configDest, 'module.exports = ' + JSON.stringify(oktaAuthConfig, null, 2) + ';');


### PR DESCRIPTION
Resolves: OKTA-96664

This allows importing via webpack without using the json-loader

@rchild-okta 
@manueltanzi-okta 