### PR TITLE
:seedling: Use cookie lib for RFC 6265 compliance

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -11,42 +11,32 @@
  *
  */
 
-var util = require('./util');
+var Cookies = require('js-cookie');
 
 function setCookie(name, value, expiresAt) {
-  var expiresText = '';
-  if (expiresAt) {
-    expiresText = ' expires=' + util.isoToUTCString(expiresAt) + ';';
-  }
+  // The "expires" key with our cookie lib maps to "days until expired".
+  // Since we expect it to expire on a specific point in time, we
+  // subtract our current time to give us our "days until expired"
+  var future = new Date(expiresAt).getTime();
+  var now = new Date().getTime();
 
-  var cookieText = name + '=' + value + '; path=/;' + expiresText;
-  setCookie._setDocumentCookie(cookieText);
+  // Convert time in ms into days
+  // 1000 ms * 60 sec * 60 min * 24 hrs
+  var expires = Math.floor((future - now)/(1000*60*60*24));
 
-  return cookieText;
+  Cookies.set(name, value, {
+    expires: expires,
+    path: '/'
+  });
+  return getCookie(name);
 }
-
-// Exposed for testing
-setCookie._setDocumentCookie = function(cookieText) {
-  document.cookie = cookieText;
-};
 
 function getCookie(name) {
-  var pattern = new RegExp(name + '=([^;]*)'),
-      matched = getCookie._getDocumentCookie().match(pattern);
-
-  if (matched) {
-    var cookie = matched[1];
-    return cookie;
-  }
+  return Cookies.get(name);
 }
 
-// Exposed for testing
-getCookie._getDocumentCookie = function() {
-  return document.cookie;
-};
-
 function deleteCookie(name) {
-  setCookie(name, '', '1970-01-01T00:00:00Z');
+  Cookies.remove(name, { path: '/' });
 }
 
 module.exports = {

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -17,8 +17,12 @@ function setCookie(name, value, expiresAt) {
     path: '/'
   };
 
-  if (expiresAt && Date.parse(expiresAt)) {
-    // Expires value can be converted to a Date object
+  // eslint-disable-next-line no-extra-boolean-cast
+  if (!!(Date.parse(expiresAt))) {
+    // Expires value can be converted to a Date object.
+    //
+    // If the 'expiresAt' value is not provided, or the value cannot be
+    // parsed as a Date object, the cookie will set as a session cookie.
     cookieOptions.expires = new Date(expiresAt);
   }
 

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -10,33 +10,30 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-
 var Cookies = require('js-cookie');
 
 function setCookie(name, value, expiresAt) {
-  // The "expires" key with our cookie lib maps to "days until expired".
-  // Since we expect it to expire on a specific point in time, we
-  // subtract our current time to give us our "days until expired"
-  var future = new Date(expiresAt).getTime();
-  var now = new Date().getTime();
+  var expires = expiresAt || new Date('2038-01-19T03:14:07.000Z');
 
-  // Convert time in ms into days
-  // 1000 ms * 60 sec * 60 min * 24 hrs
-  var expires = Math.floor((future - now)/(1000*60*60*24));
+  if (typeof expires === 'string') {
+    // Possible that the expiresAt value is passed via JSON
+    expires = new Date(expires);
+  }
 
   Cookies.set(name, value, {
     expires: expires,
     path: '/'
   });
+
   return getCookie(name);
 }
 
-function getCookie(name) {
-  return Cookies.get(name);
+function getCookie() {
+  return Cookies.get.apply(Cookies, arguments);
 }
 
-function deleteCookie(name) {
-  Cookies.remove(name, { path: '/' });
+function deleteCookie() {
+  return Cookies.remove.apply(Cookies, arguments);
 }
 
 module.exports = {

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -13,27 +13,25 @@
 var Cookies = require('js-cookie');
 
 function setCookie(name, value, expiresAt) {
-  var expires = expiresAt || new Date('2038-01-19T03:14:07.000Z');
+  var cookieOptions = {
+    path: '/'
+  };
 
-  if (typeof expires === 'string') {
-    // Possible that the expiresAt value is passed via JSON
-    expires = new Date(expires);
+  if (expiresAt && Date.parse(expiresAt)) {
+    // Expires value can be converted to a Date object
+    cookieOptions.expires = new Date(expiresAt);
   }
 
-  Cookies.set(name, value, {
-    expires: expires,
-    path: '/'
-  });
-
+  Cookies.set(name, value, cookieOptions);
   return getCookie(name);
 }
 
-function getCookie() {
-  return Cookies.get.apply(Cookies, arguments);
+function getCookie(name) {
+  return Cookies.get(name);
 }
 
-function deleteCookie() {
-  return Cookies.remove.apply(Cookies, arguments);
+function deleteCookie(name) {
+  return Cookies.remove(name, { path: '/' });
 }
 
 module.exports = {

--- a/lib/storageUtil.js
+++ b/lib/storageUtil.js
@@ -67,7 +67,8 @@ storageUtil.getCookieStorage = function() {
   return {
     getItem: cookies.getCookie,
     setItem: function(key, value) {
-      cookies.setCookie(key, value);
+      // Cookie shouldn't expire
+      cookies.setCookie(key, value, '2038-01-19T03:14:07.000Z');
     }
   };
 };

--- a/lib/storageUtil.js
+++ b/lib/storageUtil.js
@@ -67,8 +67,7 @@ storageUtil.getCookieStorage = function() {
   return {
     getItem: cookies.getCookie,
     setItem: function(key, value) {
-      // Cookie shouldn't expire
-      cookies.setCookie(key, value, '2038-01-19T03:14:07.000Z');
+      cookies.setCookie(key, value);
     }
   };
 };

--- a/lib/token.js
+++ b/lib/token.js
@@ -534,8 +534,12 @@ function parseFromUrl(sdk, url) {
   }
 
   var oauthParamsCookie = cookies.getCookie(config.REDIRECT_OAUTH_PARAMS_COOKIE_NAME);
-  if (!hash || !oauthParamsCookie) {
+  if (!hash) {
     return Q.reject(new AuthSdkError('Unable to parse a token from the url'));
+  }
+
+  if (!oauthParamsCookie) {
+    return Q.reject(new AuthSdkError('Unable to parse OAuth redirect params cookie'));
   }
   try {
     var oauthParams = JSON.parse(oauthParamsCookie);

--- a/lib/token.js
+++ b/lib/token.js
@@ -533,14 +533,15 @@ function parseFromUrl(sdk, url) {
     hash = url.substring(url.indexOf('#'));
   }
 
-  var oauthParamsCookie = cookies.getCookie(config.REDIRECT_OAUTH_PARAMS_COOKIE_NAME);
   if (!hash) {
     return Q.reject(new AuthSdkError('Unable to parse a token from the url'));
   }
 
+  var oauthParamsCookie = cookies.getCookie(config.REDIRECT_OAUTH_PARAMS_COOKIE_NAME);
   if (!oauthParamsCookie) {
-    return Q.reject(new AuthSdkError('Unable to parse OAuth redirect params cookie'));
+    return Q.reject(new AuthSdkError('Unable to retrieve OAuth redirect params cookie'));
   }
+
   try {
     var oauthParams = JSON.parse(oauthParamsCookie);
     var urls = oauthParams.urls;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "dependencies": {
     "Base64": "0.3.0",
+    "js-cookie": "2.2.0",
     "q": "1.4.1",
     "reqwest": "2.0.5",
     "tiny-emitter": "1.1.0",

--- a/test/spec/cookies.js
+++ b/test/spec/cookies.js
@@ -1,0 +1,34 @@
+var Cookies  = require('../../lib/cookies');
+var JsCookie = require('js-cookie');
+
+describe('cookie', function () {
+  beforeEach(function () {
+    spyOn(JsCookie, 'get');
+    spyOn(JsCookie, 'set');
+    spyOn(JsCookie, 'remove');
+  });
+
+  describe('setCookie',  function ()  {
+    it('proxies JsCookie.set',  function ()  {
+      Cookies.setCookie('foo', 'bar');
+      expect(JsCookie.set).toHaveBeenCalledWith('foo', 'bar', {
+        expires: new Date('2038-01-19T03:14:07.000Z'),
+        path: '/'
+      });
+    });
+  });
+
+  describe('getCookie',  function ()  {
+    it('proxies Cookie.getCookie',  function ()  {
+      Cookies.getCookie('foo');
+      expect(JsCookie.get).toHaveBeenCalledWith('foo');
+    });
+  });
+
+  describe('deleteCookie',  function ()  {
+    it('proxies JsCookie.remove',  function ()  {
+      Cookies.deleteCookie('foo', { bar: 'baz' });
+      expect(JsCookie.remove).toHaveBeenCalledWith('foo', { bar: 'baz' });
+    });
+  });
+});

--- a/test/spec/cookies.js
+++ b/test/spec/cookies.js
@@ -12,7 +12,21 @@ describe('cookie', function () {
     it('proxies JsCookie.set',  function ()  {
       Cookies.setCookie('foo', 'bar');
       expect(JsCookie.set).toHaveBeenCalledWith('foo', 'bar', {
-        expires: new Date('2038-01-19T03:14:07.000Z'),
+        path: '/'
+      });
+    });
+
+    it('proxies JsCookie.set with an expiry time',  function ()  {
+      Cookies.setCookie('foo', 'bar', '2038-01-19T03:14:07.000Z');
+      expect(JsCookie.set).toHaveBeenCalledWith('foo', 'bar', {
+        path: '/',
+        expires: new Date('2038-01-19T03:14:07.000Z')
+      });
+    });
+
+    it('proxies JsCookie.set with an invalid expiry time',  function ()  {
+      Cookies.setCookie('foo', 'bar', 'not a valid date');
+      expect(JsCookie.set).toHaveBeenCalledWith('foo', 'bar', {
         path: '/'
       });
     });
@@ -27,8 +41,8 @@ describe('cookie', function () {
 
   describe('deleteCookie',  function ()  {
     it('proxies JsCookie.remove',  function ()  {
-      Cookies.deleteCookie('foo', { bar: 'baz' });
-      expect(JsCookie.remove).toHaveBeenCalledWith('foo', { bar: 'baz' });
+      Cookies.deleteCookie('foo');
+      expect(JsCookie.remove).toHaveBeenCalledWith('foo', { path: '/' });
     });
   });
 });

--- a/test/spec/oauthUtil.js
+++ b/test/spec/oauthUtil.js
@@ -158,8 +158,7 @@ define(function(require) {
               expiresAt: 1449786329,
               response: wellKnown.response
             }
-          }),
-          '2038-01-19T03:14:07.000Z'
+          })
         );
       }
     });

--- a/test/spec/oauthUtil.js
+++ b/test/spec/oauthUtil.js
@@ -158,7 +158,8 @@ define(function(require) {
               expiresAt: 1449786329,
               response: wellKnown.response
             }
-          })
+          }),
+          '2038-01-19T03:14:07.000Z'
         );
       }
     });

--- a/test/spec/oauthUtil.js
+++ b/test/spec/oauthUtil.js
@@ -151,12 +151,16 @@ define(function(require) {
         return oauthUtil.getWellKnown(test.oa);
       },
       expectations: function(test) {
-        expect(test.setCookieMock).toHaveBeenCalledWith('okta-cache-storage=' + JSON.stringify({
-          'https://auth-js-test.okta.com/.well-known/openid-configuration': {
-            expiresAt: 1449786329,
-            response: wellKnown.response
-          }
-        }) + '; path=/; expires=Tue, 19 Jan 2038 03:14:07 GMT;');
+        expect(test.setCookieMock).toHaveBeenCalledWith(
+          'okta-cache-storage',
+          JSON.stringify({
+            'https://auth-js-test.okta.com/.well-known/openid-configuration': {
+              expiresAt: 1449786329,
+              response: wellKnown.response
+            }
+          }),
+          '2038-01-19T03:14:07.000Z'
+        );
       }
     });
   });
@@ -340,7 +344,7 @@ define(function(require) {
         expect(error.errorCauses).toEqual([]);
       }
     }
-    
+
     it('defaults all urls using global defaults', function() {
       setupOAuthUrls({
         expectedResult: {

--- a/test/spec/token.js
+++ b/test/spec/token.js
@@ -896,7 +896,7 @@ define(function(require) {
           'expires_in': 3600,
           'state': oauthUtil.mockedState
         },
-        expectedResp: [tokens.standardAccessTokenParsed, tokens.standardIdTokenParsed] 
+        expectedResp: [tokens.standardAccessTokenParsed, tokens.standardIdTokenParsed]
       })
       .fin(function() {
         done();
@@ -951,19 +951,28 @@ define(function(require) {
           sessionToken: 'testToken'
         },
         expectedCookies: [
-          'okta-oauth-redirect-params=' + JSON.stringify({
-            responseType: 'id_token',
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            scopes: ['openid', 'email'],
-            urls: {
-              issuer: 'https://auth-js-test.okta.com',
-              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-            }
-          }) + '; path=/;',
-          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
-          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+          [
+            'okta-oauth-redirect-params',
+            JSON.stringify({
+              responseType: 'id_token',
+              state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              scopes: ['openid', 'email'],
+              urls: {
+                issuer: 'https://auth-js-test.okta.com',
+                authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+                userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+              }
+            })
+          ],
+          [
+            'okta-oauth-nonce',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ],
+          [
+            'okta-oauth-state',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ]
         ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
@@ -989,19 +998,28 @@ define(function(require) {
           sessionToken: 'testToken'
         },
         expectedCookies: [
-          'okta-oauth-redirect-params=' + JSON.stringify({
-            responseType: 'id_token',
-            state: oauthUtil.mockedState,
-            nonce: oauthUtil.mockedNonce,
-            scopes: ['openid', 'email'],
-            urls: {
-              issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
-              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
-              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
-            }
-          }) + '; path=/;',
-          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
-          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+          [
+            'okta-oauth-redirect-params',
+            JSON.stringify({
+              responseType: 'id_token',
+              state: oauthUtil.mockedState,
+              nonce: oauthUtil.mockedNonce,
+              scopes: ['openid', 'email'],
+              urls: {
+                issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
+                authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
+                userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
+              }
+            })
+          ],
+          [
+            'okta-oauth-nonce',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ],
+          [
+            'okta-oauth-state',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ]
         ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
@@ -1031,19 +1049,28 @@ define(function(require) {
           issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
         }],
         expectedCookies: [
-          'okta-oauth-redirect-params=' + JSON.stringify({
-            responseType: 'token',
-            state: oauthUtil.mockedState,
-            nonce: oauthUtil.mockedNonce,
-            scopes: ['email'],
-            urls: {
-              issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
-              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
-              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
-            }
-          }) + '; path=/;',
-          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
-          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+          [
+            'okta-oauth-redirect-params',
+            JSON.stringify({
+              responseType: 'token',
+              state: oauthUtil.mockedState,
+              nonce: oauthUtil.mockedNonce,
+              scopes: ['email'],
+              urls: {
+                issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
+                authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
+                userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
+              }
+            })
+          ],
+          [
+            'okta-oauth-nonce',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ],
+          [
+            'okta-oauth-state',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ]
         ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
@@ -1065,19 +1092,28 @@ define(function(require) {
           sessionToken: 'testToken'
         },
         expectedCookies: [
-          'okta-oauth-redirect-params=' + JSON.stringify({
-            responseType: 'token',
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            scopes: ['email'],
-            urls: {
-              issuer: 'https://auth-js-test.okta.com',
-              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-            }
-          }) + '; path=/;',
-          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
-          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+          [
+            'okta-oauth-redirect-params',
+            JSON.stringify({
+              responseType: 'token',
+              state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              scopes: ['email'],
+              urls: {
+                issuer: 'https://auth-js-test.okta.com',
+                authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+                userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+              }
+            })
+          ],
+          [
+            'okta-oauth-nonce',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ],
+          [
+            'okta-oauth-state',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ]
         ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
@@ -1105,19 +1141,28 @@ define(function(require) {
           sessionToken: 'testToken'
         },
         expectedCookies: [
-          'okta-oauth-redirect-params=' + JSON.stringify({
-            responseType: 'token',
-            state: oauthUtil.mockedState,
-            nonce: oauthUtil.mockedNonce,
-            scopes: ['email'],
-            urls: {
-              issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
-              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
-              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
-            }
-          }) + '; path=/;',
-          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
-          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+          [
+            'okta-oauth-redirect-params',
+            JSON.stringify({
+              responseType: 'token',
+              state: oauthUtil.mockedState,
+              nonce: oauthUtil.mockedNonce,
+              scopes: ['email'],
+              urls: {
+                issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
+                authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
+                userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
+              }
+            })
+          ],
+          [
+            'okta-oauth-nonce',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ],
+          [
+            'okta-oauth-state',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ]
         ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
@@ -1138,19 +1183,28 @@ define(function(require) {
           idp: 'testIdp'
         },
         expectedCookies: [
-          'okta-oauth-redirect-params=' + JSON.stringify({
-            responseType: ['token', 'id_token'],
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            scopes: ['openid', 'email'],
-            urls: {
-              issuer: 'https://auth-js-test.okta.com',
-              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-            }
-          }) + '; path=/;',
-          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
-          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+          [
+            'okta-oauth-redirect-params',
+            JSON.stringify({
+              responseType: ['token', 'id_token'],
+              state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              scopes: ['openid', 'email'],
+              urls: {
+                issuer: 'https://auth-js-test.okta.com',
+                authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+                userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+              }
+            })
+          ],
+          [
+            'okta-oauth-nonce',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ],
+          [
+            'okta-oauth-state',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ]
         ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
@@ -1177,19 +1231,28 @@ define(function(require) {
           idp: 'testIdp'
         },
         expectedCookies: [
-          'okta-oauth-redirect-params=' + JSON.stringify({
-            responseType: ['token', 'id_token'],
-            state: oauthUtil.mockedState,
-            nonce: oauthUtil.mockedNonce,
-            scopes: ['openid', 'email'],
-            urls: {
-              issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
-              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
-              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
-            }
-          }) + '; path=/;',
-          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
-          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+          [
+            'okta-oauth-redirect-params',
+            JSON.stringify({
+              responseType: ['token', 'id_token'],
+              state: oauthUtil.mockedState,
+              nonce: oauthUtil.mockedNonce,
+              scopes: ['openid', 'email'],
+              urls: {
+                issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
+                authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
+                userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
+              }
+            })
+          ],
+          [
+            'okta-oauth-nonce',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ],
+          [
+            'okta-oauth-state',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ]
         ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
@@ -1210,19 +1273,28 @@ define(function(require) {
           responseType: 'code'
         },
         expectedCookies: [
-          'okta-oauth-redirect-params=' + JSON.stringify({
-            responseType: 'code',
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            scopes: ['openid', 'email'],
-            urls: {
-              issuer: 'https://auth-js-test.okta.com',
-              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-            }
-          }) + '; path=/;',
-          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
-          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+          [
+            'okta-oauth-redirect-params',
+            JSON.stringify({
+              responseType: 'code',
+              state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              scopes: ['openid', 'email'],
+              urls: {
+                issuer: 'https://auth-js-test.okta.com',
+                authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+                userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+              }
+            })
+          ],
+          [
+            'okta-oauth-nonce',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ],
+          [
+            'okta-oauth-state',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ]
         ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
@@ -1249,19 +1321,28 @@ define(function(require) {
           responseType: 'code'
         },
         expectedCookies: [
-          'okta-oauth-redirect-params=' + JSON.stringify({
-            responseType: 'code',
-            state: oauthUtil.mockedState,
-            nonce: oauthUtil.mockedNonce,
-            scopes: ['openid', 'email'],
-            urls: {
-              issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
-              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
-              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
-            }
-          }) + '; path=/;',
-          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
-          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+          [
+            'okta-oauth-redirect-params',
+            JSON.stringify({
+              responseType: 'code',
+              state: oauthUtil.mockedState,
+              nonce: oauthUtil.mockedNonce,
+              scopes: ['openid', 'email'],
+              urls: {
+                issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
+                authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
+                userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
+              }
+            })
+          ],
+          [
+            'okta-oauth-nonce',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ],
+          [
+            'okta-oauth-state',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ]
         ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
@@ -1283,19 +1364,28 @@ define(function(require) {
           responseType: ['code']
         },
         expectedCookies: [
-          'okta-oauth-redirect-params=' + JSON.stringify({
-            responseType: ['code'],
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            scopes: ['openid', 'email'],
-            urls: {
-              issuer: 'https://auth-js-test.okta.com',
-              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-            }
-          }) + '; path=/;',
-          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
-          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+          [
+            'okta-oauth-redirect-params',
+            JSON.stringify({
+              responseType: ['code'],
+              state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              scopes: ['openid', 'email'],
+              urls: {
+                issuer: 'https://auth-js-test.okta.com',
+                authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+                userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+              }
+            })
+          ],
+          [
+            'okta-oauth-nonce',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ],
+          [
+            'okta-oauth-state',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ]
         ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
@@ -1317,19 +1407,28 @@ define(function(require) {
           responseType: ['code', 'id_token']
         },
         expectedCookies: [
-          'okta-oauth-redirect-params=' + JSON.stringify({
-            responseType: ['code', 'id_token'],
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            scopes: ['openid', 'email'],
-            urls: {
-              issuer: 'https://auth-js-test.okta.com',
-              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-            }
-          }) + '; path=/;',
-          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
-          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+          [
+            'okta-oauth-redirect-params',
+            JSON.stringify({
+              responseType: ['code', 'id_token'],
+              state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              scopes: ['openid', 'email'],
+              urls: {
+                issuer: 'https://auth-js-test.okta.com',
+                authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+                userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+              }
+            })
+          ],
+          [
+            'okta-oauth-nonce',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ],
+          [
+            'okta-oauth-state',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ]
         ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
@@ -1351,19 +1450,28 @@ define(function(require) {
           responseMode: 'form_post'
         },
         expectedCookies: [
-          'okta-oauth-redirect-params=' + JSON.stringify({
-            responseType: 'code',
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            scopes: ['openid', 'email'],
-            urls: {
-              issuer: 'https://auth-js-test.okta.com',
-              authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-              userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-            }
-          }) + '; path=/;',
-          'okta-oauth-nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;',
-          'okta-oauth-state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; path=/;'
+          [
+            'okta-oauth-redirect-params',
+            JSON.stringify({
+              responseType: 'code',
+              state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              scopes: ['openid', 'email'],
+              urls: {
+                issuer: 'https://auth-js-test.okta.com',
+                authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+                userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+              }
+            })
+          ],
+          [
+            'okta-oauth-nonce',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ],
+          [
+            'okta-oauth-state',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          ]
         ],
         expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                              'client_id=NPSfOkH5eZrTy8PMDlvx&' +
@@ -1383,7 +1491,7 @@ define(function(require) {
       return oauthUtil.setupParseUrl({
         directUrl: 'http://example.com#id_token=' + tokens.standardIdToken +
                   '&state=' + oauthUtil.mockedState,
-        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+        oauthCookie: JSON.stringify({
           responseType: 'id_token',
           state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -1393,7 +1501,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + '; path=/;',
+        }),
         expectedResp: {
           idToken: tokens.standardIdToken,
           claims: tokens.standardIdTokenClaims,
@@ -1411,7 +1519,7 @@ define(function(require) {
         noHistory: true,
         hashMock: '#id_token=' + tokens.standardIdToken +
                   '&state=' + oauthUtil.mockedState,
-        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+        oauthCookie: JSON.stringify({
           responseType: 'id_token',
           state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -1421,7 +1529,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + '; path=/;',
+        }),
         expectedResp: {
           idToken: tokens.standardIdToken,
           claims: tokens.standardIdTokenClaims,
@@ -1438,7 +1546,7 @@ define(function(require) {
       return oauthUtil.setupParseUrl({
         hashMock: '#id_token=' + tokens.standardIdToken +
                   '&state=' + oauthUtil.mockedState,
-        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+        oauthCookie: JSON.stringify({
           responseType: 'id_token',
           state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -1448,7 +1556,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + '; path=/;',
+        }),
         expectedResp: {
           idToken: tokens.standardIdToken,
           claims: tokens.standardIdTokenClaims,
@@ -1465,7 +1573,7 @@ define(function(require) {
       return oauthUtil.setupParseUrl({
         hashMock: '#id_token=' + tokens.authServerIdToken +
                   '&state=' + oauthUtil.mockedState,
-        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+        oauthCookie: JSON.stringify({
           responseType: 'id_token',
           state: oauthUtil.mockedState,
           nonce: oauthUtil.mockedNonce,
@@ -1475,7 +1583,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
           }
-        }) + '; path=/;',
+        }),
         expectedResp: tokens.authServerIdTokenParsed
       })
       .fin(function() {
@@ -1490,7 +1598,7 @@ define(function(require) {
                   '&expires_in=3600' +
                   '&token_type=Bearer' +
                   '&state=' + oauthUtil.mockedState,
-        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+        oauthCookie: JSON.stringify({
           responseType: 'token',
           state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -1500,7 +1608,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + '; path=/;',
+        }),
         expectedResp: tokens.standardAccessTokenParsed
       })
       .fin(function() {
@@ -1515,7 +1623,7 @@ define(function(require) {
                   '&expires_in=3600' +
                   '&token_type=Bearer' +
                   '&state=' + oauthUtil.mockedState,
-        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+        oauthCookie: JSON.stringify({
           responseType: 'token',
           state: oauthUtil.mockedState,
           nonce: oauthUtil.mockedNonce,
@@ -1525,7 +1633,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
           }
-        }) + '; path=/;',
+        }),
         expectedResp: tokens.authServerAccessTokenParsed
       })
       .fin(function() {
@@ -1541,7 +1649,7 @@ define(function(require) {
                   '&expires_in=3600' +
                   '&token_type=Bearer' +
                   '&state=' + oauthUtil.mockedState,
-        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+        oauthCookie: JSON.stringify({
           responseType: ['id_token', 'token'],
           state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -1551,7 +1659,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + '; path=/;',
+        }),
         expectedResp: [tokens.standardIdTokenParsed, tokens.standardAccessTokenParsed]
       })
       .fin(function() {
@@ -1567,7 +1675,7 @@ define(function(require) {
                   '&expires_in=3600' +
                   '&token_type=Bearer' +
                   '&state=' + oauthUtil.mockedState,
-        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+        oauthCookie: JSON.stringify({
           responseType: ['id_token', 'token'],
           state: oauthUtil.mockedState,
           nonce: oauthUtil.mockedNonce,
@@ -1577,7 +1685,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
           }
-        }) + '; path=/;',
+        }),
         expectedResp: [tokens.authServerIdTokenParsed, tokens.authServerTokenParsed]
       })
       .fin(function() {
@@ -1594,7 +1702,7 @@ define(function(require) {
                   '&expires_in=3600' +
                   '&token_type=Bearer' +
                   '&state=' + oauthUtil.mockedState,
-        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+        oauthCookie: JSON.stringify({
           responseType: ['id_token', 'token', 'code'],
           state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -1604,7 +1712,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + '; path=/;',
+        }),
         expectedResp: [tokens.standardIdTokenParsed, tokens.standardAccessTokenParsed, {
           authorizationCode: tokens.standardAuthorizationCode
         }]
@@ -1622,7 +1730,7 @@ define(function(require) {
                   '&expires_in=3600' +
                   '&token_type=Bearer' +
                   '&state=' + oauthUtil.mockedState,
-        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+        oauthCookie: JSON.stringify({
           responseType: ['id_token', 'code', 'token'],
           state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -1632,7 +1740,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + '; path=/;',
+        }),
         expectedResp: [tokens.standardIdTokenParsed, undefined, tokens.standardAccessTokenParsed]
       })
       .fin(function() {
@@ -1649,7 +1757,7 @@ define(function(require) {
                   '&expires_in=3600' +
                   '&token_type=Bearer' +
                   '&state=' + oauthUtil.mockedState,
-        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+        oauthCookie: JSON.stringify({
           responseType: ['id_token', 'token', 'code'],
           state: oauthUtil.mockedState,
           nonce: oauthUtil.mockedNonce,
@@ -1659,7 +1767,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
           }
-        }) + '; path=/;',
+        }),
         expectedResp: [tokens.authServerIdTokenParsed, tokens.authServerAccessTokenParsed, {
           authorizationCode: tokens.standardAuthorizationCode
         }]
@@ -1673,7 +1781,7 @@ define(function(require) {
       {
         setupMethod: oauthUtil.setupParseUrl,
         hashMock: '',
-        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+        oauthCookie: JSON.stringify({
           responseType: ['id_token', 'token'],
           state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -1683,7 +1791,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + '; path=/;'
+        })
       },
       {
         name: 'AuthSdkError',
@@ -1708,9 +1816,9 @@ define(function(require) {
       },
       {
         name: 'AuthSdkError',
-        message: 'Unable to parse a token from the url',
+        message: 'Unable to parse OAuth redirect params cookie',
         errorCode: 'INTERNAL',
-        errorSummary: 'Unable to parse a token from the url',
+        errorSummary: 'Unable to parse OAuth redirect params cookie',
         errorLink: 'INTERNAL',
         errorId: 'INTERNAL',
         errorCauses: []
@@ -1725,7 +1833,7 @@ define(function(require) {
                   '&expires_in=3600' +
                   '&token_type=Bearer' +
                   '&state=' + oauthUtil.mockedState,
-        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+        oauthCookie: JSON.stringify({
           responseType: ['id_token', 'token'],
           state: 'mismatchedState',
           nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -1735,7 +1843,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + '; path=/;'
+        })
       },
       {
         name: 'AuthSdkError',
@@ -1756,7 +1864,7 @@ define(function(require) {
                   '&expires_in=3600' +
                   '&token_type=Bearer' +
                   '&state=' + oauthUtil.mockedState,
-        oauthCookie: 'okta-oauth-redirect-params=' + JSON.stringify({
+        oauthCookie: JSON.stringify({
           responseType: ['id_token', 'token'],
           state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           nonce: 'mismatchedNonce',
@@ -1766,7 +1874,7 @@ define(function(require) {
             authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
           }
-        }) + '; path=/;'
+        })
       },
       {
         name: 'AuthSdkError',

--- a/test/spec/token.js
+++ b/test/spec/token.js
@@ -1816,9 +1816,9 @@ define(function(require) {
       },
       {
         name: 'AuthSdkError',
-        message: 'Unable to parse OAuth redirect params cookie',
+        message: 'Unable to retrieve OAuth redirect params cookie',
         errorCode: 'INTERNAL',
-        errorSummary: 'Unable to parse OAuth redirect params cookie',
+        errorSummary: 'Unable to retrieve OAuth redirect params cookie',
         errorLink: 'INTERNAL',
         errorId: 'INTERNAL',
         errorCauses: []

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -47,8 +47,7 @@ define(function(require) {
         client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
         expect(setCookieMock).toHaveBeenCalledWith(
           'okta-token-storage',
-          JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
-          '2038-01-19T03:14:07.000Z'
+          JSON.stringify({'test-idToken': tokens.standardIdTokenParsed})
         );
       });
     });
@@ -528,8 +527,7 @@ define(function(require) {
           client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
           expect(setCookieMock).toHaveBeenCalledWith(
             'okta-token-storage',
-            JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
-            '2038-01-19T03:14:07.000Z'
+            JSON.stringify({'test-idToken': tokens.standardIdTokenParsed})
           );
         });
       });
@@ -552,8 +550,7 @@ define(function(require) {
           client.tokenManager.remove('test-idToken');
           expect(setCookieMock).toHaveBeenCalledWith(
             'okta-token-storage',
-            JSON.stringify({anotherKey: tokens.standardIdTokenParsed}),
-            '2038-01-19T03:14:07.000Z'
+            JSON.stringify({anotherKey: tokens.standardIdTokenParsed})
           );
         });
       });
@@ -567,8 +564,7 @@ define(function(require) {
           client.tokenManager.clear();
           expect(setCookieMock).toHaveBeenCalledWith(
             'okta-token-storage',
-            '{}',
-            '2038-01-19T03:14:07.000Z'
+            '{}'
           );
         });
       });

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -47,7 +47,8 @@ define(function(require) {
         client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
         expect(setCookieMock).toHaveBeenCalledWith(
           'okta-token-storage',
-          JSON.stringify({'test-idToken': tokens.standardIdTokenParsed})
+          JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
+          '2038-01-19T03:14:07.000Z'
         );
       });
     });
@@ -527,7 +528,8 @@ define(function(require) {
           client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
           expect(setCookieMock).toHaveBeenCalledWith(
             'okta-token-storage',
-            JSON.stringify({'test-idToken': tokens.standardIdTokenParsed})
+            JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
+            '2038-01-19T03:14:07.000Z'
           );
         });
       });
@@ -550,7 +552,8 @@ define(function(require) {
           client.tokenManager.remove('test-idToken');
           expect(setCookieMock).toHaveBeenCalledWith(
             'okta-token-storage',
-            JSON.stringify({anotherKey: tokens.standardIdTokenParsed})
+            JSON.stringify({anotherKey: tokens.standardIdTokenParsed}),
+            '2038-01-19T03:14:07.000Z'
           );
         });
       });
@@ -564,7 +567,8 @@ define(function(require) {
           client.tokenManager.clear();
           expect(setCookieMock).toHaveBeenCalledWith(
             'okta-token-storage',
-            '{}'
+            '{}',
+            '2038-01-19T03:14:07.000Z'
           );
         });
       });

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -45,9 +45,11 @@ define(function(require) {
         var client = setupSync();
         var setCookieMock = util.mockSetCookie();
         client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
-        expect(setCookieMock).toHaveBeenCalledWith('okta-token-storage=' + JSON.stringify({
-          'test-idToken': tokens.standardIdTokenParsed
-        }) + '; path=/; expires=Tue, 19 Jan 2038 03:14:07 GMT;');
+        expect(setCookieMock).toHaveBeenCalledWith(
+          'okta-token-storage',
+          JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
+          '2038-01-19T03:14:07.000Z'
+        );
       });
     });
 
@@ -496,7 +498,7 @@ define(function(require) {
           });
         });
       });
-      
+
       describe('clear', function() {
         it('clears all tokens', function() {
           var client = sessionStorageSetup();
@@ -522,21 +524,20 @@ define(function(require) {
       describe('add', function() {
         it('adds a token', function() {
           var client = cookieStorageSetup();
-          util.mockGetCookie('');
           var setCookieMock = util.mockSetCookie();
           client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
-          expect(setCookieMock).toHaveBeenCalledWith('okta-token-storage=' + JSON.stringify({
-            'test-idToken': tokens.standardIdTokenParsed
-          }) + '; path=/; expires=Tue, 19 Jan 2038 03:14:07 GMT;');
+          expect(setCookieMock).toHaveBeenCalledWith(
+            'okta-token-storage',
+            JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
+            '2038-01-19T03:14:07.000Z'
+          );
         });
       });
 
       describe('get', function() {
         it('gets a token', function() {
           var client = cookieStorageSetup();
-          util.mockGetCookie('okta-token-storage=' + JSON.stringify({
-            'test-idToken': tokens.standardIdTokenParsed
-          }) + ';');
+          client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
           var result = client.tokenManager.get('test-idToken');
           expect(result).toEqual(tokens.standardIdTokenParsed);
         });
@@ -545,29 +546,30 @@ define(function(require) {
       describe('remove', function() {
         it('removes a token', function() {
           var client = cookieStorageSetup();
-          util.mockGetCookie('okta-token-storage=' + JSON.stringify({
-            'test-idToken': tokens.standardIdTokenParsed,
-            anotherKey: tokens.standardIdTokenParsed
-          }) + ';');
+          client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
+          client.tokenManager.add('anotherKey', tokens.standardIdTokenParsed);
           var setCookieMock = util.mockSetCookie();
           client.tokenManager.remove('test-idToken');
-          expect(setCookieMock).toHaveBeenCalledWith('okta-token-storage=' + JSON.stringify({
-            anotherKey: tokens.standardIdTokenParsed
-          }) + '; path=/; expires=Tue, 19 Jan 2038 03:14:07 GMT;');
+          expect(setCookieMock).toHaveBeenCalledWith(
+            'okta-token-storage',
+            JSON.stringify({anotherKey: tokens.standardIdTokenParsed}),
+            '2038-01-19T03:14:07.000Z'
+          );
         });
       });
 
       describe('clear', function() {
         it('clears all tokens', function() {
           var client = cookieStorageSetup();
-          util.mockGetCookie('okta-token-storage=' + JSON.stringify({
-            'test-idToken': tokens.standardIdTokenParsed,
-            anotherKey: tokens.standardIdTokenParsed
-          }) + ';');
+          client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
+          client.tokenManager.add('anotherKey', tokens.standardIdTokenParsed);
           var setCookieMock = util.mockSetCookie();
           client.tokenManager.clear();
-          expect(setCookieMock).toHaveBeenCalledWith('okta-token-storage={}; path=/; ' +
-            'expires=Tue, 19 Jan 2038 03:14:07 GMT;');
+          expect(setCookieMock).toHaveBeenCalledWith(
+            'okta-token-storage',
+            '{}',
+            '2038-01-19T03:14:07.000Z'
+          );
         });
       });
     });

--- a/test/util/oauthUtil.js
+++ b/test/util/oauthUtil.js
@@ -5,7 +5,6 @@ define(function(require) {
   var tokens = require('./tokens');
   var Q = require('q');
   var EventEmitter = require('tiny-emitter');
-  var _ = require('lodash');
   var wellKnown = require('../xhr/well-known');
   var wellKnownSharedResource = require('../xhr/well-known-shared-resource');
   var keys = require('../xhr/keys');
@@ -344,9 +343,7 @@ define(function(require) {
 
     expect(windowLocationMock).toHaveBeenCalledWith(opts.expectedRedirectUrl);
 
-    _.each(opts.expectedCookies, function(cookie) {
-      expect(setCookieMock).toHaveBeenCalledWith(cookie);
-    });
+    expect(setCookieMock.calls.allArgs()).toEqual(opts.expectedCookies);
   };
 
   oauthUtil.setupParseUrl = function(opts) {
@@ -395,7 +392,7 @@ define(function(require) {
     }
 
     util.mockGetCookie(opts.oauthCookie);
-    var setCookieMock = util.mockSetCookie();
+    var deleteCookieMock = util.mockDeleteCookie();
 
     return client.token.parseFromUrl(opts.directUrl)
       .then(function(res) {
@@ -403,8 +400,7 @@ define(function(require) {
         validateResponse(res, expectedResp);
 
         // The cookie should be deleted
-        expect(setCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params=; path=/; ' +
-          'expires=Thu, 01 Jan 1970 00:00:00 GMT;');
+        expect(deleteCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
 
         if (opts.directUrl) {
           expect(setLocationHashSpy).not.toHaveBeenCalled();

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -31,6 +31,12 @@ define(function(require) {
     jasmine.clock().tick(ticks);
   };
 
+  util.calculateDaysUntilCookieExperation = function () {
+    var future = new Date('2038-01-19T03:14:07.000Z').getTime();
+    var now = new Date().getTime();
+    return Math.floor((future - now)/(86400000));
+  };
+
   function generateXHRPair(request, response, uri) {
     return Q.Promise(function(resolve) {
 
@@ -330,11 +336,15 @@ define(function(require) {
   };
 
   util.mockSetCookie = function () {
-    return spyOn(cookies.setCookie, '_setDocumentCookie');
+    return spyOn(cookies, 'setCookie');
+  };
+
+  util.mockDeleteCookie = function () {
+    return spyOn(cookies, 'deleteCookie');
   };
 
   util.mockGetCookie = function (text) {
-    spyOn(cookies.getCookie, '_getDocumentCookie').and.returnValue(text || '');
+    spyOn(cookies, 'getCookie').and.returnValue(text || '');
   };
 
   util.mockGetHistory = function (client, mockHistory) {

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -31,12 +31,6 @@ define(function(require) {
     jasmine.clock().tick(ticks);
   };
 
-  util.calculateDaysUntilCookieExperation = function () {
-    var future = new Date('2038-01-19T03:14:07.000Z').getTime();
-    var now = new Date().getTime();
-    return Math.floor((future - now)/(86400000));
-  };
-
   function generateXHRPair(request, response, uri) {
     return Q.Promise(function(resolve) {
 


### PR DESCRIPTION
### Description

Updates cookie storage to be compliant with [RFC 6265](https://tools.ietf.org/html/rfc6265#section-4.1.1).

### Notable Changes
We're now using a new dependency - [`js-cookie`](https://github.com/js-cookie/js-cookie) to handle storing/retrieving objects from `document.cookie`. This creates a slightly larger build:

| File                                       | Size             | New Size   |
|  :------------------------  | :----------: | :---------: |
| `okta-auth-js.min.js`         | **63KB**   |  **63KB**  |
| `okta-auth-js.min.js.map` | **465KB** | **470KB** |

### Resolves
- #112 
- #100 

