### PR TITLE
feat: Allow user agent to be modified

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,7 @@
     "max-depth": [2, 3],
     "max-len": [2, 120],
     "max-params": [2, 5],
-    "max-statements": [2, 20],
+    "max-statements": [2, 25],
     "quotes": [2, "single"],
     "semi": 2,
     "strict": 0,

--- a/lib/clientBuilder.js
+++ b/lib/clientBuilder.js
@@ -56,6 +56,8 @@ function OktaAuthBuilder(args) {
     headers: args.headers
   };
 
+  this.userAgent = 'okta-auth-js-' + config.SDK_VERSION;
+
   // Digital clocks will drift over time, so the server
   // can misalign with the time reported by the browser.
   // The maxClockSkew allows relaxing the time-based
@@ -271,7 +273,7 @@ module.exports = function(ajaxRequest) {
     if (!(this instanceof OktaAuth)) {
       return new OktaAuth(args);
     }
-    
+
     if (args && !args.ajaxRequest) {
       args.ajaxRequest = ajaxRequest;
     }

--- a/lib/http.js
+++ b/lib/http.js
@@ -26,7 +26,7 @@ function httpRequest(sdk, options) {
   var headers = {
     'Accept': 'application/json',
     'Content-Type': 'application/json',
-    'X-Okta-User-Agent-Extended': 'okta-auth-js-' + config.SDK_VERSION
+    'X-Okta-User-Agent-Extended': sdk.userAgent
   };
   util.extend(headers, sdk.options.headers, options.headers);
 
@@ -66,7 +66,7 @@ function httpRequest(sdk, options) {
 
       return res;
     })
-    .fail(function(resp) { 
+    .fail(function(resp) {
       var serverErr = resp.responseText || {};
       if (util.isString(serverErr)) {
         try {

--- a/test/spec/general.js
+++ b/test/spec/general.js
@@ -363,6 +363,30 @@ define(function(require) {
       });
     });
 
+    describe('modified user agent', function () {
+      util.itMakesCorrectRequestResponse({
+        title: 'should be added to requests headers',
+        setup: {
+          request: {
+            uri: '/api/v1/sessions/me',
+            headers: {
+              'Accept': 'application/json',
+              'Content-Type': 'application/json',
+              'X-Okta-User-Agent-Extended': 'custom okta-auth-js-' + packageJson.version
+            }
+          },
+          response: 'session'
+        },
+        execute: function (test) {
+          test.oa.userAgent = 'custom ' + test.oa.userAgent;
+          return test.oa.session.get();
+        },
+        expectations: function (test, res) {
+          // We validate the headers for each request in our ajaxMock
+        }
+      });
+    });
+
     describe('custom headers', function () {
       util.itMakesCorrectRequestResponse({
         title: 'adds custom headers',


### PR DESCRIPTION
This allows other libraries to prefix the user agent, rather than overwriting it entirely with passed options