### PR TITLE
Added auth code support

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -213,7 +213,7 @@ function hashToObject(hash) {
     var value = param[2];
 
     // id_token should remain base64url encoded
-    if (key === 'id_token' || key === 'access_token') {
+    if (key === 'id_token' || key === 'access_token' || key === 'code') {
       obj[key] = value;
     } else {
       obj[key] = decodeURIComponent(value.replace(plus2space, ' '));
@@ -299,6 +299,18 @@ function handleOAuthResponse(sdk, oauthParams, res) {
       tokenDict['token'] = accessToken;
     } else {
       return accessToken;
+    }
+  }
+
+  if (res['code']) {
+    var authorizationCode = {
+      authorizationCode: res['code']
+    };
+
+    if (Array.isArray(tokenTypes)) {
+      tokenDict['code'] = authorizationCode;
+    } else {
+      return authorizationCode;
     }
   }
 
@@ -583,9 +595,24 @@ function getWithPopup(sdk, oauthOptions, options) {
 function getWithRedirect(sdk, oauthOptions, options) {
   oauthOptions = util.clone(oauthOptions) || {};
   var oauthParams = getDefaultOAuthParams(sdk, oauthOptions);
-  util.extend(oauthParams, {
-    responseMode: 'fragment'
-  });
+  // If the user didn't specify a responseMode
+  if (!oauthOptions.responseMode) {
+    // And it's only an auth code request (responseType could be an array)
+    var respType = oauthParams.responseType;
+    if (respType.indexOf('code') !== -1 &&
+        (util.isString(respType) || (util.isArray(respType) && respType.length === 1))) {
+        // Default the responseMode to query
+        util.extend(oauthParams, {
+          responseMode: 'query'
+        });
+    // Otherwise, default to fragment
+    } else {
+      util.extend(oauthParams, {
+        responseMode: 'fragment'
+      });
+    }
+  }
+  
   var requestUrl = buildAuthorizeUrl(sdk, oauthParams);
 
   // Set session cookie to store the oauthParams

--- a/lib/token.js
+++ b/lib/token.js
@@ -600,7 +600,7 @@ function getWithRedirect(sdk, oauthOptions, options) {
     // And it's only an auth code request (responseType could be an array)
     var respType = oauthParams.responseType;
     if (respType.indexOf('code') !== -1 &&
-        (util.isString(respType) || (util.isArray(respType) && respType.length === 1))) {
+        (util.isString(respType) || (Array.isArray(respType) && respType.length === 1))) {
         // Default the responseMode to query
         util.extend(oauthParams, {
           responseMode: 'query'
@@ -629,7 +629,7 @@ function getWithRedirect(sdk, oauthOptions, options) {
 function isToken(obj) {
   if (obj &&
       (obj.accessToken || obj.idToken) &&
-      util.isArray(obj.scopes)) {
+      Array.isArray(obj.scopes)) {
     return true;
   }
   return false;

--- a/test/spec/token.js
+++ b/test/spec/token.js
@@ -562,6 +562,105 @@ define(function(require) {
                              'scope=openid%20email'
       });
     });
+
+    it('sets authorize url for authorization code requests, defaulting responseMode to query', function() {
+      oauthUtil.setupRedirect({
+        getWithRedirectArgs: {
+          sessionToken: 'testToken',
+          responseType: 'code'
+        },
+        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+          responseType: 'code',
+          state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          scopes: ['openid', 'email']
+        }) + ';',
+        expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
+                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
+                             'redirect_uri=https%3A%2F%2Fauth-js-test.okta.com%2Fredirect&' +
+                             'response_type=code&' +
+                             'response_mode=query&' +
+                             'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                             'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                             'sessionToken=testToken&' +
+                             'scope=openid%20email'
+      });
+    });
+
+    it('sets authorize url for authorization code (as an array) requests, ' +
+      'defaulting responseMode to query', function() {
+      oauthUtil.setupRedirect({
+        getWithRedirectArgs: {
+          sessionToken: 'testToken',
+          responseType: ['code']
+        },
+        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+          responseType: ['code'],
+          state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          scopes: ['openid', 'email']
+        }) + ';',
+        expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
+                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
+                             'redirect_uri=https%3A%2F%2Fauth-js-test.okta.com%2Fredirect&' +
+                             'response_type=code&' +
+                             'response_mode=query&' +
+                             'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                             'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                             'sessionToken=testToken&' +
+                             'scope=openid%20email'
+      });
+    });
+
+    it('sets authorize url for authorization code and id_token requests,' +
+      ' defaulting responseMode to fragment', function() {
+      oauthUtil.setupRedirect({
+        getWithRedirectArgs: {
+          sessionToken: 'testToken',
+          responseType: ['code', 'id_token']
+        },
+        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+          responseType: ['code', 'id_token'],
+          state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          scopes: ['openid', 'email']
+        }) + ';',
+        expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
+                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
+                             'redirect_uri=https%3A%2F%2Fauth-js-test.okta.com%2Fredirect&' +
+                             'response_type=code%20id_token&' +
+                             'response_mode=fragment&' +
+                             'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                             'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                             'sessionToken=testToken&' +
+                             'scope=openid%20email'
+      });
+    });
+
+    it('sets authorize url for authorization code requests, allowing form_post responseMode', function() {
+      oauthUtil.setupRedirect({
+        getWithRedirectArgs: {
+          sessionToken: 'testToken',
+          responseType: 'code',
+          responseMode: 'form_post'
+        },
+        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+          responseType: 'code',
+          state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          scopes: ['openid', 'email']
+        }) + ';',
+        expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
+                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
+                             'redirect_uri=https%3A%2F%2Fauth-js-test.okta.com%2Fredirect&' +
+                             'response_type=code&' +
+                             'response_mode=form_post&' +
+                             'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                             'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                             'sessionToken=testToken&' +
+                             'scope=openid%20email'
+      });
+    });
   });
 
   describe('token.parseFromUrl', function() {
@@ -636,6 +735,40 @@ define(function(require) {
           expiresAt: 1449703529,
           scopes: ['openid', 'email'],
           tokenType: 'Bearer'
+        }]
+      })
+      .fin(function() {
+        done();
+      });
+    });
+
+    it('parses access_token, id_token, and code', function(done) {
+      return oauthUtil.setupParseUrl({
+        time: 1449699929,
+        hashMock: '#access_token=' + tokens.standardAccessToken +
+                  '&id_token=' + tokens.standardIdToken +
+                  '&code=' + tokens.standardAuthorizationCode +
+                  '&expires_in=3600' +
+                  '&token_type=Bearer' +
+                  '&state=' + oauthUtil.mockedState,
+        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+          responseType: ['id_token', 'token', 'code'],
+          state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          scopes: ['openid', 'email']
+        }) + ';',
+        expectedResp: [{
+          idToken: tokens.standardIdToken,
+          claims: tokens.standardIdTokenClaims,
+          expiresAt: 1449699930,
+          scopes: ['openid', 'email']
+        }, {
+          accessToken: tokens.standardAccessToken,
+          expiresAt: 1449703529,
+          scopes: ['openid', 'email'],
+          tokenType: 'Bearer'
+        }, {
+          authorizationCode: tokens.standardAuthorizationCode
         }]
       })
       .fin(function() {

--- a/test/util/tokens.js
+++ b/test/util/tokens.js
@@ -197,5 +197,7 @@ define(function() {
                            'KZsa4srVE0uXiqdiyiljZ692gdXbwBXgWNIA2PWMrIagxWiqYCn' +
                            'fAJcS7TCE611eg-c';
 
+  tokens.standardAuthorizationCode = '35cFyfgCU2u0a1EzAqbO';
+
   return tokens;
 });


### PR DESCRIPTION
Resolves: OKTA-100899

Uses query as default responseMode if only an authorization code is requested, otherwise defaults to fragment. Also adds the ability to parse an authorization code from a url fragment.

@rchild-okta 
@haishengwu-okta 