### PR TITLE
:seedling: Infer url from issuer during creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ var config = {
 var authClient = new OktaAuth(config);
 ```
 
+Alternatively, the `url` can be omitted if the `issuer` param is present, and passed as an absolute URL.
+
+```javascript
+var config = {
+  issuer: 'https://{yourOktaDomain}/oauth2/default'
+};
+
+var authClient = new OktaAuth(config);
+```
+
 ### [OpenID Connect](https://developer.okta.com/docs/api/resources/oidc) options
 
 These configuration options can be included when instantiating Okta Auth JS (`new OktaAuth(config)`) or in `token.getWithoutPrompt`, `token.getWithPopup`, or `token.getWithRedirect` (unless noted otherwise). If included in both, the value passed in the method takes priority.

--- a/lib/clientBuilder.js
+++ b/lib/clientBuilder.js
@@ -34,18 +34,25 @@ function OktaAuthBuilder(args) {
       'Required usage: new OktaAuth(args)');
   }
 
-  if (!args.url) {
-    throw new AuthSdkError('No url passed to constructor. ' +
+  var url = args.url;
+  if (!url) {
+    var isUrlRegex = new RegExp('^http?s?://.+');
+    if (args.issuer && isUrlRegex.test(args.issuer)) {
+      // Infer the URL from the issuer URL, omitting the /oauth2/{authServerId}
+      url = args.issuer.split('/oauth2/')[0];
+    } else {
+      throw new AuthSdkError('No url passed to constructor. ' +
       'Required usage: new OktaAuth({url: "https://sample.okta.com"})');
+    }
   }
 
-  if (args.url.indexOf('-admin.') !== -1) {
+  if (url.indexOf('-admin.') !== -1) {
     throw new AuthSdkError('URL passed to constructor contains "-admin" in subdomain. ' +
       'Required usage: new OktaAuth({url: "https://dev-12345.okta.com})');
   }
 
   this.options = {
-    url: util.removeTrailingSlash(args.url),
+    url: util.removeTrailingSlash(url),
     clientId: args.clientId,
     issuer: util.removeTrailingSlash(args.issuer),
     authorizeUrl: util.removeTrailingSlash(args.authorizeUrl),

--- a/test/spec/errors.js
+++ b/test/spec/errors.js
@@ -83,7 +83,7 @@ define(function(require) {
       expect(err.errorSummary).toEqual('No arguments passed to constructor. Required usage: new OktaAuth(args)');
     });
 
-    it('throw an error if no url and issuer are passed to the constructor', function () {
+    it('throw an error if no url and no issuer are passed to the constructor', function () {
       var err;
       try {
         new OktaAuth({}); // eslint-disable-line no-new

--- a/test/spec/errors.js
+++ b/test/spec/errors.js
@@ -34,8 +34,8 @@ define(function(require) {
       expectations: function (test, err) {
         var expected = _.cloneDeep(test.responseBody);
         expected.errorSummary = 'Unknown error';
-        
-        // We explicitly defined the fields to compare, 
+
+        // We explicitly defined the fields to compare,
         // because we don't want to compare all the xhr fields
         expect(err.xhr.status).toEqual(test.resReply.status);
 
@@ -83,10 +83,22 @@ define(function(require) {
       expect(err.errorSummary).toEqual('No arguments passed to constructor. Required usage: new OktaAuth(args)');
     });
 
-    it('throw an error if no url is passed to the constructor', function () {
+    it('throw an error if no url and issuer are passed to the constructor', function () {
       var err;
       try {
         new OktaAuth({}); // eslint-disable-line no-new
+      } catch (e) {
+        err = e;
+      }
+      expect(err.name).toEqual('AuthSdkError');
+      expect(err.errorSummary).toEqual('No url passed to constructor. ' +
+        'Required usage: new OktaAuth({url: "https://sample.okta.com"})');
+    });
+
+    it('throw an error if issuer is not a url and url is omitted when passed to the constructor', function () {
+      var err;
+      try {
+        new OktaAuth({issuer: 'default'}); // eslint-disable-line no-new
       } catch (e) {
         err = e;
       }

--- a/test/spec/token.js
+++ b/test/spec/token.js
@@ -8,7 +8,7 @@ define(function(require) {
   var Q = require('q');
 
   function setupSync() {
-    return new OktaAuth({ url: 'http://example.okta.com' });
+    return new OktaAuth({ issuer: 'http://example.okta.com' });
   }
 
   describe('token.decode', function () {
@@ -36,7 +36,7 @@ define(function(require) {
     it('returns id_token using sessionToken', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
@@ -66,10 +66,9 @@ define(function(require) {
     it('returns id_token using sessionToken with issuer', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
-          redirectUri: 'https://example.com/redirect',
-          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
+          redirectUri: 'https://example.com/redirect'
         },
         getWithoutPromptArgs: {
           sessionToken: 'testSessionToken'
@@ -138,10 +137,9 @@ define(function(require) {
     it('allows passing issuer through getWithoutPrompt, which takes precedence', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com/oauth2/ORIGINAL_AUTH_SERVER_ID',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
-          redirectUri: 'https://example.com/redirect',
-          issuer: 'https://auth-js-test.okta.com/oauth2/ORIGINAL_AUTH_SERVER_ID'
+          redirectUri: 'https://example.com/redirect'
         },
         getWithoutPromptArgs: [{
           sessionToken: 'testSessionToken'
@@ -176,10 +174,9 @@ define(function(require) {
     it('allows passing issuer as an id through getWithoutPrompt, which takes precedence', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com/oauth2/ORIGINAL_AUTH_SERVER_ID',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
-          redirectUri: 'https://example.com/redirect',
-          issuer: 'https://auth-js-test.okta.com/oauth2/ORIGINAL_AUTH_SERVER_ID'
+          redirectUri: 'https://example.com/redirect'
         },
         getWithoutPromptArgs: [{
           sessionToken: 'testSessionToken'
@@ -214,7 +211,7 @@ define(function(require) {
     it('returns id_token overriding all possible oauth params', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
@@ -324,7 +321,7 @@ define(function(require) {
     it('returns access_token using sessionToken', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
@@ -363,10 +360,9 @@ define(function(require) {
     it('returns access_token using sessionToken with authorization server', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
-          redirectUri: 'https://example.com/redirect',
-          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
+          redirectUri: 'https://example.com/redirect'
         },
         getWithoutPromptArgs: {
           responseType: 'token',
@@ -403,10 +399,9 @@ define(function(require) {
     it('returns access_token and id_token with an authorization server', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
-          redirectUri: 'https://example.com/redirect',
-          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
+          redirectUri: 'https://example.com/redirect'
         },
         getWithoutPromptArgs: {
           responseType: ['id_token', 'token'],
@@ -444,7 +439,7 @@ define(function(require) {
     it('returns id_token and access_token (in that order) using an array of responseTypes', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
@@ -484,7 +479,7 @@ define(function(require) {
     it('returns access_token and id_token (in that order) using an array of responseTypes', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
@@ -524,7 +519,7 @@ define(function(require) {
     it('returns a single token using an array with a single responseType', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
@@ -556,7 +551,7 @@ define(function(require) {
     oauthUtil.itpErrorsCorrectly('throws an error if multiple responseTypes are sent as a string',
       {
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
@@ -581,7 +576,7 @@ define(function(require) {
     it('returns id_token using idp', function (done) {
         return oauthUtil.setupPopup({
           oktaAuthArgs: {
-            url: 'https://auth-js-test.okta.com',
+            issuer: 'https://auth-js-test.okta.com',
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             redirectUri: 'https://example.com/redirect'
           },
@@ -611,10 +606,9 @@ define(function(require) {
     it('returns id_token using idp with authorization server', function (done) {
         return oauthUtil.setupPopup({
           oktaAuthArgs: {
-            url: 'https://auth-js-test.okta.com',
+            issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
-            redirectUri: 'https://example.com/redirect',
-            issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
+            redirectUri: 'https://example.com/redirect'
           },
           getWithPopupArgs: {
             idp: 'testIdp'
@@ -647,10 +641,9 @@ define(function(require) {
     it('allows passing issuer through getWithPopup, which takes precedence', function (done) {
         return oauthUtil.setupPopup({
           oktaAuthArgs: {
-            url: 'https://auth-js-test.okta.com',
+            issuer: 'https://auth-js-test.okta.com/oauth2/ORIGINAL_AUTH_SERVER_ID',
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
-            redirectUri: 'https://example.com/redirect',
-            issuer: 'https://auth-js-test.okta.com/oauth2/ORIGINAL_AUTH_SERVER_ID'
+            redirectUri: 'https://example.com/redirect'
           },
           getWithPopupArgs: [{
             idp: 'testIdp'
@@ -746,7 +739,7 @@ define(function(require) {
     it('returns access_token using sessionToken', function (done) {
       return oauthUtil.setupPopup({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
@@ -785,10 +778,9 @@ define(function(require) {
     it('returns access_token using idp with authorization server', function (done) {
       return oauthUtil.setupPopup({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
-          redirectUri: 'https://example.com/redirect',
-          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
+          redirectUri: 'https://example.com/redirect'
         },
         getWithPopupArgs: {
           responseType: 'token',
@@ -825,10 +817,9 @@ define(function(require) {
     it('returns access_token and id_token using idp with authorization server', function (done) {
       return oauthUtil.setupPopup({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
-          redirectUri: 'https://example.com/redirect',
-          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
+          redirectUri: 'https://example.com/redirect'
         },
         getWithPopupArgs: {
           responseType: ['token', 'id_token'],
@@ -866,7 +857,7 @@ define(function(require) {
     it('returns access_token and id_token (in that order) using idp', function (done) {
       return oauthUtil.setupPopup({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
@@ -896,7 +887,7 @@ define(function(require) {
           'expires_in': 3600,
           'state': oauthUtil.mockedState
         },
-        expectedResp: [tokens.standardAccessTokenParsed, tokens.standardIdTokenParsed] 
+        expectedResp: [tokens.standardAccessTokenParsed, tokens.standardIdTokenParsed]
       })
       .fin(function() {
         done();
@@ -906,7 +897,7 @@ define(function(require) {
     it('returns id_token and access_token (in that order) using idp', function (done) {
       return oauthUtil.setupPopup({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
@@ -980,10 +971,9 @@ define(function(require) {
     it('sets authorize url and cookie for id_token using sessionToken and authorization server', function() {
       oauthUtil.setupRedirect({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
-          redirectUri: 'https://example.com/redirect',
-          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
+          redirectUri: 'https://example.com/redirect'
         },
         getWithRedirectArgs: {
           sessionToken: 'testToken'
@@ -1018,10 +1008,9 @@ define(function(require) {
     it('allows passing issuer through getWithRedirect, which takes precedence', function() {
       oauthUtil.setupRedirect({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com/oauth2/ORIGINAL_AUTH_SERVER_ID',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
-          redirectUri: 'https://example.com/redirect',
-          issuer: 'https://auth-js-test.okta.com/oauth2/ORIGINAL_AUTH_SERVER_ID'
+          redirectUri: 'https://example.com/redirect'
         },
         getWithRedirectArgs: [{
           responseType: 'token',
@@ -1094,10 +1083,9 @@ define(function(require) {
     it('sets authorize url and cookie for access_token using sessionToken and authorization server', function() {
       oauthUtil.setupRedirect({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
-          redirectUri: 'https://example.com/redirect',
-          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
+          redirectUri: 'https://example.com/redirect'
         },
         getWithRedirectArgs: {
           responseType: 'token',
@@ -1167,10 +1155,9 @@ define(function(require) {
     it('sets authorize url for access_token and id_token using idp and authorization server', function() {
       oauthUtil.setupRedirect({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
-          redirectUri: 'https://example.com/redirect',
-          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
+          redirectUri: 'https://example.com/redirect'
         },
         getWithRedirectArgs: {
           responseType: ['token', 'id_token'],
@@ -1239,10 +1226,9 @@ define(function(require) {
     it('sets authorize url for authorization code requests with an authorization server', function() {
       oauthUtil.setupRedirect({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
-          redirectUri: 'https://example.com/redirect',
-          issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
+          redirectUri: 'https://example.com/redirect'
         },
         getWithRedirectArgs: {
           sessionToken: 'testToken',
@@ -1784,7 +1770,7 @@ define(function(require) {
     it('returns id_token', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+         issuer: 'https://auth-js-test.okta.com',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
@@ -1811,7 +1797,7 @@ define(function(require) {
     it('returns id_token with authorization server', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
@@ -1850,7 +1836,7 @@ define(function(require) {
     it('returns access_token', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
@@ -1891,10 +1877,9 @@ define(function(require) {
     it('returns access_token with authorization server', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com/oauth2/wontusethisone',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
-          redirectUri: 'https://example.com/redirect',
-          issuer: 'https://auth-js-test.okta.com/oauth2/wontusethisone'
+          redirectUri: 'https://example.com/redirect'
         },
         tokenRefreshArgs: [tokens.authServerAccessTokenParsed],
         postMessageSrc: {
@@ -1933,7 +1918,7 @@ define(function(require) {
     oauthUtil.itpErrorsCorrectly('throws an error if a non-token is passed',
       {
         oktaAuthArgs: {
-          url: 'https://auth-js-test.okta.com',
+          issuer: 'https://auth-js-test.okta.com',
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -7,7 +7,7 @@ define(function(require) {
   function setupSync(options) {
     options = options || {};
     return new OktaAuth({
-      url: 'https://auth-js-test.okta.com',
+      issuer: 'https://auth-js-test.okta.com',
       clientId: 'NPSfOkH5eZrTy8PMDlvx',
       redirectUri: 'https://example.com/redirect',
       tokenManager: {
@@ -80,7 +80,7 @@ define(function(require) {
       it('allows refreshing an idToken', function(done) {
         return oauthUtil.setupFrame({
           oktaAuthArgs: {
-            url: 'https://auth-js-test.okta.com',
+            issuer: 'https://auth-js-test.okta.com',
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             redirectUri: 'https://example.com/redirect',
             tokenManager: {
@@ -126,7 +126,7 @@ define(function(require) {
       it('allows refreshing an accessToken', function(done) {
         return oauthUtil.setupFrame({
           oktaAuthArgs: {
-            url: 'https://auth-js-test.okta.com',
+            issuer: 'https://auth-js-test.okta.com',
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             redirectUri: 'https://example.com/redirect',
             tokenManager: {
@@ -174,7 +174,7 @@ define(function(require) {
       oauthUtil.itpErrorsCorrectly('throws an errors when a token doesn\'t exist',
         {
           oktaAuthArgs: {
-            url: 'https://auth-js-test.okta.com',
+            issuer: 'https://auth-js-test.okta.com',
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             redirectUri: 'https://example.com/redirect'
           },
@@ -196,7 +196,7 @@ define(function(require) {
         return oauthUtil.setupFrame({
           willFail: true,
           oktaAuthArgs: {
-            url: 'https://auth-js-test.okta.com',
+            issuer: 'https://auth-js-test.okta.com',
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             redirectUri: 'https://example.com/redirect'
           },
@@ -222,7 +222,7 @@ define(function(require) {
       oauthUtil.itpErrorsCorrectly('throws an error if there\'s an issue refreshing',
         {
           oktaAuthArgs: {
-            url: 'https://auth-js-test.okta.com',
+            issuer: 'https://auth-js-test.okta.com',
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             redirectUri: 'https://example.com/redirect'
           },
@@ -263,7 +263,7 @@ define(function(require) {
         return oauthUtil.setupFrame({
           willFail: true,
           oktaAuthArgs: {
-            url: 'https://auth-js-test.okta.com',
+            issuer: 'https://auth-js-test.okta.com',
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             redirectUri: 'https://example.com/redirect'
           },
@@ -308,7 +308,7 @@ define(function(require) {
           fastForwardToTime: expiresAt + 1,
           autoRefresh: true,
           oktaAuthArgs: {
-            url: 'https://auth-js-test.okta.com',
+            issuer: 'https://auth-js-test.okta.com',
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             redirectUri: 'https://example.com/redirect'
           },
@@ -351,7 +351,7 @@ define(function(require) {
           fastForwardToTime: tokens.standardIdTokenParsed.expiresAt + 1,
           autoRefresh: true,
           oktaAuthArgs: {
-            url: 'https://auth-js-test.okta.com',
+            issuer: 'https://auth-js-test.okta.com',
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             redirectUri: 'https://example.com/redirect'
           },
@@ -496,7 +496,7 @@ define(function(require) {
           });
         });
       });
-      
+
       describe('clear', function() {
         it('clears all tokens', function() {
           var client = sessionStorageSetup();


### PR DESCRIPTION
### Description
Infer the required `url` parameter if `issuer` is given during client instantiation.

For OAuth flows, it is encouraged to request tokens from the `/token` endpoint via a custom authorization server, as opposed to Okta's authorization server for API AM use cases.

This change simplifies the setup for developers, and eliminates confusion on **which** URL goes where, as they only need to inject **one** URL.

#### Previously
```javascript
var config = {
  url: 'https://{yourOktaDomain}',
  clientId: 'your-client-id',
  redirectUri: 'https://your.redirect.uri/redirect',
  issuer: 'https://{yourOktaDomain}/oauth2/default'
};

var authClient = new OktaAuth(config);
```

#### Update
```javascript
var config = {
  issuer: 'https://{yourOktaDomain}/oauth2/default',
  clientId: 'your-client-id',
  redirectUri: 'https://your.redirect.uri/redirect'
};

var authClient = new OktaAuth(config);
```

**IMPORTANT**: When the `issuer` passed is a **authorization server ID**, we will continue to throw an `AuthSdkError`:

```javascript
var config = {
  issuer: 'default',
  clientId: 'your-client-id',
  redirectUri: 'https://your.redirect.uri/redirect'
};

var authClient = new OktaAuth(config);
// throws:
//   No url passed to constructor.
//   Required usage: new OktaAuth({url: "https://sample.okta.com"})
```



