### PR TITLE
:bug: Make token retrieval async

### DIFF
--- a/README.md
+++ b/README.md
@@ -1519,6 +1519,10 @@ authClient.tokenManager.get('idToken')
   } else {
     // Token has expired
   }
+})
+.catch(function(err) {
+  // OAuth Error
+  console.error(err);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1515,7 +1515,7 @@ authClient.tokenManager.get('idToken')
 .then(function(token) {
   if (token) {
     // Token is valid
-    doSomethingWith(token);
+    console.log(token);
   } else {
     // Token has expired
   }
@@ -1551,12 +1551,12 @@ Manually refresh a token before it expires.
 // by using the returned Promise:
 authClient.tokenManager.refresh('idToken')
 .then(function (newToken) {
-  // doSomethingWith(newToken);
+  console.log(newToken);
 });
 
 // Alternatively, you can subscribe to the 'refreshed' event:
 authClient.tokenManager.on('refreshed', function (key, newToken, oldToken) {
-  // doSomethingWith(newToken);
+  console.log(newToken);
 });
 authClient.tokenManager.refresh('idToken');
 ```

--- a/README.md
+++ b/README.md
@@ -1506,12 +1506,20 @@ authClient.token.getWithPopup()
 
 #### `tokenManager.get(key)`
 
-Get a token that you have previously added to the `tokenManager` with the given `key`.
+Get a token that you have previously added to the `tokenManager` with the given `key`. The token object will be returned if it has not expired.
 
 * `key` - Key for the token you want to get
 
 ```javascript
-var token = authClient.tokenManager.get('idToken');
+authClient.tokenManager.get('idToken')
+.then(function(token) {
+  if (token) {
+    // Token is valid
+    doSomethingWith(token);
+  } else {
+    // Token has expired
+  }
+});
 ```
 
 #### `tokenManager.remove(key)`
@@ -1562,19 +1570,25 @@ Subscribe to an event published by the `tokenManager`.
 * `context` - Optional context to bind the callback to
 
 ```javascript
+// Triggered when the token has expired
 authClient.tokenManager.on('expired', function (key, expiredToken) {
   console.log('Token with key', key, ' has expired:');
   console.log(expiredToken);
-});
-
-authClient.tokenManager.on('error', function (err) {
-  console.log('TokenManager error:', err);
 });
 
 authClient.tokenManager.on('refreshed', function (key, newToken, oldToken) {
   console.log('Token with key', key, 'has been refreshed');
   console.log('Old token:', oldToken);
   console.log('New token:', newToken);
+});
+
+// Triggered when an OAuthError is returned via the API
+authClient.tokenManager.on('error', function (err) {
+  console.log('TokenManager error:', err.message);
+  // err.name
+  // err.message
+  // err.errorCode
+  // err.errorSummary
 });
 ```
 

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -48,7 +48,10 @@ function setRefreshTimeout(sdk, tokenMgmtRef, storage, key, token) {
   }
   var refreshTimeout = setTimeout(function() {
     if (tokenMgmtRef.autoRefresh) {
-      return refresh(sdk, tokenMgmtRef, storage, key);
+      // Set a flag to ensure multiple refresh attempts
+      // are not executed
+      tokenMgmtRef.refreshNeeded = true;
+      return getAsync(sdk, tokenMgmtRef, storage, key);
     } else if (token.expiresAt * 1000 <= Date.now()) {
       remove(tokenMgmtRef, storage, key);
       emitExpired(tokenMgmtRef, key, token);
@@ -99,6 +102,27 @@ function get(storage, key) {
   return tokenStorage[key];
 }
 
+function getAsync(sdk, tokenMgmtRef, storage, key) {
+  var token = get(storage, key);
+  var deferred = Q.defer();
+
+  if (token && (token.expiresAt * 1000 <= Date.now())) {
+    if (tokenMgmtRef.refreshNeeded) {
+      // Token has expired, refresh the token
+      refresh(sdk, tokenMgmtRef, storage, key)
+      .then(function(newToken) {
+        deferred.resolve(newToken);
+      });
+    } else {
+      remove(tokenMgmtRef, storage, key);
+      deferred.resolve();
+    }
+  } else {
+    deferred.resolve(token);
+  }
+  return deferred.promise;
+}
+
 function remove(tokenMgmtRef, storage, key) {
   // Clear any listener for this token
   clearRefreshTimeout(tokenMgmtRef, key);
@@ -121,6 +145,10 @@ function refresh(sdk, tokenMgmtRef, storage, key) {
 
   // Remove existing autoRefresh timeout for this key
   clearRefreshTimeout(tokenMgmtRef, key);
+
+  // Do not attempt to refresh again
+  // until token is expired
+  tokenMgmtRef.refreshNeeded = false;
 
   return sdk.token.refresh(token)
   .then(function(freshToken) {
@@ -177,11 +205,12 @@ function TokenManager(sdk, options) {
   var tokenMgmtRef = {
     emitter: new Emitter(),
     autoRefresh: options.autoRefresh,
-    refreshTimeouts: {}
+    refreshTimeouts: {},
+    refreshNeeded: false
   };
 
   this.add = util.bind(add, this, sdk, tokenMgmtRef, storage);
-  this.get = util.bind(get, this, storage);
+  this.get = util.bind(getAsync, this, sdk, tokenMgmtRef, storage);
   this.remove = util.bind(remove, this, tokenMgmtRef, storage);
   this.clear = util.bind(clear, this, tokenMgmtRef, storage);
   this.refresh = util.bind(refresh, this, sdk, tokenMgmtRef, storage);

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -35,21 +35,17 @@ function clearExpireEventTimeout(tokenMgmtRef, key) {
 
 function clearExpireEventTimeoutAll(tokenMgmtRef) {
   var expireTimeouts = tokenMgmtRef.expireTimeouts;
-  for(var key in expireTimeouts) {
+  for (var key in expireTimeouts) {
     if (!expireTimeouts.hasOwnProperty(key)) {
       continue;
     }
     clearExpireEventTimeout(tokenMgmtRef, key);
   }
-  tokenMgmtRef.expireTimeouts = {};
 }
 
 function setExpireEventTimeout(tokenMgmtRef, key, token) {
   var expireEventWait = (token.expiresAt * 1000) - Date.now();
-  if (expireEventWait < 0) {
-    // Already expired
-    expireEventWait = 0;
-  }
+
   var expireEventTimeout = setTimeout(function() {
     emitExpired(tokenMgmtRef, key, token);
   }, expireEventWait);

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -99,17 +99,19 @@ function get(storage, key) {
 }
 
 function getAsync(sdk, tokenMgmtRef, storage, key) {
-  var token = get(storage, key);
-  var clockSkew = sdk.options.maxClockSkew * 1000;
-  if (!token || token.expiresAt * 1000 > (Date.now() - clockSkew)) {
-    return Q.resolve(token);
-  }
+  return Q.Promise(function(resolve) {
+    var token = get(storage, key);
+    var clockSkew = sdk.options.maxClockSkew * 1000;
+    if (!token || token.expiresAt * 1000 > (Date.now() - clockSkew)) {
+      resolve(token);
+    }
 
-  var tokenPromise = tokenMgmtRef.autoRefresh
-    ? refresh(sdk, tokenMgmtRef, storage, key)
-    : Q.resolve(remove(tokenMgmtRef, storage, key));
+    var tokenPromise = tokenMgmtRef.autoRefresh
+      ? refresh(sdk, tokenMgmtRef, storage, key)
+      : remove(tokenMgmtRef, storage, key);
 
-  return new Q(tokenPromise);
+    resolve(tokenPromise);
+  });
 }
 
 function remove(tokenMgmtRef, storage, key) {
@@ -139,6 +141,12 @@ function refresh(sdk, tokenMgmtRef, storage, key) {
   if (!tokenMgmtRef.refreshPromise[key]) {
     tokenMgmtRef.refreshPromise[key] = sdk.token.refresh(token)
     .then(function(freshToken) {
+      if (!tokenMgmtRef.refreshPromise[key]) {
+        // It is possible to enter a state where the tokens have been cleared
+        // after a renewal request was triggered. To ensure we do not store a
+        // renewed token, we verify the promise key doesn't exist and return.
+        return;
+      }
       add(sdk, tokenMgmtRef, storage, key, freshToken);
       tokenMgmtRef.emitter.emit('refreshed', key, freshToken, token);
       // Remove existing promise key

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -31,6 +31,9 @@ function emitError(tokenMgmtRef, error) {
 function clearExpireEventTimeout(tokenMgmtRef, key) {
   clearTimeout(tokenMgmtRef.expireTimeouts[key]);
   delete tokenMgmtRef.expireTimeouts[key];
+
+  // Remove the refresh promise (if it exists)
+  delete tokenMgmtRef.refreshPromise[key];
 }
 
 function clearExpireEventTimeoutAll(tokenMgmtRef) {
@@ -43,21 +46,22 @@ function clearExpireEventTimeoutAll(tokenMgmtRef) {
   }
 }
 
-function setExpireEventTimeout(tokenMgmtRef, key, token) {
-  var expireEventWait = (token.expiresAt * 1000) - Date.now();
+function setExpireEventTimeout(sdk, tokenMgmtRef, key, token) {
+  var clockSkew = sdk.options.maxClockSkew * 1000;
+  var expireEventWait = (token.expiresAt * 1000) - (Date.now() - clockSkew);
+
+  // Clear any existing timeout
+  clearExpireEventTimeout(tokenMgmtRef, key);
 
   var expireEventTimeout = setTimeout(function() {
     emitExpired(tokenMgmtRef, key, token);
   }, expireEventWait);
 
-  // Clear any existing timeout
-  clearExpireEventTimeout(tokenMgmtRef, key);
-
   // Add a new timeout
   tokenMgmtRef.expireTimeouts[key] = expireEventTimeout;
 }
 
-function setExpireEventTimeoutAll(tokenMgmtRef, storage) {
+function setExpireEventTimeoutAll(sdk, tokenMgmtRef, storage) {
   try {
     var tokenStorage = storage.getStorage();
   } catch(e) {
@@ -72,11 +76,11 @@ function setExpireEventTimeoutAll(tokenMgmtRef, storage) {
       continue;
     }
     var token = tokenStorage[key];
-    setExpireEventTimeout(tokenMgmtRef, key, token);
+    setExpireEventTimeout(sdk, tokenMgmtRef, key, token);
   }
 }
 
-function add(tokenMgmtRef, storage, key, token) {
+function add(sdk, tokenMgmtRef, storage, key, token) {
   var tokenStorage = storage.getStorage();
   if (!util.isObject(token) ||
       !token.scopes ||
@@ -86,10 +90,7 @@ function add(tokenMgmtRef, storage, key, token) {
   }
   tokenStorage[key] = token;
   storage.setStorage(tokenStorage);
-  setExpireEventTimeout(tokenMgmtRef, key, token);
-
-  // Remove existing promise key
-  delete tokenMgmtRef.refreshPromise[key];
+  setExpireEventTimeout(sdk, tokenMgmtRef, key, token);
 }
 
 function get(storage, key) {
@@ -99,13 +100,16 @@ function get(storage, key) {
 
 function getAsync(sdk, tokenMgmtRef, storage, key) {
   var token = get(storage, key);
-  if (!token || token.expiresAt * 1000 > Date.now()) {
+  var clockSkew = sdk.options.maxClockSkew * 1000;
+  if (!token || token.expiresAt * 1000 > (Date.now() - clockSkew)) {
     return Q.resolve(token);
   }
 
-  return tokenMgmtRef.autoRefresh
+  var tokenPromise = tokenMgmtRef.autoRefresh
     ? refresh(sdk, tokenMgmtRef, storage, key)
     : Q.resolve(remove(tokenMgmtRef, storage, key));
+
+  return new Q(tokenPromise);
 }
 
 function remove(tokenMgmtRef, storage, key) {
@@ -135,9 +139,10 @@ function refresh(sdk, tokenMgmtRef, storage, key) {
   if (!tokenMgmtRef.refreshPromise[key]) {
     tokenMgmtRef.refreshPromise[key] = sdk.token.refresh(token)
     .then(function(freshToken) {
-      add(tokenMgmtRef, storage, key, freshToken);
+      add(sdk, tokenMgmtRef, storage, key, freshToken);
       tokenMgmtRef.emitter.emit('refreshed', key, freshToken, token);
-
+      // Remove existing promise key
+      delete tokenMgmtRef.refreshPromise[key];
       return freshToken;
     })
     .fail(function(err) {
@@ -196,7 +201,7 @@ function TokenManager(sdk, options) {
     refreshPromise: {}
   };
 
-  this.add = util.bind(add, this, tokenMgmtRef, storage);
+  this.add = util.bind(add, this, sdk, tokenMgmtRef, storage);
   this.get = util.bind(getAsync, this, sdk, tokenMgmtRef, storage);
   this.remove = util.bind(remove, this, tokenMgmtRef, storage);
   this.clear = util.bind(clear, this, tokenMgmtRef, storage);
@@ -204,7 +209,7 @@ function TokenManager(sdk, options) {
   this.on = util.bind(tokenMgmtRef.emitter.on, tokenMgmtRef.emitter);
   this.off = util.bind(tokenMgmtRef.emitter.off, tokenMgmtRef.emitter);
 
-  setExpireEventTimeoutAll(tokenMgmtRef, storage);
+  setExpireEventTimeoutAll(sdk, tokenMgmtRef, storage);
 }
 
 module.exports = TokenManager;

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -91,6 +91,9 @@ function add(tokenMgmtRef, storage, key, token) {
   tokenStorage[key] = token;
   storage.setStorage(tokenStorage);
   setExpireEventTimeout(tokenMgmtRef, key, token);
+
+  // Remove existing promise key
+  delete tokenMgmtRef.refreshPromise[key];
 }
 
 function get(storage, key) {
@@ -132,21 +135,25 @@ function refresh(sdk, tokenMgmtRef, storage, key) {
   // Remove existing autoRefresh timeout for this key
   clearExpireEventTimeout(tokenMgmtRef, key);
 
-  return sdk.token.refresh(token)
-  .then(function(freshToken) {
-    add(tokenMgmtRef, storage, key, freshToken);
-    tokenMgmtRef.emitter.emit('refreshed', key, freshToken, token);
+  // Store the refresh promise state, to avoid refreshing again
+  if (!tokenMgmtRef.refreshPromise[key]) {
+    tokenMgmtRef.refreshPromise[key] = sdk.token.refresh(token)
+    .then(function(freshToken) {
+      add(tokenMgmtRef, storage, key, freshToken);
+      tokenMgmtRef.emitter.emit('refreshed', key, freshToken, token);
 
-    return freshToken;
-  })
-  .fail(function(err) {
-    if (err.name === 'OAuthError') {
-      remove(tokenMgmtRef, storage, key);
-      emitError(tokenMgmtRef, err);
-    }
+      return freshToken;
+    })
+    .fail(function(err) {
+      if (err.name === 'OAuthError') {
+        remove(tokenMgmtRef, storage, key);
+        emitError(tokenMgmtRef, err);
+      }
 
-    throw err;
-  });
+      throw err;
+    });
+  }
+  return tokenMgmtRef.refreshPromise[key];
 }
 
 function clear(tokenMgmtRef, storage) {
@@ -189,7 +196,8 @@ function TokenManager(sdk, options) {
   var tokenMgmtRef = {
     emitter: new Emitter(),
     autoRefresh: options.autoRefresh,
-    expireTimeouts: {}
+    expireTimeouts: {},
+    refreshPromise: {}
   };
 
   this.add = util.bind(add, this, tokenMgmtRef, storage);

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -102,7 +102,7 @@ function getAsync(sdk, tokenMgmtRef, storage, key) {
   return Q.Promise(function(resolve) {
     var token = get(storage, key);
     var clockSkew = sdk.options.maxClockSkew * 1000;
-    if (!token || token.expiresAt * 1000 > (Date.now() - clockSkew)) {
+    if (!token || (token.expiresAt * 1000 - clockSkew) > Date.now()) {
       resolve(token);
     }
 
@@ -141,7 +141,7 @@ function refresh(sdk, tokenMgmtRef, storage, key) {
   if (!tokenMgmtRef.refreshPromise[key]) {
     tokenMgmtRef.refreshPromise[key] = sdk.token.refresh(token)
     .then(function(freshToken) {
-      if (!tokenMgmtRef.refreshPromise[key]) {
+      if (!get(storage, key)) {
         // It is possible to enter a state where the tokens have been cleared
         // after a renewal request was triggered. To ensure we do not store a
         // renewed token, we verify the promise key doesn't exist and return.

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -28,41 +28,40 @@ function emitError(tokenMgmtRef, error) {
   tokenMgmtRef.emitter.emit('error', error);
 }
 
-function clearRefreshTimeout(tokenMgmtRef, key) {
-  clearTimeout(tokenMgmtRef.refreshTimeouts[key]);
-  delete tokenMgmtRef.refreshTimeouts[key];
+function clearExpireEventTimeout(tokenMgmtRef, key) {
+  clearTimeout(tokenMgmtRef.expireTimeouts[key]);
+  delete tokenMgmtRef.expireTimeouts[key];
 }
 
-function clearRefreshTimeoutAll(tokenMgmtRef) {
-  var refreshTimeouts = tokenMgmtRef.refreshTimeouts;
-  for(var key in refreshTimeouts) {
-    if (!refreshTimeouts.hasOwnProperty(key)) {
+function clearExpireEventTimeoutAll(tokenMgmtRef) {
+  var expireTimeouts = tokenMgmtRef.expireTimeouts;
+  for(var key in expireTimeouts) {
+    if (!expireTimeouts.hasOwnProperty(key)) {
       continue;
     }
-    clearRefreshTimeout(tokenMgmtRef, key);
+    clearExpireEventTimeout(tokenMgmtRef, key);
   }
-  tokenMgmtRef.refreshTimeouts = {};
+  tokenMgmtRef.expireTimeouts = {};
 }
 
-function setRefreshTimeout(sdk, tokenMgmtRef, storage, key, token) {
-  var refreshWait = (token.expiresAt * 1000) - Date.now();
-  if (refreshWait < 0) {
+function setExpireEventTimeout(tokenMgmtRef, key, token) {
+  var expireEventWait = (token.expiresAt * 1000) - Date.now();
+  if (expireEventWait < 0) {
     // Already expired
-    refreshWait = 0;
+    expireEventWait = 0;
   }
-  var refreshTimeout = setTimeout(function() {
+  var expireEventTimeout = setTimeout(function() {
     emitExpired(tokenMgmtRef, key, token);
-    return getAsync(sdk, tokenMgmtRef, storage, key);
-  }, refreshWait);
+  }, expireEventWait);
 
   // Clear any existing timeout
-  clearRefreshTimeout(tokenMgmtRef, key);
+  clearExpireEventTimeout(tokenMgmtRef, key);
 
   // Add a new timeout
-  tokenMgmtRef.refreshTimeouts[key] = refreshTimeout;
+  tokenMgmtRef.expireTimeouts[key] = expireEventTimeout;
 }
 
-function setRefreshTimeoutAll(sdk, tokenMgmtRef, storage) {
+function setExpireEventTimeoutAll(tokenMgmtRef, storage) {
   try {
     var tokenStorage = storage.getStorage();
   } catch(e) {
@@ -77,11 +76,11 @@ function setRefreshTimeoutAll(sdk, tokenMgmtRef, storage) {
       continue;
     }
     var token = tokenStorage[key];
-    setRefreshTimeout(sdk, tokenMgmtRef, storage, key, token);
+    setExpireEventTimeout(tokenMgmtRef, key, token);
   }
 }
 
-function add(sdk, tokenMgmtRef, storage, key, token) {
+function add(tokenMgmtRef, storage, key, token) {
   var tokenStorage = storage.getStorage();
   if (!util.isObject(token) ||
       !token.scopes ||
@@ -91,7 +90,7 @@ function add(sdk, tokenMgmtRef, storage, key, token) {
   }
   tokenStorage[key] = token;
   storage.setStorage(tokenStorage);
-  setRefreshTimeout(sdk, tokenMgmtRef, storage, key, token);
+  setExpireEventTimeout(tokenMgmtRef, key, token);
 }
 
 function get(storage, key) {
@@ -101,28 +100,18 @@ function get(storage, key) {
 
 function getAsync(sdk, tokenMgmtRef, storage, key) {
   var token = get(storage, key);
-  var deferred = Q.defer();
-
-  if (token && (token.expiresAt * 1000 <= Date.now())) {
-    if (tokenMgmtRef.autoRefresh) {
-      // Token has expired, refresh the token
-      refresh(sdk, tokenMgmtRef, storage, key)
-      .then(function(newToken) {
-        deferred.resolve(newToken);
-      });
-    } else {
-      remove(tokenMgmtRef, storage, key);
-      deferred.resolve();
-    }
-  } else {
-    deferred.resolve(token);
+  if (!token || token.expiresAt * 1000 > Date.now()) {
+    return Q.resolve(token);
   }
-  return deferred.promise;
+
+  return tokenMgmtRef.autoRefresh
+    ? refresh(sdk, tokenMgmtRef, storage, key)
+    : Q.resolve(remove(tokenMgmtRef, storage, key));
 }
 
 function remove(tokenMgmtRef, storage, key) {
   // Clear any listener for this token
-  clearRefreshTimeout(tokenMgmtRef, key);
+  clearExpireEventTimeout(tokenMgmtRef, key);
 
   // Remove it from storage
   var tokenStorage = storage.getStorage();
@@ -141,31 +130,13 @@ function refresh(sdk, tokenMgmtRef, storage, key) {
   }
 
   // Remove existing autoRefresh timeout for this key
-  clearRefreshTimeout(tokenMgmtRef, key);
+  clearExpireEventTimeout(tokenMgmtRef, key);
 
-  var deferred = Q.defer();
-
-  if (!tokenMgmtRef.refreshPromises[key]) {
-    tokenMgmtRef.refreshPromises[key] = [];
-  }
-
-  tokenMgmtRef.refreshPromises[key].push(deferred);
-
-  if (!tokenMgmtRef.refreshPromise[key]) {
-    tokenMgmtRef.refreshPromise[key] = refreshToken(sdk, tokenMgmtRef, storage, key, token);
-  }
-
-  return deferred.promise;
-}
-
-function refreshToken(sdk, tokenMgmtRef, storage, key, token) {
   return sdk.token.refresh(token)
   .then(function(freshToken) {
-    add(sdk, tokenMgmtRef, storage, key, freshToken);
+    add(tokenMgmtRef, storage, key, freshToken);
     tokenMgmtRef.emitter.emit('refreshed', key, freshToken, token);
 
-    // Resolve all promises with the same refreshed token
-    resolveRefreshTimeouts(tokenMgmtRef, key, freshToken);
     return freshToken;
   })
   .fail(function(err) {
@@ -173,31 +144,14 @@ function refreshToken(sdk, tokenMgmtRef, storage, key, token) {
       remove(tokenMgmtRef, storage, key);
       emitError(tokenMgmtRef, err);
     }
-    // Resolve all promises with the same empty value
-    rejectRefreshTimeouts(tokenMgmtRef, key, err);
+
     throw err;
   });
 }
 
 function clear(tokenMgmtRef, storage) {
-  clearRefreshTimeoutAll(tokenMgmtRef);
+  clearExpireEventTimeoutAll(tokenMgmtRef);
   storage.clearStorage();
-}
-
-function resolveRefreshTimeouts(tokenMgmtRef, key, value) {
-  for (var i = 0; i < tokenMgmtRef.refreshPromises[key].length; ++i) {
-    tokenMgmtRef.refreshPromises[key][i].resolve(value);
-  }
-  tokenMgmtRef.refreshPromises[key] = [];
-  tokenMgmtRef.refreshPromise[key] = null;
-}
-
-function rejectRefreshTimeouts(tokenMgmtRef, key, value) {
-  for (var i = 0; i < tokenMgmtRef.refreshPromises[key].length; ++i) {
-    tokenMgmtRef.refreshPromises[key][i].reject(value);
-  }
-  tokenMgmtRef.refreshPromises[key] = [];
-  tokenMgmtRef.refreshPromise[key] = null;
 }
 
 function TokenManager(sdk, options) {
@@ -235,12 +189,10 @@ function TokenManager(sdk, options) {
   var tokenMgmtRef = {
     emitter: new Emitter(),
     autoRefresh: options.autoRefresh,
-    refreshTimeouts: {},
-    refreshPromises: {},
-    refreshPromise: {}
+    expireTimeouts: {}
   };
 
-  this.add = util.bind(add, this, sdk, tokenMgmtRef, storage);
+  this.add = util.bind(add, this, tokenMgmtRef, storage);
   this.get = util.bind(getAsync, this, sdk, tokenMgmtRef, storage);
   this.remove = util.bind(remove, this, tokenMgmtRef, storage);
   this.clear = util.bind(clear, this, tokenMgmtRef, storage);
@@ -248,7 +200,7 @@ function TokenManager(sdk, options) {
   this.on = util.bind(tokenMgmtRef.emitter.on, tokenMgmtRef.emitter);
   this.off = util.bind(tokenMgmtRef.emitter.off, tokenMgmtRef.emitter);
 
-  setRefreshTimeoutAll(sdk, tokenMgmtRef, storage);
+  setExpireEventTimeoutAll(tokenMgmtRef, storage);
 }
 
 module.exports = TokenManager;

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -24,6 +24,10 @@ function emitExpired(tokenMgmtRef, key, token) {
   tokenMgmtRef.emitter.emit('expired', key, token);
 }
 
+function emitError(tokenMgmtRef, error) {
+  tokenMgmtRef.emitter.emit('error', error);
+}
+
 function clearRefreshTimeout(tokenMgmtRef, key) {
   clearTimeout(tokenMgmtRef.refreshTimeouts[key]);
   delete tokenMgmtRef.refreshTimeouts[key];
@@ -47,15 +51,8 @@ function setRefreshTimeout(sdk, tokenMgmtRef, storage, key, token) {
     refreshWait = 0;
   }
   var refreshTimeout = setTimeout(function() {
-    if (tokenMgmtRef.autoRefresh) {
-      // Set a flag to ensure multiple refresh attempts
-      // are not executed
-      tokenMgmtRef.refreshNeeded = true;
-      return getAsync(sdk, tokenMgmtRef, storage, key);
-    } else if (token.expiresAt * 1000 <= Date.now()) {
-      remove(tokenMgmtRef, storage, key);
-      emitExpired(tokenMgmtRef, key, token);
-    }
+    emitExpired(tokenMgmtRef, key, token);
+    return getAsync(sdk, tokenMgmtRef, storage, key);
   }, refreshWait);
 
   // Clear any existing timeout
@@ -71,7 +68,7 @@ function setRefreshTimeoutAll(sdk, tokenMgmtRef, storage) {
   } catch(e) {
     // Any errors thrown on instantiation will not be caught,
     // because there are no listeners yet
-    tokenMgmtRef.emitter.emit('error', e);
+    emitError(tokenMgmtRef, e);
     return;
   }
 
@@ -107,7 +104,7 @@ function getAsync(sdk, tokenMgmtRef, storage, key) {
   var deferred = Q.defer();
 
   if (token && (token.expiresAt * 1000 <= Date.now())) {
-    if (tokenMgmtRef.refreshNeeded) {
+    if (tokenMgmtRef.autoRefresh) {
       // Token has expired, refresh the token
       refresh(sdk, tokenMgmtRef, storage, key)
       .then(function(newToken) {
@@ -146,21 +143,38 @@ function refresh(sdk, tokenMgmtRef, storage, key) {
   // Remove existing autoRefresh timeout for this key
   clearRefreshTimeout(tokenMgmtRef, key);
 
-  // Do not attempt to refresh again
-  // until token is expired
-  tokenMgmtRef.refreshNeeded = false;
+  var deferred = Q.defer();
 
+  if (!tokenMgmtRef.refreshPromises[key]) {
+    tokenMgmtRef.refreshPromises[key] = [];
+  }
+
+  tokenMgmtRef.refreshPromises[key].push(deferred);
+
+  if (!tokenMgmtRef.refreshPromise[key]) {
+    tokenMgmtRef.refreshPromise[key] = refreshToken(sdk, tokenMgmtRef, storage, key, token);
+  }
+
+  return deferred.promise;
+}
+
+function refreshToken(sdk, tokenMgmtRef, storage, key, token) {
   return sdk.token.refresh(token)
   .then(function(freshToken) {
     add(sdk, tokenMgmtRef, storage, key, freshToken);
     tokenMgmtRef.emitter.emit('refreshed', key, freshToken, token);
+
+    // Resolve all promises with the same refreshed token
+    resolveRefreshTimeouts(tokenMgmtRef, key, freshToken);
     return freshToken;
   })
   .fail(function(err) {
     if (err.name === 'OAuthError') {
       remove(tokenMgmtRef, storage, key);
-      emitExpired(tokenMgmtRef, key, token);
+      emitError(tokenMgmtRef, err);
     }
+    // Resolve all promises with the same empty value
+    rejectRefreshTimeouts(tokenMgmtRef, key, err);
     throw err;
   });
 }
@@ -168,6 +182,22 @@ function refresh(sdk, tokenMgmtRef, storage, key) {
 function clear(tokenMgmtRef, storage) {
   clearRefreshTimeoutAll(tokenMgmtRef);
   storage.clearStorage();
+}
+
+function resolveRefreshTimeouts(tokenMgmtRef, key, value) {
+  for (var i = 0; i < tokenMgmtRef.refreshPromises[key].length; ++i) {
+    tokenMgmtRef.refreshPromises[key][i].resolve(value);
+  }
+  tokenMgmtRef.refreshPromises[key] = [];
+  tokenMgmtRef.refreshPromise[key] = null;
+}
+
+function rejectRefreshTimeouts(tokenMgmtRef, key, value) {
+  for (var i = 0; i < tokenMgmtRef.refreshPromises[key].length; ++i) {
+    tokenMgmtRef.refreshPromises[key][i].reject(value);
+  }
+  tokenMgmtRef.refreshPromises[key] = [];
+  tokenMgmtRef.refreshPromise[key] = null;
 }
 
 function TokenManager(sdk, options) {
@@ -206,7 +236,8 @@ function TokenManager(sdk, options) {
     emitter: new Emitter(),
     autoRefresh: options.autoRefresh,
     refreshTimeouts: {},
-    refreshNeeded: false
+    refreshPromises: {},
+    refreshPromise: {}
   };
 
   this.add = util.bind(add, this, sdk, tokenMgmtRef, storage);

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -32,17 +32,27 @@ define(function(require) {
         });
       });
       it('defaults to sessionStorage if localStorage isn\'t available', function() {
+        spyOn(window.console, 'log');
         oauthUtil.mockLocalStorageError();
         var client = setupSync();
+        expect(window.console.log).toHaveBeenCalledWith(
+          '[okta-auth-sdk] WARN: This browser doesn\'t ' +
+          'support localStorage. Switching to sessionStorage.'
+        );
         client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
         oauthUtil.expectTokenStorageToEqual(sessionStorage, {
           'test-idToken': tokens.standardIdTokenParsed
         });
       });
       it('defaults to cookie-based storage if localStorage and sessionStorage are not available', function() {
+        spyOn(window.console, 'log');
         oauthUtil.mockLocalStorageError();
         oauthUtil.mockSessionStorageError();
         var client = setupSync();
+        expect(window.console.log).toHaveBeenCalledWith(
+          '[okta-auth-sdk] WARN: This browser doesn\'t ' +
+          'support sessionStorage. Switching to cookie-based storage.'
+        );
         var setCookieMock = util.mockSetCookie();
         client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
         expect(setCookieMock).toHaveBeenCalledWith(
@@ -81,14 +91,7 @@ define(function(require) {
     describe('refresh', function() {
       it('allows refreshing an idToken', function(done) {
         return oauthUtil.setupFrame({
-          oktaAuthArgs: {
-            issuer: 'https://auth-js-test.okta.com',
-            clientId: 'NPSfOkH5eZrTy8PMDlvx',
-            redirectUri: 'https://example.com/redirect',
-            tokenManager: {
-              autoRefresh: false
-            }
-          },
+          authClient: setupSync(),
           tokenManagerAddKeys: {
             'test-idToken': {
               idToken: 'testInitialToken',
@@ -127,14 +130,7 @@ define(function(require) {
 
       it('allows refreshing an accessToken', function(done) {
         return oauthUtil.setupFrame({
-          oktaAuthArgs: {
-            issuer: 'https://auth-js-test.okta.com',
-            clientId: 'NPSfOkH5eZrTy8PMDlvx',
-            redirectUri: 'https://example.com/redirect',
-            tokenManager: {
-              autoRefresh: false
-            }
-          },
+          authClient: setupSync(),
           tokenManagerAddKeys: {
             'test-accessToken': {
               accessToken: 'testInitialToken',
@@ -175,11 +171,7 @@ define(function(require) {
 
       oauthUtil.itpErrorsCorrectly('throws an errors when a token doesn\'t exist',
         {
-          oktaAuthArgs: {
-            issuer: 'https://auth-js-test.okta.com',
-            clientId: 'NPSfOkH5eZrTy8PMDlvx',
-            redirectUri: 'https://example.com/redirect'
-          },
+          authClient: setupSync(),
           tokenManagerRefreshArgs: ['test-accessToken']
         },
         {
@@ -196,12 +188,8 @@ define(function(require) {
       it('throws an errors when the token is mangled', function(done) {
         localStorage.setItem('okta-token-storage', '#unparseableJson#');
         return oauthUtil.setupFrame({
+          authClient: setupSync(),
           willFail: true,
-          oktaAuthArgs: {
-            issuer: 'https://auth-js-test.okta.com',
-            clientId: 'NPSfOkH5eZrTy8PMDlvx',
-            redirectUri: 'https://example.com/redirect'
-          },
           tokenManagerRefreshArgs: ['test-accessToken']
         })
         .then(function() {
@@ -223,11 +211,7 @@ define(function(require) {
 
       oauthUtil.itpErrorsCorrectly('throws an error if there\'s an issue refreshing',
         {
-          oktaAuthArgs: {
-            issuer: 'https://auth-js-test.okta.com',
-            clientId: 'NPSfOkH5eZrTy8PMDlvx',
-            redirectUri: 'https://example.com/redirect'
-          },
+          authClient: setupSync(),
           tokenManagerAddKeys: {
             'test-idToken': tokens.standardIdTokenParsed
           },
@@ -263,12 +247,8 @@ define(function(require) {
 
       it('removes token if an OAuthError is thrown while refreshing', function(done) {
         return oauthUtil.setupFrame({
+          authClient: setupSync(),
           willFail: true,
-          oktaAuthArgs: {
-            issuer: 'https://auth-js-test.okta.com',
-            clientId: 'NPSfOkH5eZrTy8PMDlvx',
-            redirectUri: 'https://example.com/redirect'
-          },
           tokenManagerAddKeys: {
             'test-accessToken': tokens.standardAccessTokenParsed,
             'test-idToken': tokens.standardIdTokenParsed
@@ -307,13 +287,13 @@ define(function(require) {
       it('automatically refreshes a token by default', function(done) {
         var expiresAt = tokens.standardIdTokenParsed.expiresAt;
         return oauthUtil.setupFrame({
-          fastForwardToTime: expiresAt + 1,
+          authClient: setupSync({
+            autoRefresh: true
+          }),
           autoRefresh: true,
-          oktaAuthArgs: {
-            issuer: 'https://auth-js-test.okta.com',
-            clientId: 'NPSfOkH5eZrTy8PMDlvx',
-            redirectUri: 'https://example.com/redirect'
-          },
+          fastForwardToTime: true,
+          autoRefreshTokenKey: 'test-idToken',
+          time: expiresAt + 1,
           tokenManagerAddKeys: {
             'test-idToken': {
               idToken: 'testInitialToken',
@@ -350,13 +330,14 @@ define(function(require) {
 
       it('removes a token on OAuth failure', function(done) {
         return oauthUtil.setupFrame({
-          fastForwardToTime: tokens.standardIdTokenParsed.expiresAt + 1,
+          authClient: setupSync({
+            autoRefresh: true
+          }),
           autoRefresh: true,
-          oktaAuthArgs: {
-            issuer: 'https://auth-js-test.okta.com',
-            clientId: 'NPSfOkH5eZrTy8PMDlvx',
-            redirectUri: 'https://example.com/redirect'
-          },
+          willFail: true,
+          fastForwardToTime: true,
+          autoRefreshTokenKey: 'test-idToken',
+          time: tokens.standardIdTokenParsed.expiresAt + 1,
           tokenManagerAddKeys: {
             'test-idToken': tokens.standardIdTokenParsed
           },
@@ -366,7 +347,13 @@ define(function(require) {
             state: oauthUtil.mockedState
           }
         })
-        .then(function() {
+        .fail(function(err) {
+          util.expectErrorToEqual(err, {
+            name: 'OAuthError',
+            message: 'something went wrong',
+            errorCode: 'sampleErrorCode',
+            errorSummary: 'something went wrong'
+          });
           oauthUtil.expectTokenStorageToEqual(localStorage, {});
         })
         .fin(done);
@@ -381,10 +368,18 @@ define(function(require) {
         client.tokenManager.on('expired', function(key, token) {
           expect(key).toEqual('test-idToken');
           expect(token).toEqual(tokens.standardIdTokenParsed);
-          expect(client.tokenManager.get('test-idToken')).toBeUndefined();
-          done();
+          client.tokenManager.get('test-idToken')
+          .then(function(token) {
+            expect(token).toBeUndefined();
+            done();
+          });
         });
         util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
+        client.tokenManager.get('test-idToken')
+        .then(function(token) {
+          expect(token).toBeUndefined();
+          done();
+        });
       });
 
       it('emits "expired" on new tokens even when autoRefresh is disabled', function(done) {
@@ -397,6 +392,11 @@ define(function(require) {
           done();
         });
         util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
+        client.tokenManager.get('test-idToken')
+        .then(function(token) {
+          expect(token).toBeUndefined();
+          done();
+        });
       });
     });
 
@@ -419,13 +419,31 @@ define(function(require) {
       });
 
       describe('get', function() {
-        it('gets a token', function() {
+        it('returns a token', function(done) {
           var client = localStorageSetup();
           localStorage.setItem('okta-token-storage', JSON.stringify({
             'test-idToken': tokens.standardIdTokenParsed
           }));
-          var result = client.tokenManager.get('test-idToken');
-          expect(result).toEqual(tokens.standardIdTokenParsed);
+          util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
+          client.tokenManager.get('test-idToken')
+          .then(function(token) {
+            expect(token).toEqual(tokens.standardIdTokenParsed);
+            done();
+          });
+          // Warp back to current time
+          util.warpToUnixTime(Date.now());
+        });
+
+        it('returns undefined for an expired token', function(done) {
+          var client = localStorageSetup();
+          localStorage.setItem('okta-token-storage', JSON.stringify({
+            'test-idToken': tokens.standardIdTokenParsed
+          }));
+          client.tokenManager.get('test-idToken')
+          .then(function(token) {
+            expect(token).toBeUndefined();
+            done();
+          });
         });
       });
 
@@ -475,13 +493,31 @@ define(function(require) {
       });
 
       describe('get', function() {
-        it('gets a token', function() {
+        it('returns a token', function(done) {
           var client = sessionStorageSetup();
           sessionStorage.setItem('okta-token-storage', JSON.stringify({
             'test-idToken': tokens.standardIdTokenParsed
           }));
-          var result = client.tokenManager.get('test-idToken');
-          expect(result).toEqual(tokens.standardIdTokenParsed);
+          util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
+          client.tokenManager.get('test-idToken')
+          .then(function(token) {
+            expect(token).toEqual(tokens.standardIdTokenParsed);
+            done();
+          });
+          // Warp back to current time
+          util.warpToUnixTime(Date.now());
+        });
+
+        it('returns undefined for an expired token', function(done) {
+          var client = sessionStorageSetup();
+          sessionStorage.setItem('okta-token-storage', JSON.stringify({
+            'test-idToken': tokens.standardIdTokenParsed
+          }));
+          client.tokenManager.get('test-idToken')
+          .then(function(token) {
+            expect(token).toBeUndefined();
+            done();
+          });
         });
       });
 
@@ -535,11 +571,27 @@ define(function(require) {
       });
 
       describe('get', function() {
-        it('gets a token', function() {
+        it('returns a token', function(done) {
           var client = cookieStorageSetup();
           client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
-          var result = client.tokenManager.get('test-idToken');
-          expect(result).toEqual(tokens.standardIdTokenParsed);
+          util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
+          client.tokenManager.get('test-idToken')
+          .then(function(token) {
+            expect(token).toEqual(tokens.standardIdTokenParsed);
+            done();
+          });
+          // Warp back to current time
+          util.warpToUnixTime(Date.now());
+        });
+
+        it('returns undefined for an expired token', function(done) {
+          var client = cookieStorageSetup();
+          client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
+          client.tokenManager.get('test-idToken')
+          .then(function(token) {
+            expect(token).toBeUndefined();
+            done();
+          });
         });
       });
 

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -375,11 +375,6 @@ define(function(require) {
           });
         });
         util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
-        client.tokenManager.get('test-idToken')
-        .then(function(token) {
-          expect(token).toBeUndefined();
-          done();
-        });
       });
 
       it('emits "expired" on new tokens even when autoRefresh is disabled', function(done) {
@@ -391,6 +386,20 @@ define(function(require) {
           expect(token).toEqual(tokens.standardIdTokenParsed);
           done();
         });
+        util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
+        client.tokenManager.get('test-idToken')
+        .then(function(token) {
+          expect(token).toBeUndefined();
+          done();
+        });
+      });
+
+      it('returns undefined for a token that has expired when autoRefresh is disabled', function(done) {
+        util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
+        localStorage.setItem('okta-token-storage', JSON.stringify({
+          'test-idToken': tokens.standardIdTokenParsed
+        }));
+        var client = setupSync({ autoRefresh: false });
         util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
         client.tokenManager.get('test-idToken')
         .then(function(token) {

--- a/test/util/oauthUtil.js
+++ b/test/util/oauthUtil.js
@@ -144,6 +144,8 @@ define(function(require) {
     var authClient;
     if (opts.oktaAuthArgs) {
       authClient = new OktaAuth(opts.oktaAuthArgs);
+    } else if (opts.authClient) {
+      authClient = opts.authClient;
     } else {
       authClient = new OktaAuth({
         url: 'https://auth-js-test.okta.com'
@@ -193,7 +195,11 @@ define(function(require) {
     }
 
     if (opts.fastForwardToTime) {
-      util.warpByTicksToUnixTime(opts.fastForwardToTime);
+      // Since the token is "expired", we're going to attempt to
+      // retrieve it and kick-off the autoRefresh and let the event listeners
+      // above pick up the 'refreshed' and 'error' events.
+      promise = authClient.tokenManager.get(opts.autoRefreshTokenKey);
+      util.warpByTicksToUnixTime(opts.time);
     }
 
     return promise
@@ -201,7 +207,6 @@ define(function(require) {
         if (opts.autoRefresh) {
           return;
         }
-
         var expectedResp = opts.expectedResp || defaultResponse;
         validateResponse(res, expectedResp);
       })

--- a/test/util/oauthUtil.js
+++ b/test/util/oauthUtil.js
@@ -204,6 +204,9 @@ define(function(require) {
 
     return promise
       .then(function(res) {
+        if(opts.beforeCompletion) {
+          opts.beforeCompletion(authClient);
+        }
         if (opts.autoRefresh) {
           return;
         }

--- a/test/util/oauthUtil.js
+++ b/test/util/oauthUtil.js
@@ -188,7 +188,7 @@ define(function(require) {
       authClient.tokenManager.on('refreshed', function() {
         refreshDeferred.resolve();
       });
-      authClient.tokenManager.on('expired', function() {
+      authClient.tokenManager.on('error', function() {
         refreshDeferred.resolve();
       });
       promise = refreshDeferred.promise;


### PR DESCRIPTION
### Description

Modifies token retrieval methods to account for asynchronous token refresh.

Previously, `setTimeout` was used to continuously **refresh** the tokens when they expired. In some cases, retrieving a token after token expiration created a refresh/return race condition.

Modifying the `tokenManager` to return a `Promise` with respect to refreshing the token as needed, reassures that tokens returned via `authClient.tokenManager.get('tokenName')` are valid.

#### Syntax changes

Previously:
```javascript
const accessToken = authClient.tokenManager.get('accessToken');
```

Now:
```javascript
// ES2016+
const accessToken = await authClient.tokenManager.get('accessToken');

// Handle as a promise
authClient.tokenManager.get('accessToken')
.then(function(accessToken) {
  console.log(accessToken);
});
```

#### Impacted Libraries

- [okta-angular](https://github.com/okta/okta-oidc-js/blob/master/packages/okta-angular)
- [okta-react](https://github.com/okta/okta-oidc-js/blob/master/packages/okta-react)
- [okta-vue](https://github.com/okta/okta-oidc-js/blob/master/packages/okta-vue)
- [okta-signin-widget](https://github.com/okta/okta-signin-widget)

### Resolves
- [OKTA-175673](https://oktainc.atlassian.net/browse/OKTA-175673)
- #125 

### Reviewers
- @okta/devex-javascript 