### PR TITLE
release: Publish okta-auth-js v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.1
+
+### Bug Fixes
+
+- [#187](https://github.com/okta/okta-auth-js/pull/187) - When deprecated `ajaxRequest` was passed to config, the logger for the deprecate message was still using window.console. This fix makes the logger isomorphic.
+
 ## 2.3.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -184,7 +184,35 @@ var authClient = new OktaAuth(config);
 
 ### Optional configuration options
 
+### `httpRequestClient`
+
+The http request implementation. By default, this is implemented using [reqwest](https://github.com/ded/reqwest) for browser and [cross-fetch](https://github.com/lquixada/cross-fetch) for server. To provide your own request library, implement the following interface:
+
+  1. Must accept:
+      * method (http method)
+      * url (target url)
+      * args (object containing headers and data)
+  2. Must return a Promise that resolves with a raw XMLHttpRequest response
+
+```javascript
+var config = {
+  url: 'https://{yourOktaDomain}',
+  httpRequestClient: function(method, url, args) {
+    // args is in the form:
+    // {
+    //   headers: {
+    //     headerName: headerValue
+    //   },
+    //   data: postBodyData
+    // }
+    return Promise.resolve(/* a raw XMLHttpRequest response */);
+  }
+}
+```
+
 #### `ajaxRequest`
+
+:warning: This parameter has been *deprecated*, please use [**httpRequestClient**](#httpRequestClient) instead.
 
 The ajax request implementation. By default, this is implemented using [reqwest](https://github.com/ded/reqwest). To provide your own request library, implement the following interface:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "2.4.0",
+  "version": "2.3.1",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "lib/server/serverIndex.js",


### PR DESCRIPTION
* When deprecated `ajaxRequest` was passed to config, the logger for the deprecate message was still using window.console. In this new version the logger is made isomorphic so that issue is fixed.
* Also updateds README to highlight deprecation of `ajaxRequest` parameter in favor of `httpRequestClient`.

## Reviewers

@robertjd @brettritter-okta 
