### PR TITLE
chore: Remove requestContext from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,13 +413,11 @@ Calls the [Webfinger](https://tools.ietf.org/html/rfc7033) API and gets a respon
 
 * `resource` - URI that identifies the entity whose information is sought, currently only acct scheme is supported (e.g acct:dade.murphy@example.com)
 * `rel` - Optional parameter to request only a subset of the information that would otherwise be returned without the "rel" parameter
-* `requestContext` - Optional parameter that provides Webfinger the context of that which the user is trying to access, such as the path of an app
 
 ```javascript
 authClient.webfinger({
   resource: 'acct:john.joe@example.com',
-  rel: 'okta:idp',
-  requestContext: '/home/dropbox/0oa16630PzpWKeWrH0g4/121'
+  rel: 'okta:idp'
 })
 .then(function(res) {
   // use the webfinger response to select an idp


### PR DESCRIPTION
### Description

As discussed with @robertjd , we gonna remove it for now only from the README, and we are gonna remove it from the code when we will bump okta-auth-js to 3.x (https://oktainc.atlassian.net/browse/OKTA-219719), since that would be a breaking change.

Jira: https://oktainc.atlassian.net/browse/OKTA-219718

### Reviewers

@haishengwu-okta @robertjd @royalchan-okta 

### Additional Reviewers

@antonshyltsev-okta 
