### PR TITLE
Updates changelog for @okta/okta-auth-js@2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,26 @@
 # Changelog
 
+## 2.1.1
+
+### Bug Fixes
+
+- [#178](https://github.com/okta/okta-auth-js/pull/178) - Resolves an issue introduced with [#171](https://github.com/okta/okta-auth-js/pull/171) causing the silent login flow to throw errors
+
+## 2.1.0
+
+### Bug Fixes
+
+- [#172](https://github.com/okta/okta-auth-js/pull/172) - Fixes an issue where default storage was read-only
+- [#161](https://github.com/okta/okta-auth-js/pull/161) - `ignoreSignature` was not set when redirecting
+
+### Other
+
+- [#171](https://github.com/okta/okta-auth-js/pull/171) - Scrub null/undefined values from authorize requests
+- [#162](https://github.com/okta/okta-auth-js/pull/162) - Update dependencies
+
 ## 2.0.1
 
-Bug Fixes
+### Bug Fixes
 
 * Fixed an problem, introduced in 2.0.0, that was causing tokens to be refreshed every time `authClient.tokenManager.get('accessToken')` was called.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.1.1
+## 2.2.0
 
 ### Bug Fixes
 


### PR DESCRIPTION
Updates changelog entries to reflect changes with `2.1.0` and `2.2.0`.