### PR TITLE
Renames refresh to renew

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,11 @@ var config = {
 var authClient = new OktaAuth(config);
 ```
 
-The `tokenManager` will **automatically refresh tokens** for you when they expire. To disable this feature, set `autoRefresh` to false.
+The `tokenManager` will **automatically renew tokens** for you when they expire. To disable this feature, set `autoRenew` to false.
 
 ```javascript
 tokenManager: {
-  autoRefresh: false
+  autoRenew: false
 }
 ```
 
@@ -248,7 +248,7 @@ var config = {
   * [token.getWithRedirect](#tokengetwithredirectoptions)
   * [token.parseFromUrl](#tokenparsefromurloptions)
   * [token.decode](#tokendecodeidtokenstring)
-  * [token.refresh](#tokenrefreshtokentorefresh)
+  * [token.renew](#tokenrenewtokentorenew)
   * [token.getUserInfo](#tokengetuserinfoaccesstokenobject)
   * [token.verify](#tokenverifyidtokenobject)
 * [tokenManager](#tokenManager)
@@ -256,7 +256,7 @@ var config = {
   * [tokenManager.get](#tokenmanagergetkey)
   * [tokenManager.remove](#tokenmanagerremovekey)
   * [tokenManager.clear](#tokenmanagerclear)
-  * [tokenManager.refresh](#tokenmanagerrefreshkey)
+  * [tokenManager.renew](#tokenmanagerrenewkey)
   * [tokenManager.on](#tokenmanagerontokenevent-callback-context)
   * [tokenManager.off](#tokenmanageroffevent-callback)
 
@@ -1432,15 +1432,15 @@ Decode a raw ID Token
 authClient.token.decode('YOUR_ID_TOKEN_JWT');
 ```
 
-#### `token.refresh(tokenToRefresh)`
+#### `token.renew(tokenToRenew)`
 
 Returns a new token if the Okta [session](https://developer.okta.com/docs/api/resources/sessions#example) is still valid.
 
-* `tokenToRefresh` - an access token or ID token previously provided by Okta. note: this is not the raw JWT
+* `tokenToRenew` - an access token or ID token previously provided by Okta. note: this is not the raw JWT
 
 ```javascript
 // this token is provided by Okta via getWithoutPrompt, getWithPopup, and parseFromUrl
-var tokenToRefresh = {
+var tokenToRenew = {
   idToken: 'YOUR_ID_TOKEN_JWT',
   claims: { /* token claims */ },
   expiresAt: 1449699930,
@@ -1450,7 +1450,7 @@ var tokenToRefresh = {
   clientId: 'NPSfOkH5eZrTy8PMDlvx'
 };
 
-authClient.token.refresh(tokenToRefresh)
+authClient.token.renew(tokenToRenew)
 .then(function(freshToken) {
   // manage freshToken
 })
@@ -1492,9 +1492,9 @@ authClient.token.verify(idTokenObject)
 
 #### `tokenManager.add(key, token)`
 
-After receiving an `access_token` or `id_token`, add it to the `tokenManager` to manage token expiration and refresh operations. When a token is added to the `tokenManager`, it is automatically refreshed when it expires.
+After receiving an `access_token` or `id_token`, add it to the `tokenManager` to manage token expiration and renew operations. When a token is added to the `tokenManager`, it is automatically renewed when it expires.
 
-* `key` - Unique key to store the token in the `tokenManager`. This is used later when you want to get, delete, or refresh the token.
+* `key` - Unique key to store the token in the `tokenManager`. This is used later when you want to get, delete, or renew the token.
 * `token` - Token object that will be added
 
 ```javascript
@@ -1544,32 +1544,32 @@ Remove all tokens from the `tokenManager`.
 authClient.tokenManager.clear();
 ```
 
-#### `tokenManager.refresh(key)`
+#### `tokenManager.renew(key)`
 
-Manually refresh a token before it expires.
+Manually renew a token before it expires.
 
-* `key` - Key for the token you want to refresh
+* `key` - Key for the token you want to renew
 
 ```javascript
-// Because the refresh() method is async, you can wait for it to complete
+// Because the renew() method is async, you can wait for it to complete
 // by using the returned Promise:
-authClient.tokenManager.refresh('idToken')
+authClient.tokenManager.renew('idToken')
 .then(function (newToken) {
   console.log(newToken);
 });
 
-// Alternatively, you can subscribe to the 'refreshed' event:
-authClient.tokenManager.on('refreshed', function (key, newToken, oldToken) {
+// Alternatively, you can subscribe to the 'renewed' event:
+authClient.tokenManager.on('renewed', function (key, newToken, oldToken) {
   console.log(newToken);
 });
-authClient.tokenManager.refresh('idToken');
+authClient.tokenManager.renew('idToken');
 ```
 
 #### `tokenManager.on(event, callback[, context])`
 
 Subscribe to an event published by the `tokenManager`.
 
-* `event` - Event to subscribe to. Possible events are `expired`, `error`, and `refreshed`.
+* `event` - Event to subscribe to. Possible events are `expired`, `error`, and `renewed`.
 * `callback` - Function to call when the event is triggered
 * `context` - Optional context to bind the callback to
 
@@ -1580,8 +1580,8 @@ authClient.tokenManager.on('expired', function (key, expiredToken) {
   console.log(expiredToken);
 });
 
-authClient.tokenManager.on('refreshed', function (key, newToken, oldToken) {
-  console.log('Token with key', key, 'has been refreshed');
+authClient.tokenManager.on('renewed', function (key, newToken, oldToken) {
+  console.log('Token with key', key, 'has been renewed');
   console.log('Old token:', oldToken);
   console.log('New token:', newToken);
 });
@@ -1604,8 +1604,8 @@ Unsubscribe from `tokenManager` events. If no callback is provided, unsubscribes
 * `callback` - Optional callback that was used to subscribe to the event
 
 ```javascript
-authClient.tokenManager.off('refreshed');
-authClient.tokenManager.off('refreshed', myRefreshedCallback);
+authClient.tokenManager.off('renewed');
+authClient.tokenManager.off('renewed', myRenewedCallback);
 ```
 
 ## Building the SDK

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ var config = {
 var authClient = new OktaAuth(config);
 ```
 
-The `tokenManager` will **automatically renew tokens** for you when they expire. To disable this feature, set `autoRenew` to false.
+By default, the `tokenManager` will attempt to renew expired tokens. When an expired token is requested by the `tokenManager.get()` method, a renewal request is executed to update the token. If you wish to manually control token renewal, set `autoRenew` to false to disable this feature. You can listen to  [`expired`](#tokenmanageronevent-callback-context) events to know when the token has expired.
 
 ```javascript
 tokenManager: {
@@ -257,7 +257,7 @@ var config = {
   * [tokenManager.remove](#tokenmanagerremovekey)
   * [tokenManager.clear](#tokenmanagerclear)
   * [tokenManager.renew](#tokenmanagerrenewkey)
-  * [tokenManager.on](#tokenmanagerontokenevent-callback-context)
+  * [tokenManager.on](#tokenmanageronevent-callback-context)
   * [tokenManager.off](#tokenmanageroffevent-callback)
 
 ------

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -32,8 +32,8 @@ function clearExpireEventTimeout(tokenMgmtRef, key) {
   clearTimeout(tokenMgmtRef.expireTimeouts[key]);
   delete tokenMgmtRef.expireTimeouts[key];
 
-  // Remove the refresh promise (if it exists)
-  delete tokenMgmtRef.refreshPromise[key];
+  // Remove the renew promise (if it exists)
+  delete tokenMgmtRef.renewPromise[key];
 }
 
 function clearExpireEventTimeoutAll(tokenMgmtRef) {
@@ -107,7 +107,7 @@ function getAsync(sdk, tokenMgmtRef, storage, key) {
     }
 
     var tokenPromise = tokenMgmtRef.autoRenew
-      ? refresh(sdk, tokenMgmtRef, storage, key)
+      ? renew(sdk, tokenMgmtRef, storage, key)
       : remove(tokenMgmtRef, storage, key);
 
     resolve(tokenPromise);
@@ -124,7 +124,7 @@ function remove(tokenMgmtRef, storage, key) {
   storage.setStorage(tokenStorage);
 }
 
-function refresh(sdk, tokenMgmtRef, storage, key) {
+function renew(sdk, tokenMgmtRef, storage, key) {
   try {
     var token = get(storage, key);
     if (!token) {
@@ -137,9 +137,9 @@ function refresh(sdk, tokenMgmtRef, storage, key) {
   // Remove existing autoRenew timeout for this key
   clearExpireEventTimeout(tokenMgmtRef, key);
 
-  // Store the refresh promise state, to avoid refreshing again
-  if (!tokenMgmtRef.refreshPromise[key]) {
-    tokenMgmtRef.refreshPromise[key] = sdk.token.refresh(token)
+  // Store the renew promise state, to avoid renewing again
+  if (!tokenMgmtRef.renewPromise[key]) {
+    tokenMgmtRef.renewPromise[key] = sdk.token.refresh(token)
     .then(function(freshToken) {
       if (!get(storage, key)) {
         // It is possible to enter a state where the tokens have been cleared
@@ -148,9 +148,9 @@ function refresh(sdk, tokenMgmtRef, storage, key) {
         return;
       }
       add(sdk, tokenMgmtRef, storage, key, freshToken);
-      tokenMgmtRef.emitter.emit('refreshed', key, freshToken, token);
+      tokenMgmtRef.emitter.emit('renewed', key, freshToken, token);
       // Remove existing promise key
-      delete tokenMgmtRef.refreshPromise[key];
+      delete tokenMgmtRef.renewPromise[key];
       return freshToken;
     })
     .fail(function(err) {
@@ -162,7 +162,7 @@ function refresh(sdk, tokenMgmtRef, storage, key) {
       throw err;
     });
   }
-  return tokenMgmtRef.refreshPromise[key];
+  return tokenMgmtRef.renewPromise[key];
 }
 
 function clear(tokenMgmtRef, storage) {
@@ -206,14 +206,14 @@ function TokenManager(sdk, options) {
     emitter: new Emitter(),
     autoRenew: options.autoRenew,
     expireTimeouts: {},
-    refreshPromise: {}
+    renewPromise: {}
   };
 
   this.add = util.bind(add, this, sdk, tokenMgmtRef, storage);
   this.get = util.bind(getAsync, this, sdk, tokenMgmtRef, storage);
   this.remove = util.bind(remove, this, tokenMgmtRef, storage);
   this.clear = util.bind(clear, this, tokenMgmtRef, storage);
-  this.refresh = util.bind(refresh, this, sdk, tokenMgmtRef, storage);
+  this.renew = util.bind(renew, this, sdk, tokenMgmtRef, storage);
   this.on = util.bind(tokenMgmtRef.emitter.on, tokenMgmtRef.emitter);
   this.off = util.bind(tokenMgmtRef.emitter.off, tokenMgmtRef.emitter);
 

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -106,7 +106,7 @@ function getAsync(sdk, tokenMgmtRef, storage, key) {
       resolve(token);
     }
 
-    var tokenPromise = tokenMgmtRef.autoRefresh
+    var tokenPromise = tokenMgmtRef.autoRenew
       ? refresh(sdk, tokenMgmtRef, storage, key)
       : remove(tokenMgmtRef, storage, key);
 
@@ -134,7 +134,7 @@ function refresh(sdk, tokenMgmtRef, storage, key) {
     return Q.reject(e);
   }
 
-  // Remove existing autoRefresh timeout for this key
+  // Remove existing autoRenew timeout for this key
   clearExpireEventTimeout(tokenMgmtRef, key);
 
   // Store the refresh promise state, to avoid refreshing again
@@ -173,8 +173,8 @@ function clear(tokenMgmtRef, storage) {
 function TokenManager(sdk, options) {
   options = options || {};
   options.storage = options.storage || 'localStorage';
-  if (!options.autoRefresh && options.autoRefresh !== false) {
-    options.autoRefresh = true;
+  if (!options.autoRenew && options.autoRenew !== false) {
+    options.autoRenew = true;
   }
 
   if (options.storage === 'localStorage' && !storageUtil.browserHasLocalStorage()) {
@@ -204,7 +204,7 @@ function TokenManager(sdk, options) {
 
   var tokenMgmtRef = {
     emitter: new Emitter(),
-    autoRefresh: options.autoRefresh,
+    autoRenew: options.autoRenew,
     expireTimeouts: {},
     refreshPromise: {}
   };

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -139,7 +139,7 @@ function renew(sdk, tokenMgmtRef, storage, key) {
 
   // Store the renew promise state, to avoid renewing again
   if (!tokenMgmtRef.renewPromise[key]) {
-    tokenMgmtRef.renewPromise[key] = sdk.token.refresh(token)
+    tokenMgmtRef.renewPromise[key] = sdk.token.renew(token)
     .then(function(freshToken) {
       if (!get(storage, key)) {
         // It is possible to enter a state where the tokens have been cleared

--- a/lib/clientBuilder.js
+++ b/lib/clientBuilder.js
@@ -112,7 +112,7 @@ function OktaAuthBuilder(args) {
     getWithRedirect: util.bind(token.getWithRedirect, null, sdk),
     parseFromUrl: util.bind(token.parseFromUrl, null, sdk),
     decode: token.decodeToken,
-    refresh: util.bind(token.refreshToken, null, sdk),
+    renew: util.bind(token.renewToken, null, sdk),
     getUserInfo: util.bind(token.getUserInfo, null, sdk),
     verify: util.bind(token.verifyToken, null, sdk)
   };

--- a/lib/token.js
+++ b/lib/token.js
@@ -493,9 +493,9 @@ function getWithRedirect(sdk, oauthOptions, options) {
   sdk.token.getWithRedirect._setLocation(requestUrl);
 }
 
-function refreshToken(sdk, token) {
+function renewToken(sdk, token) {
   if (!oauthUtil.isToken(token)) {
-    return Q.reject(new AuthSdkError('Refresh must be passed a token with ' +
+    return Q.reject(new AuthSdkError('Renew must be passed a token with ' +
       'an array of scopes and an accessToken or idToken'));
   }
 
@@ -596,7 +596,7 @@ module.exports = {
   getWithRedirect: getWithRedirect,
   parseFromUrl: parseFromUrl,
   decodeToken: decodeToken,
-  refreshToken: refreshToken,
+  renewToken: renewToken,
   getUserInfo: getUserInfo,
   verifyToken: verifyToken
 };

--- a/test/spec/token.js
+++ b/test/spec/token.js
@@ -1874,7 +1874,7 @@ define(function(require) {
     );
   });
 
-  describe('token.refresh', function () {
+  describe('token.renew', function () {
     it('returns id_token', function (done) {
       return oauthUtil.setupFrame({
         oktaAuthArgs: {
@@ -1882,7 +1882,7 @@ define(function(require) {
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
-        tokenRefreshArgs: [tokens.standardIdTokenParsed],
+        tokenRenewArgs: [tokens.standardIdTokenParsed],
         postMessageSrc: {
           baseUri: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
           queryParams: {
@@ -1909,7 +1909,7 @@ define(function(require) {
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
-        tokenRefreshArgs: [tokens.authServerIdTokenParsed],
+        tokenRenewArgs: [tokens.authServerIdTokenParsed],
         postMessageSrc: {
           baseUri: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
           queryParams: {
@@ -1948,7 +1948,7 @@ define(function(require) {
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
-        tokenRefreshArgs: [tokens.standardAccessTokenParsed],
+        tokenRenewArgs: [tokens.standardAccessTokenParsed],
         postMessageSrc: {
           baseUri: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
           queryParams: {
@@ -1989,7 +1989,7 @@ define(function(require) {
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
-        tokenRefreshArgs: [tokens.authServerAccessTokenParsed],
+        tokenRenewArgs: [tokens.authServerAccessTokenParsed],
         postMessageSrc: {
           baseUri: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
           queryParams: {
@@ -2030,13 +2030,13 @@ define(function(require) {
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           redirectUri: 'https://example.com/redirect'
         },
-        tokenRefreshArgs: [{non:'token'}]
+        tokenRenewArgs: [{non:'token'}]
       },
       {
         name: 'AuthSdkError',
-        message: 'Refresh must be passed a token with an array of scopes and an accessToken or idToken',
+        message: 'Renew must be passed a token with an array of scopes and an accessToken or idToken',
         errorCode: 'INTERNAL',
-        errorSummary: 'Refresh must be passed a token with an array of scopes and an accessToken or idToken',
+        errorSummary: 'Renew must be passed a token with an array of scopes and an accessToken or idToken',
         errorLink: 'INTERNAL',
         errorId: 'INTERNAL',
         errorCauses: []

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -13,7 +13,7 @@ define(function(require) {
       maxClockSkew: options.maxClockSkew || 1, // set default to 1 second
       tokenManager: {
         storage: options.tokenManager.type,
-        autoRefresh: options.tokenManager.autoRefresh || false
+        autoRenew: options.tokenManager.autoRenew || false
       }
     });
   }
@@ -276,7 +276,7 @@ define(function(require) {
       });
     });
 
-    describe('autoRefresh', function() {
+    describe('autoRenew', function() {
       beforeEach(function() {
         jasmine.clock().install();
       });
@@ -290,10 +290,10 @@ define(function(require) {
         return oauthUtil.setupFrame({
           authClient: setupSync({
             tokenManager: {
-              autoRefresh: true
+              autoRenew: true
             }
           }),
-          autoRefresh: true,
+          autoRenew: true,
           fastForwardToTime: true,
           autoRefreshTokenKey: 'test-idToken',
           time: expiresAt + 1,
@@ -338,10 +338,10 @@ define(function(require) {
             // Account for 10 min of clock skew
             maxClockSkew: 600,
             tokenManager: {
-              autoRefresh: true
+              autoRenew: true
             }
           }),
-          autoRefresh: true,
+          autoRenew: true,
           fastForwardToTime: true,
           autoRefreshTokenKey: 'test-idToken',
           time: expiresAt - 10,
@@ -384,10 +384,10 @@ define(function(require) {
         return oauthUtil.setupFrame({
           authClient: setupSync({
             tokenManager: {
-              autoRefresh: true
+              autoRenew: true
             }
           }),
-          autoRefresh: true,
+          autoRenew: true,
           fastForwardToTime: true,
           autoRefreshTokenKey: 'test-idToken',
           time: expiresAt + 1,
@@ -431,10 +431,10 @@ define(function(require) {
         return oauthUtil.setupFrame({
           authClient: setupSync({
             tokenManager: {
-              autoRefresh: true
+              autoRenew: true
             }
           }),
-          autoRefresh: true,
+          autoRenew: true,
           willFail: true,
           fastForwardToTime: true,
           autoRefreshTokenKey: 'test-idToken',
@@ -460,12 +460,12 @@ define(function(require) {
         .fin(done);
       });
 
-      it('emits "expired" on existing tokens even when autoRefresh is disabled', function(done) {
+      it('emits "expired" on existing tokens even when autoRenew is disabled', function(done) {
         util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
         localStorage.setItem('okta-token-storage', JSON.stringify({
           'test-idToken': tokens.standardIdTokenParsed
         }));
-        var client = setupSync({ tokenManager: { autoRefresh: false } });
+        var client = setupSync({ tokenManager: { autoRenew: false } });
         client.tokenManager.on('expired', function(key, token) {
           expect(key).toEqual('test-idToken');
           expect(token).toEqual(tokens.standardIdTokenParsed);
@@ -478,9 +478,9 @@ define(function(require) {
         util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
       });
 
-      it('emits "expired" on new tokens even when autoRefresh is disabled', function(done) {
+      it('emits "expired" on new tokens even when autoRenew is disabled', function(done) {
         util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
-        var client = setupSync({ tokenManager: { autoRefresh: false } });
+        var client = setupSync({ tokenManager: { autoRenew: false } });
         client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
         client.tokenManager.on('expired', function(key, token) {
           expect(key).toEqual('test-idToken');
@@ -495,12 +495,12 @@ define(function(require) {
         });
       });
 
-      it('returns undefined for a token that has expired when autoRefresh is disabled', function(done) {
+      it('returns undefined for a token that has expired when autoRenew is disabled', function(done) {
         util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
         localStorage.setItem('okta-token-storage', JSON.stringify({
           'test-idToken': tokens.standardIdTokenParsed
         }));
-        var client = setupSync({ tokenManager: { autoRefresh: false } });
+        var client = setupSync({ tokenManager: { autoRenew: false } });
         util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
         client.tokenManager.get('test-idToken')
         .then(function(token) {
@@ -509,7 +509,7 @@ define(function(require) {
         });
       });
 
-      it('returns undefined for an active token when autoRefresh is disabled, accounting' +
+      it('returns undefined for an active token when autoRenew is disabled, accounting' +
          'for clock skew', function(done) {
         util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
         localStorage.setItem('okta-token-storage', JSON.stringify({
@@ -519,7 +519,7 @@ define(function(require) {
           // Account for 10 min of clock skew
           maxClockSkew: 600,
           tokenManager: {
-            autoRefresh: false
+            autoRenew: false
           }
         });
         util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt - 5);

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -89,8 +89,8 @@ define(function(require) {
       });
     });
 
-    describe('refresh', function() {
-      it('allows refreshing an idToken', function(done) {
+    describe('renew', function() {
+      it('allows renewing an idToken', function(done) {
         return oauthUtil.setupFrame({
           authClient: setupSync(),
           tokenManagerAddKeys: {
@@ -101,7 +101,7 @@ define(function(require) {
               scopes: ['openid', 'email']
             }
           },
-          tokenManagerRefreshArgs: ['test-idToken'],
+          tokenManagerRenewArgs: ['test-idToken'],
           postMessageSrc: {
             baseUri: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             queryParams: {
@@ -129,7 +129,7 @@ define(function(require) {
         .fin(done);
       });
 
-      it('allows refreshing an accessToken', function(done) {
+      it('allows renewing an accessToken', function(done) {
         return oauthUtil.setupFrame({
           authClient: setupSync(),
           tokenManagerAddKeys: {
@@ -140,7 +140,7 @@ define(function(require) {
               tokenType: 'Bearer'
             }
           },
-          tokenManagerRefreshArgs: ['test-accessToken'],
+          tokenManagerRenewArgs: ['test-accessToken'],
           postMessageSrc: {
             baseUri: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             queryParams: {
@@ -173,7 +173,7 @@ define(function(require) {
       oauthUtil.itpErrorsCorrectly('throws an errors when a token doesn\'t exist',
         {
           authClient: setupSync(),
-          tokenManagerRefreshArgs: ['test-accessToken']
+          tokenManagerRenewArgs: ['test-accessToken']
         },
         {
           name: 'AuthSdkError',
@@ -191,7 +191,7 @@ define(function(require) {
         return oauthUtil.setupFrame({
           authClient: setupSync(),
           willFail: true,
-          tokenManagerRefreshArgs: ['test-accessToken']
+          tokenManagerRenewArgs: ['test-accessToken']
         })
         .then(function() {
           expect(true).toEqual(false);
@@ -210,13 +210,13 @@ define(function(require) {
         .fin(done);
       });
 
-      oauthUtil.itpErrorsCorrectly('throws an error if there\'s an issue refreshing',
+      oauthUtil.itpErrorsCorrectly('throws an error if there\'s an issue renewing',
         {
           authClient: setupSync(),
           tokenManagerAddKeys: {
             'test-idToken': tokens.standardIdTokenParsed
           },
-          tokenManagerRefreshArgs: ['test-idToken'],
+          tokenManagerRenewArgs: ['test-idToken'],
           postMessageSrc: {
             baseUri: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
             queryParams: {
@@ -246,7 +246,7 @@ define(function(require) {
         }
       );
 
-      it('removes token if an OAuthError is thrown while refreshing', function(done) {
+      it('removes token if an OAuthError is thrown while renewing', function(done) {
         return oauthUtil.setupFrame({
           authClient: setupSync(),
           willFail: true,
@@ -254,7 +254,7 @@ define(function(require) {
             'test-accessToken': tokens.standardAccessTokenParsed,
             'test-idToken': tokens.standardIdTokenParsed
           },
-          tokenManagerRefreshArgs: ['test-accessToken'],
+          tokenManagerRenewArgs: ['test-accessToken'],
           postMessageResp: {
             error: 'sampleErrorCode',
             'error_description': 'something went wrong',
@@ -285,7 +285,7 @@ define(function(require) {
         jasmine.clock().uninstall();
       });
 
-      it('automatically refreshes a token by default', function(done) {
+      it('automatically renewes a token by default', function(done) {
         var expiresAt = tokens.standardIdTokenParsed.expiresAt;
         return oauthUtil.setupFrame({
           authClient: setupSync({
@@ -295,7 +295,7 @@ define(function(require) {
           }),
           autoRenew: true,
           fastForwardToTime: true,
-          autoRefreshTokenKey: 'test-idToken',
+          autoRenewTokenKey: 'test-idToken',
           time: expiresAt + 1,
           tokenManagerAddKeys: {
             'test-idToken': {
@@ -331,7 +331,7 @@ define(function(require) {
         .fin(done);
       });
 
-      it('automatically refreshes a token early when clock skew is considered', function(done) {
+      it('automatically renewes a token early when clock skew is considered', function(done) {
         var expiresAt = tokens.standardIdTokenParsed.expiresAt;
         return oauthUtil.setupFrame({
           authClient: setupSync({
@@ -343,7 +343,7 @@ define(function(require) {
           }),
           autoRenew: true,
           fastForwardToTime: true,
-          autoRefreshTokenKey: 'test-idToken',
+          autoRenewTokenKey: 'test-idToken',
           time: expiresAt - 10,
           tokenManagerAddKeys: {
             'test-idToken': {
@@ -379,7 +379,7 @@ define(function(require) {
         .fin(done);
       });
 
-      it('does not return the token after tokens were cleared before refresh promise was resolved', function(done) {
+      it('does not return the token after tokens were cleared before renew promise was resolved', function(done) {
         var expiresAt = tokens.standardIdTokenParsed.expiresAt;
         return oauthUtil.setupFrame({
           authClient: setupSync({
@@ -389,7 +389,7 @@ define(function(require) {
           }),
           autoRenew: true,
           fastForwardToTime: true,
-          autoRefreshTokenKey: 'test-idToken',
+          autoRenewTokenKey: 'test-idToken',
           time: expiresAt + 1,
           tokenManagerAddKeys: {
             'test-idToken': {
@@ -417,7 +417,7 @@ define(function(require) {
             state: oauthUtil.mockedState
           },
           beforeCompletion: function(authClient) {
-            // Simulate tokens being cleared while the refresh request is performed
+            // Simulate tokens being cleared while the renew request is performed
             authClient.tokenManager.clear();
           }
         })
@@ -437,7 +437,7 @@ define(function(require) {
           autoRenew: true,
           willFail: true,
           fastForwardToTime: true,
-          autoRefreshTokenKey: 'test-idToken',
+          autoRenewTokenKey: 'test-idToken',
           time: tokens.standardIdTokenParsed.expiresAt + 1,
           tokenManagerAddKeys: {
             'test-idToken': tokens.standardIdTokenParsed

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -285,7 +285,7 @@ define(function(require) {
         jasmine.clock().uninstall();
       });
 
-      it('automatically renewes a token by default', function(done) {
+      it('automatically renews a token by default', function(done) {
         var expiresAt = tokens.standardIdTokenParsed.expiresAt;
         return oauthUtil.setupFrame({
           authClient: setupSync({
@@ -331,7 +331,7 @@ define(function(require) {
         .fin(done);
       });
 
-      it('automatically renewes a token early when clock skew is considered', function(done) {
+      it('automatically renews a token early when clock skew is considered', function(done) {
         var expiresAt = tokens.standardIdTokenParsed.expiresAt;
         return oauthUtil.setupFrame({
           authClient: setupSync({

--- a/test/util/oauthUtil.js
+++ b/test/util/oauthUtil.js
@@ -121,8 +121,8 @@ define(function(require) {
         opts.getWithoutPromptArgs ||
         opts.getWithPopupArgs ||
         opts.tokenManagerRenewArgs ||
-        opts.refreshArgs ||
-        opts.tokenRefreshArgs ||
+        opts.renewArgs ||
+        opts.tokenRenewArgs ||
         opts.autoRenew) {
       // Simulate the postMessage between the window and the popup or iframe
       spyOn(window, 'addEventListener').and.callFake(function(eventName, fn) {
@@ -165,8 +165,8 @@ define(function(require) {
     }
 
     var promise;
-    if (opts.refreshArgs) {
-      promise = authClient.token.refresh(opts.refreshArgs);
+    if (opts.renewArgs) {
+      promise = authClient.token.renew(opts.renewArgs);
     } else if (opts.getWithoutPromptArgs) {
       if (Array.isArray(opts.getWithoutPromptArgs)) {
         promise = authClient.token.getWithoutPrompt.apply(null, opts.getWithoutPromptArgs);
@@ -181,23 +181,23 @@ define(function(require) {
       }
     } else if (opts.tokenManagerRenewArgs) {
       promise = authClient.tokenManager.renew.apply(this, opts.tokenManagerRenewArgs);
-    } else if (opts.tokenRefreshArgs) {
-      promise = authClient.token.refresh.apply(this, opts.tokenRefreshArgs);
+    } else if (opts.tokenRenewArgs) {
+      promise = authClient.token.renew.apply(this, opts.tokenRenewArgs);
     } else if (opts.autoRenew) {
-      var refreshDeferred = Q.defer();
+      var renewDeferred = Q.defer();
       authClient.tokenManager.on('renewed', function() {
-        refreshDeferred.resolve();
+        renewDeferred.resolve();
       });
       authClient.tokenManager.on('error', function() {
-        refreshDeferred.resolve();
+        renewDeferred.resolve();
       });
-      promise = refreshDeferred.promise;
+      promise = renewDeferred.promise;
     }
 
     if (opts.fastForwardToTime) {
       // Since the token is "expired", we're going to attempt to
       // retrieve it and kick-off the autoRenew and let the event listeners
-      // above pick up the 'refreshed' and 'error' events.
+      // above pick up the 'renewed' and 'error' events.
       promise = authClient.tokenManager.get(opts.autoRenewTokenKey);
       util.warpByTicksToUnixTime(opts.time);
     }

--- a/test/util/oauthUtil.js
+++ b/test/util/oauthUtil.js
@@ -120,7 +120,7 @@ define(function(require) {
         (opts.authorizeArgs && opts.authorizeArgs.responseMode !== 'fragment') ||
         opts.getWithoutPromptArgs ||
         opts.getWithPopupArgs ||
-        opts.tokenManagerRefreshArgs ||
+        opts.tokenManagerRenewArgs ||
         opts.refreshArgs ||
         opts.tokenRefreshArgs ||
         opts.autoRenew) {
@@ -179,13 +179,13 @@ define(function(require) {
       } else {
         promise = authClient.token.getWithPopup(opts.getWithPopupArgs);
       }
-    } else if (opts.tokenManagerRefreshArgs) {
-      promise = authClient.tokenManager.refresh.apply(this, opts.tokenManagerRefreshArgs);
+    } else if (opts.tokenManagerRenewArgs) {
+      promise = authClient.tokenManager.renew.apply(this, opts.tokenManagerRenewArgs);
     } else if (opts.tokenRefreshArgs) {
       promise = authClient.token.refresh.apply(this, opts.tokenRefreshArgs);
     } else if (opts.autoRenew) {
       var refreshDeferred = Q.defer();
-      authClient.tokenManager.on('refreshed', function() {
+      authClient.tokenManager.on('renewed', function() {
         refreshDeferred.resolve();
       });
       authClient.tokenManager.on('error', function() {
@@ -198,7 +198,7 @@ define(function(require) {
       // Since the token is "expired", we're going to attempt to
       // retrieve it and kick-off the autoRenew and let the event listeners
       // above pick up the 'refreshed' and 'error' events.
-      promise = authClient.tokenManager.get(opts.autoRefreshTokenKey);
+      promise = authClient.tokenManager.get(opts.autoRenewTokenKey);
       util.warpByTicksToUnixTime(opts.time);
     }
 

--- a/test/util/oauthUtil.js
+++ b/test/util/oauthUtil.js
@@ -123,7 +123,7 @@ define(function(require) {
         opts.tokenManagerRefreshArgs ||
         opts.refreshArgs ||
         opts.tokenRefreshArgs ||
-        opts.autoRefresh) {
+        opts.autoRenew) {
       // Simulate the postMessage between the window and the popup or iframe
       spyOn(window, 'addEventListener').and.callFake(function(eventName, fn) {
         if (eventName === 'message' && !opts.closePopup) {
@@ -183,7 +183,7 @@ define(function(require) {
       promise = authClient.tokenManager.refresh.apply(this, opts.tokenManagerRefreshArgs);
     } else if (opts.tokenRefreshArgs) {
       promise = authClient.token.refresh.apply(this, opts.tokenRefreshArgs);
-    } else if (opts.autoRefresh) {
+    } else if (opts.autoRenew) {
       var refreshDeferred = Q.defer();
       authClient.tokenManager.on('refreshed', function() {
         refreshDeferred.resolve();
@@ -196,7 +196,7 @@ define(function(require) {
 
     if (opts.fastForwardToTime) {
       // Since the token is "expired", we're going to attempt to
-      // retrieve it and kick-off the autoRefresh and let the event listeners
+      // retrieve it and kick-off the autoRenew and let the event listeners
       // above pick up the 'refreshed' and 'error' events.
       promise = authClient.tokenManager.get(opts.autoRefreshTokenKey);
       util.warpByTicksToUnixTime(opts.time);
@@ -207,7 +207,7 @@ define(function(require) {
         if(opts.beforeCompletion) {
           opts.beforeCompletion(authClient);
         }
-        if (opts.autoRefresh) {
+        if (opts.autoRenew) {
           return;
         }
         var expectedResp = opts.expectedResp || defaultResponse;


### PR DESCRIPTION
### Description

To make it more clear to developers, token methods have been renamed as follows to help imply that tokens are being **renewed** using the Okta session, not a `refreshToken`

* `token.refresh` ➡️  `token.renew`
* `tokenManager.refresh` ➡️ `tokenManager.renew`
* The `refreshed` event is now `renewed`
* `autoRefresh` ➡️ `autoRenew`

This PR is broken into the following commits:

* [`5fb8d37`](https://github.com/okta/okta-auth-js/commit/5fb8d376edf604c2cc278e1bec8ed3a90463d097) - Renames `autoRefresh` to `autoRenew`
* [`0692261`](https://github.com/okta/okta-auth-js/commit/069226164ca8eef4ed3297c8bcfb3ee0dd307974) - Renames all tokenManager refresh methods to renew
* [`cec65a9`](https://github.com/okta/okta-auth-js/commit/cec65a9d65b90c65ba8e9ba75d96db32e363459a) - Rename `token.refresh` to `token.renew`
* [`c5f95c2`](https://github.com/okta/okta-auth-js/commit/c5f95c2512659f825461c1eb10ec42adb827050e) - Update `README`

### Resolves

[OKTA-181449](https://oktainc.atlassian.net/browse/OKTA-181449)