### PR TITLE
Change distributed filename to okta-auth-js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = _.extend(commonConfig, {
   entry: './lib/index.js',
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: 'OktaAuth.min.js',
+    filename: 'okta-auth-js.min.js',
     library: 'OktaAuth',
     libraryTarget: 'umd'
   },


### PR DESCRIPTION
Resolves: OKTA-104120

@rchild-okta @magizh-okta 

This changes future distributed assets from:

> https://ok1static.oktacdn.com/assets/js/sdk/okta-auth-js/x.x.x/OktaAuth.min.js

to:

> https://ok1static.oktacdn.com/assets/js/sdk/okta-auth-js/x.x.x/okta-auth-js.min.js

in order to match okta-signin-widget:

> https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/x.x.x/js/okta-sign-in.min.js

edit: just noticed our okta-signin-widget name is pretty strange itself. Should we change "okta-sign-in.min.js" to "okta-signin-widget.min.js"?