### PR TITLE
:arrow_up: Rev up version to handle @okta/ci-update-package upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "lib/index.js",


### PR DESCRIPTION
Rev up version of okta-auth-js to 1.18.0 to handle an implicit upgrade to @okta/ci-update-package that handles release NPM packages differently.

Resolves: OKTA-178456

Primary reviewers:
@rchild-okta 
@jmelberg-okta 
@okta/travisci 