### PR TITLE
:memo: Add metadata to package.json for D.O.C linkage

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,20 @@
     "ci-pkginfo:dataload": "./node_modules/@okta/ci-pkginfo/bin/ci-pkginfo.js -t dataload",
     "prepublish": "node ./writeConfig.js && grunt shell:UMDNoDependencies"
   },
+  "okta": {
+    "doc": [
+      {
+        "source": "README.md",
+        "target": "_source/_code/javascript/okta_auth_sdk.md",
+        "frontmatter": {
+          "layout": "docs_page",
+          "title": "Okta Auth SDK",
+          "weight": "10",
+          "excerpt": "A Javascript wrapper for Okta's Authentication APIs. Build your own branded UI and power sign-in with Okta."
+        }
+      }
+    ]
+  },
   "author": "Okta",
   "keywords": [
     "Okta",


### PR DESCRIPTION
Add metadata to `package.json` which will enable scripts to transclude documentation from GitHub repositories into developer.okta.com

Resolves: OKTA-115325
Bacon: test