### PR TITLE
fix: Fixes an issue where default storage was read-only

### DIFF
--- a/lib/storageUtil.js
+++ b/lib/storageUtil.js
@@ -23,11 +23,7 @@ var storageUtil = {};
 storageUtil.browserHasLocalStorage = function() {
   try {
     var storage = storageUtil.getLocalStorage();
-    if (storageUtil.testStorage(storage)) {
-      return true;
-    } else {
-      return false;
-    }
+    return storageUtil.testStorage(storage);
   } catch (e) {
     return false;
   }
@@ -36,11 +32,7 @@ storageUtil.browserHasLocalStorage = function() {
 storageUtil.browserHasSessionStorage = function() {
   try {
     var storage = storageUtil.getSessionStorage();
-    if (storageUtil.testStorage(storage)) {
-      return true;
-    } else {
-      return false;
-    }
+    return storageUtil.testStorage(storage);
   } catch (e) {
     return false;
   }

--- a/lib/storageUtil.js
+++ b/lib/storageUtil.js
@@ -22,7 +22,8 @@ var storageUtil = {};
 // https://connect.microsoft.com/IE/Feedback/Details/1496040
 storageUtil.browserHasLocalStorage = function() {
   try {
-    if (storageUtil.getLocalStorage()) {
+    var storage = storageUtil.getLocalStorage();
+    if (storageUtil.testStorage(storage)) {
       return true;
     } else {
       return false;
@@ -34,7 +35,8 @@ storageUtil.browserHasLocalStorage = function() {
 
 storageUtil.browserHasSessionStorage = function() {
   try {
-    if (storageUtil.getSessionStorage()) {
+    var storage = storageUtil.getSessionStorage();
+    if (storageUtil.testStorage(storage)) {
       return true;
     } else {
       return false;
@@ -71,6 +73,17 @@ storageUtil.getCookieStorage = function() {
       cookies.setCookie(key, value, '2038-01-19T03:14:07.000Z');
     }
   };
+};
+
+storageUtil.testStorage = function(storage) {
+  var key = 'okta-test-storage';
+  try {
+    storage.setItem(key, key);
+    storage.removeItem(key);
+    return true;
+  } catch (e) {
+    return false;
+  }
 };
 
 module.exports = storageUtil;

--- a/test/util/oauthUtil.js
+++ b/test/util/oauthUtil.js
@@ -29,6 +29,12 @@ oauthUtil.mockLocalStorageError = function() {
   });
 };
 
+oauthUtil.mockStorageSetItemError = function() {
+  jest.spyOn(Storage.prototype, 'setItem').mockImplementationOnce(function() {
+    throw 'This function is not supported on this system.';
+  });
+};
+
 oauthUtil.mockSessionStorageError = function() {
   jest.spyOn(storageUtil, 'getSessionStorage').mockImplementation(function() {
     throw 'This function is not supported on this system.';


### PR DESCRIPTION
### Description

Fixes an issue where checking if `localStorage` and/or `sessionStorage` was returning `true`, even though it cannot be written to.

See: 
- https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API#Private_Browsing_Incognito_modes

### Example

Here is an example using iOS 10 Safari:
- [Video](http://g.recordit.co/yK7g1YWGDR.gif)