### PR TITLE
:bug: Bust the cache to avoid COORS issues when hitting the jwks uri

### DIFF
--- a/lib/oauthUtil.js
+++ b/lib/oauthUtil.js
@@ -78,7 +78,9 @@ function getWellKnown(sdk, issuer) {
 function getKey(sdk, issuer, kid) {
   return getWellKnown(sdk, issuer)
   .then(function(wellKnown) {
-    var jwksUri = wellKnown['jwks_uri'];
+    // NOTE: the query param here is to bust the cache because it can cause COORS issues if you login with multiple domains
+    // see: https://github.com/okta/okta-signin-widget/issues/541
+    var jwksUri = wellKnown['jwks_uri'] + "?now=" + Date.now();
 
     // Check our kid against the cached version (if it exists and isn't expired)
     var cacheContents = httpCache.getStorage();


### PR DESCRIPTION
A temporary workaround for this issue https://github.com/okta/okta-signin-widget/issues/541
It looks like we cache a specific allow-origin header for a single domain and if a user tries to login with another domain the user is served the old cached response.  This change adds a querystring param with Date.now() to this request to always make sure you don't hit the local cache.