### PR TITLE
Added state and nonce cookies for token validation

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -6,7 +6,7 @@ function setCookie(name, value, expiresAt) {
     expiresText = ' expires=' + util.isoToUTCString(expiresAt) + ';';
   }
 
-  var cookieText = name + '=' + value + ';' + expiresText;
+  var cookieText = name + '=' + value + '; path=/;' + expiresText;
   setCookie._setDocumentCookie(cookieText);
 
   return cookieText;

--- a/lib/token.js
+++ b/lib/token.js
@@ -531,6 +531,12 @@ function getWithRedirect(sdk, oauthOptions, options) {
     urls: urls
   }));
 
+  // Set nonce cookie for servers to validate nonce in id_token
+  cookies.setCookie(config.REDIRECT_NONCE_COOKIE_NAME, oauthParams.nonce);
+
+  // Set state cookie for servers to validate state
+  cookies.setCookie(config.REDIRECT_STATE_COOKIE_NAME, oauthParams.state);
+
   sdk.token.getWithRedirect._setLocation(requestUrl);
 }
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "DEFAULT_CACHE_DURATION": 86400,
     "FRAME_ID": "okta-oauth-helper-frame",
     "REDIRECT_OAUTH_PARAMS_COOKIE_NAME": "okta-oauth-redirect-params",
+    "REDIRECT_STATE_COOKIE_NAME": "okta-oauth-state",
+    "REDIRECT_NONCE_COOKIE_NAME": "okta-oauth-nonce",
     "TOKEN_STORAGE_NAME": "okta-token-storage",
     "CACHE_STORAGE_NAME": "okta-cache-storage"
   }

--- a/test/spec/token.js
+++ b/test/spec/token.js
@@ -949,17 +949,21 @@ define(function(require) {
         getWithRedirectArgs: {
           sessionToken: 'testToken'
         },
-        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
-          responseType: 'id_token',
-          state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          scopes: ['openid', 'email'],
-          urls: {
-            issuer: 'https://auth-js-test.okta.com',
-            authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-            userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-          }
-        }) + ';',
+        expectedCookies: [
+          'okta-oauth-redirect-params=' + JSON.stringify({
+            responseType: 'id_token',
+            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            scopes: ['openid', 'email'],
+            urls: {
+              issuer: 'https://auth-js-test.okta.com',
+              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+            }
+          }) + '; path=/;',
+          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
+          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+        ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                              'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
@@ -983,17 +987,21 @@ define(function(require) {
         getWithRedirectArgs: {
           sessionToken: 'testToken'
         },
-        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
-          responseType: 'id_token',
-          state: oauthUtil.mockedState,
-          nonce: oauthUtil.mockedNonce,
-          scopes: ['openid', 'email'],
-          urls: {
-            issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
-            authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
-            userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
-          }
-        }) + ';',
+        expectedCookies: [
+          'okta-oauth-redirect-params=' + JSON.stringify({
+            responseType: 'id_token',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
+            scopes: ['openid', 'email'],
+            urls: {
+              issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
+              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
+              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
+            }
+          }) + '; path=/;',
+          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
+          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+        ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                              'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
@@ -1021,17 +1029,21 @@ define(function(require) {
         }, {
           issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
         }],
-        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
-          responseType: 'token',
-          state: oauthUtil.mockedState,
-          nonce: oauthUtil.mockedNonce,
-          scopes: ['email'],
-          urls: {
-            issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
-            authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
-            userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
-          }
-        }) + ';',
+        expectedCookies: [
+          'okta-oauth-redirect-params=' + JSON.stringify({
+            responseType: 'token',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
+            scopes: ['email'],
+            urls: {
+              issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
+              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
+              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
+            }
+          }) + '; path=/;',
+          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
+          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+        ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                              'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
@@ -1051,17 +1063,21 @@ define(function(require) {
           scopes: ['email'],
           sessionToken: 'testToken'
         },
-        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
-          responseType: 'token',
-          state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          scopes: ['email'],
-          urls: {
-            issuer: 'https://auth-js-test.okta.com',
-            authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-            userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-          }
-        }) + ';',
+        expectedCookies: [
+          'okta-oauth-redirect-params=' + JSON.stringify({
+            responseType: 'token',
+            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            scopes: ['email'],
+            urls: {
+              issuer: 'https://auth-js-test.okta.com',
+              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+            }
+          }) + '; path=/;',
+          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
+          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+        ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                              'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
@@ -1087,17 +1103,21 @@ define(function(require) {
           scopes: ['email'],
           sessionToken: 'testToken'
         },
-        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
-          responseType: 'token',
-          state: oauthUtil.mockedState,
-          nonce: oauthUtil.mockedNonce,
-          scopes: ['email'],
-          urls: {
-            issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
-            authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
-            userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
-          }
-        }) + ';',
+        expectedCookies: [
+          'okta-oauth-redirect-params=' + JSON.stringify({
+            responseType: 'token',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
+            scopes: ['email'],
+            urls: {
+              issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
+              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
+              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
+            }
+          }) + '; path=/;',
+          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
+          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+        ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                              'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
@@ -1116,17 +1136,21 @@ define(function(require) {
           responseType: ['token', 'id_token'],
           idp: 'testIdp'
         },
-        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
-          responseType: ['token', 'id_token'],
-          state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          scopes: ['openid', 'email'],
-          urls: {
-            issuer: 'https://auth-js-test.okta.com',
-            authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-            userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-          }
-        }) + ';',
+        expectedCookies: [
+          'okta-oauth-redirect-params=' + JSON.stringify({
+            responseType: ['token', 'id_token'],
+            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            scopes: ['openid', 'email'],
+            urls: {
+              issuer: 'https://auth-js-test.okta.com',
+              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+            }
+          }) + '; path=/;',
+          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
+          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+        ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                              'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
@@ -1151,17 +1175,21 @@ define(function(require) {
           responseType: ['token', 'id_token'],
           idp: 'testIdp'
         },
-        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
-          responseType: ['token', 'id_token'],
-          state: oauthUtil.mockedState,
-          nonce: oauthUtil.mockedNonce,
-          scopes: ['openid', 'email'],
-          urls: {
-            issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
-            authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
-            userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
-          }
-        }) + ';',
+        expectedCookies: [
+          'okta-oauth-redirect-params=' + JSON.stringify({
+            responseType: ['token', 'id_token'],
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
+            scopes: ['openid', 'email'],
+            urls: {
+              issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
+              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
+              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
+            }
+          }) + '; path=/;',
+          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
+          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+        ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                              'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
@@ -1180,17 +1208,21 @@ define(function(require) {
           sessionToken: 'testToken',
           responseType: 'code'
         },
-        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
-          responseType: 'code',
-          state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          scopes: ['openid', 'email'],
-          urls: {
-            issuer: 'https://auth-js-test.okta.com',
-            authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-            userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-          }
-        }) + ';',
+        expectedCookies: [
+          'okta-oauth-redirect-params=' + JSON.stringify({
+            responseType: 'code',
+            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            scopes: ['openid', 'email'],
+            urls: {
+              issuer: 'https://auth-js-test.okta.com',
+              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+            }
+          }) + '; path=/;',
+          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
+          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+        ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                              'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
@@ -1215,17 +1247,21 @@ define(function(require) {
           sessionToken: 'testToken',
           responseType: 'code'
         },
-        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
-          responseType: 'code',
-          state: oauthUtil.mockedState,
-          nonce: oauthUtil.mockedNonce,
-          scopes: ['openid', 'email'],
-          urls: {
-            issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
-            authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
-            userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
-          }
-        }) + ';',
+        expectedCookies: [
+          'okta-oauth-redirect-params=' + JSON.stringify({
+            responseType: 'code',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
+            scopes: ['openid', 'email'],
+            urls: {
+              issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
+              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
+              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
+            }
+          }) + '; path=/;',
+          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
+          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+        ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                              'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
@@ -1245,17 +1281,21 @@ define(function(require) {
           sessionToken: 'testToken',
           responseType: ['code']
         },
-        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
-          responseType: ['code'],
-          state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          scopes: ['openid', 'email'],
-          urls: {
-            issuer: 'https://auth-js-test.okta.com',
-            authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-            userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-          }
-        }) + ';',
+        expectedCookies: [
+          'okta-oauth-redirect-params=' + JSON.stringify({
+            responseType: ['code'],
+            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            scopes: ['openid', 'email'],
+            urls: {
+              issuer: 'https://auth-js-test.okta.com',
+              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+            }
+          }) + '; path=/;',
+          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
+          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+        ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                              'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
@@ -1275,17 +1315,21 @@ define(function(require) {
           sessionToken: 'testToken',
           responseType: ['code', 'id_token']
         },
-        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
-          responseType: ['code', 'id_token'],
-          state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          scopes: ['openid', 'email'],
-          urls: {
-            issuer: 'https://auth-js-test.okta.com',
-            authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-            userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-          }
-        }) + ';',
+        expectedCookies: [
+          'okta-oauth-redirect-params=' + JSON.stringify({
+            responseType: ['code', 'id_token'],
+            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            scopes: ['openid', 'email'],
+            urls: {
+              issuer: 'https://auth-js-test.okta.com',
+              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+            }
+          }) + '; path=/;',
+          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
+          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+        ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                              'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
@@ -1305,17 +1349,21 @@ define(function(require) {
           responseType: 'code',
           responseMode: 'form_post'
         },
-        expectedCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
-          responseType: 'code',
-          state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          scopes: ['openid', 'email'],
-          urls: {
-            issuer: 'https://auth-js-test.okta.com',
-            authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-            userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-          }
-        }) + ';',
+        expectedCookies: [
+          'okta-oauth-redirect-params=' + JSON.stringify({
+            responseType: 'code',
+            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            scopes: ['openid', 'email'],
+            urls: {
+              issuer: 'https://auth-js-test.okta.com',
+              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+            }
+          }) + '; path=/;',
+          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
+          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+        ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                              'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
@@ -1344,7 +1392,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + ';',
+        }) + '; path=/;',
         expectedResp: {
           idToken: tokens.standardIdToken,
           claims: tokens.standardIdTokenClaims,
@@ -1371,7 +1419,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
           }
-        }) + ';',
+        }) + '; path=/;',
         expectedResp: tokens.authServerIdTokenParsed
       })
       .fin(function() {
@@ -1396,7 +1444,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + ';',
+        }) + '; path=/;',
         expectedResp: tokens.standardAccessTokenParsed
       })
       .fin(function() {
@@ -1421,7 +1469,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
           }
-        }) + ';',
+        }) + '; path=/;',
         expectedResp: tokens.authServerAccessTokenParsed
       })
       .fin(function() {
@@ -1447,7 +1495,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + ';',
+        }) + '; path=/;',
         expectedResp: [tokens.standardIdTokenParsed, tokens.standardAccessTokenParsed]
       })
       .fin(function() {
@@ -1473,7 +1521,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
           }
-        }) + ';',
+        }) + '; path=/;',
         expectedResp: [tokens.authServerIdTokenParsed, tokens.authServerTokenParsed]
       })
       .fin(function() {
@@ -1500,7 +1548,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + ';',
+        }) + '; path=/;',
         expectedResp: [tokens.standardIdTokenParsed, tokens.standardAccessTokenParsed, {
           authorizationCode: tokens.standardAuthorizationCode
         }]
@@ -1529,7 +1577,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
           }
-        }) + ';',
+        }) + '; path=/;',
         expectedResp: [tokens.authServerIdTokenParsed, tokens.authServerAccessTokenParsed, {
           authorizationCode: tokens.standardAuthorizationCode
         }]
@@ -1553,7 +1601,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + ';'
+        }) + '; path=/;'
       },
       {
         name: 'AuthSdkError',
@@ -1605,7 +1653,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + ';'
+        }) + '; path=/;'
       },
       {
         name: 'AuthSdkError',
@@ -1636,7 +1684,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + ';'
+        }) + '; path=/;'
       },
       {
         name: 'AuthSdkError',

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -503,7 +503,7 @@ define(function(require) {
           client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
           expect(setCookieMock).toHaveBeenCalledWith('okta-token-storage=' + JSON.stringify({
             'test-idToken': tokens.standardIdTokenParsed
-          }) + '; expires=Tue, 19 Jan 2038 03:14:07 GMT;');
+          }) + '; path=/; expires=Tue, 19 Jan 2038 03:14:07 GMT;');
         });
       });
 
@@ -529,7 +529,7 @@ define(function(require) {
           client.tokenManager.remove('test-idToken');
           expect(setCookieMock).toHaveBeenCalledWith('okta-token-storage=' + JSON.stringify({
             anotherKey: tokens.standardIdTokenParsed
-          }) + '; expires=Tue, 19 Jan 2038 03:14:07 GMT;');
+          }) + '; path=/; expires=Tue, 19 Jan 2038 03:14:07 GMT;');
         });
       });
 
@@ -542,7 +542,8 @@ define(function(require) {
           }) + ';');
           var setCookieMock = util.mockSetCookie();
           client.tokenManager.clear();
-          expect(setCookieMock).toHaveBeenCalledWith('okta-token-storage={}; expires=Tue, 19 Jan 2038 03:14:07 GMT;');
+          expect(setCookieMock).toHaveBeenCalledWith('okta-token-storage={}; path=/; ' +
+            'expires=Tue, 19 Jan 2038 03:14:07 GMT;');
         });
       });
     });

--- a/test/util/oauthUtil.js
+++ b/test/util/oauthUtil.js
@@ -5,6 +5,7 @@ define(function(require) {
   var tokens = require('./tokens');
   var Q = require('q');
   var EventEmitter = require('tiny-emitter');
+  var _ = require('lodash');
 
   var oauthUtil = {};
 
@@ -296,7 +297,10 @@ define(function(require) {
     }
 
     expect(windowLocationMock).toHaveBeenCalledWith(opts.expectedRedirectUrl);
-    expect(setCookieMock).toHaveBeenCalledWith(opts.expectedCookie);
+
+    _.each(opts.expectedCookies, function(cookie) {
+      expect(setCookieMock).toHaveBeenCalledWith(cookie);
+    });
   };
 
   oauthUtil.setupParseUrl = function(opts) {
@@ -317,7 +321,7 @@ define(function(require) {
         validateResponse(res, expectedResp);
 
         // The cookie should be deleted
-        expect(setCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params=; ' +
+        expect(setCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params=; path=/; ' +
           'expires=Thu, 01 Jan 1970 00:00:00 GMT;');
       });
   };


### PR DESCRIPTION
Resolves: OKTA-104490

In order to validate id_tokens sent to the server via query responses, we need to pass cookies with the state and nonce. We store stringified JSON in `okta-oauth-redirect-params`, but this is non-trivial to parse on the server, so I've added `okta-oauth-state` and `okta-oauth-nonce` to make this easier.

I also changed the path of the cookies to match root. Without the root path, the cookies aren't parseable from different url paths.

@rchild-okta @magizh-okta 