### PR TITLE
:bug: Update postMessage to call correct origin

### DIFF
--- a/lib/clientBuilder.js
+++ b/lib/clientBuilder.js
@@ -243,11 +243,9 @@ proto.fingerprint = function(options) {
       return deferred.resolve(msg.fingerprint);
     }
     if (msg.type === 'FingerprintServiceReady') {
-      if (iframe.contentWindow) {
-        iframe.contentWindow.postMessage(JSON.stringify({
-          type: 'GetFingerprint'
-        }), sdk.options.url);
-      }
+      e.source.postMessage(JSON.stringify({
+        type: 'GetFingerprint'
+      }), e.origin);
     }
   }
   oauthUtil.addListener(window, 'message', listener);

--- a/test/spec/fingerprint.js
+++ b/test/spec/fingerprint.js
@@ -25,9 +25,6 @@ define(function(require) {
 
       test.iframe = {
         style: {},
-        contentWindow: {
-          postMessage: postMessageSpy
-        },
         parentElement: {
           removeChild: jasmine.createSpy('removeChild')
         }
@@ -55,7 +52,10 @@ define(function(require) {
             data: options.firstMessage || JSON.stringify({
               type: 'FingerprintServiceReady'
             }),
-            origin: 'http://example.okta.com'
+            origin: 'http://example.okta.com',
+            source: {
+              postMessage: postMessageSpy
+            }
           });
         });
       });
@@ -80,6 +80,7 @@ define(function(require) {
         expect(test.iframe.style.display).toEqual('none');
         expect(test.iframe.src).toEqual('http://example.okta.com/auth/services/devicefingerprint');
         expect(document.body.appendChild).toHaveBeenCalledWith(test.iframe);
+        expect(test.e.source.postMessage).toHaveBeenCalled();
         expect(test.iframe.parentElement.removeChild).toHaveBeenCalled();
         expect(fingerprint).toEqual('ABCD');
       })


### PR DESCRIPTION
### Description
Fixes an issue where the `iframe` triggering the fingerprint request was receiving an invalid origin. This was caused by attempting to `postMessage` to an incorrect origin.

#### Resolves
[OKTA-163625](https://oktainc.atlassian.net/browse/OKTA-163625)