### PR TITLE
Prevent token renewal when token is not expired

### DIFF
--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -103,14 +103,14 @@ function getAsync(sdk, tokenMgmtRef, storage, key) {
     var token = get(storage, key);
     var clockSkew = sdk.options.maxClockSkew * 1000;
     if (!token || (token.expiresAt * 1000 - clockSkew) > Date.now()) {
-      resolve(token);
+      return resolve(token);
     }
 
     var tokenPromise = tokenMgmtRef.autoRenew
       ? renew(sdk, tokenMgmtRef, storage, key)
       : remove(tokenMgmtRef, storage, key);
 
-    resolve(tokenPromise);
+    return resolve(tokenPromise);
   });
 }
 


### PR DESCRIPTION
### Steps to Reproduce
1) Add an unexpired access token to the token manager.
2) Call `auth.getAccessToken()` before the access token expires.

### Expected Result
- Token is retrieved from storage.
- No HTTP request is made to retrieve a new access token from the issuing server.

### Actual Result
- Token is retrieved from storage.
- HTTP request is made.

The problem is in the `getAsync()` function in the `TokenManager`. Although it correctly retrieves the token from storage when the token has not expired, the execution of the function does not end when the promise is resolved. Consequently, the code to renew the token is executed and a new access token is retrieved from the issuer.

I think this new behavior is preferable, since it doesn't result in excessive requests to the auth server.

My tests don't exactly conform to the style established in the rest of the file, but I think they clearly demonstrate the problem in action. Still, if the testing style is a problem, please let me know how I can improve this.