### PR TITLE
Removed dependency on global window object.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -199,7 +199,13 @@ util.getLink = function(obj, linkName, altName) {
 };
 
 util.getNativeConsole = function() {
-  return window.console;
+  if (typeof window !== "undefined") {
+    return window.console;
+  } else if (typeof console !== "undefined") {
+    return console;
+  } else {
+    return undefined;
+  }
 };
 
 util.getConsole = function() {

--- a/lib/util.js
+++ b/lib/util.js
@@ -199,9 +199,9 @@ util.getLink = function(obj, linkName, altName) {
 };
 
 util.getNativeConsole = function() {
-  if (typeof window !== "undefined") {
+  if (typeof window !== 'undefined') {
     return window.console;
-  } else if (typeof console !== "undefined") {
+  } else if (typeof console !== 'undefined') {
     return console;
   } else {
     return undefined;


### PR DESCRIPTION
Hey,

as of the documentation I should be able to use okta-auth-js from nodejs (at least in part). In practice this leads to an exception very fast because 'window' is not defined in node.

Best

Christian