### PR TITLE
:white_check_mark: Check for -admin in URL during init

### DIFF
--- a/lib/clientBuilder.js
+++ b/lib/clientBuilder.js
@@ -39,6 +39,11 @@ function OktaAuthBuilder(args) {
       'Required usage: new OktaAuth({url: "https://sample.okta.com"})');
   }
 
+  if (args.url.includes('-admin.')) {
+    throw new AuthSdkError('URL passed to constructor contains illegal "-admin". ' +
+      'Required usage: new OktaAuth({url: "https://dev-12345.okta.com})');
+  }
+
   this.options = {
     url: util.removeTrailingSlash(args.url),
     clientId: args.clientId,

--- a/lib/clientBuilder.js
+++ b/lib/clientBuilder.js
@@ -39,7 +39,7 @@ function OktaAuthBuilder(args) {
       'Required usage: new OktaAuth({url: "https://sample.okta.com"})');
   }
 
-  if (args.url.includes('-admin.')) {
+  if (args.url.indexOf('-admin.') !== -1) {
     throw new AuthSdkError('URL passed to constructor contains illegal "-admin". ' +
       'Required usage: new OktaAuth({url: "https://dev-12345.okta.com})');
   }

--- a/lib/clientBuilder.js
+++ b/lib/clientBuilder.js
@@ -40,7 +40,7 @@ function OktaAuthBuilder(args) {
   }
 
   if (args.url.indexOf('-admin.') !== -1) {
-    throw new AuthSdkError('URL passed to constructor contains illegal "-admin". ' +
+    throw new AuthSdkError('URL passed to constructor contains "-admin" in subdomain. ' +
       'Required usage: new OktaAuth({url: "https://dev-12345.okta.com})');
   }
 

--- a/test/spec/errors.js
+++ b/test/spec/errors.js
@@ -95,5 +95,16 @@ define(function(require) {
         'Required usage: new OktaAuth({url: "https://sample.okta.com"})');
     });
 
+    it('throw an error if url contains "-admin" when passed to the constructor', function () {
+      var err;
+      try {
+        new OktaAuth({url: 'https://dev-12345-admin.oktapreview.com'}); // eslint-disable-line no-new
+      } catch (e) {
+        err = e;
+      }
+      expect(err.name).toEqual('AuthSdkError');
+      expect(err.errorSummary).toEqual('URL passed to constructor contains illegal "-admin". ' +
+        'Required usage: new OktaAuth({url: "https://dev-12345.okta.com})');
+    });
   });
 });

--- a/test/spec/errors.js
+++ b/test/spec/errors.js
@@ -103,7 +103,7 @@ define(function(require) {
         err = e;
       }
       expect(err.name).toEqual('AuthSdkError');
-      expect(err.errorSummary).toEqual('URL passed to constructor contains illegal "-admin". ' +
+      expect(err.errorSummary).toEqual('URL passed to constructor contains "-admin" in subdomain. ' +
         'Required usage: new OktaAuth({url: "https://dev-12345.okta.com})');
     });
   });


### PR DESCRIPTION
- Checks for `*-admin.*` when attempting to init the `OktaAuth` object.