### PR TITLE
chore: Prevents scripts to go to the npm artifact

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ build2
 .travis.yml
 ci-scripts
 webpack*config.js
+scripts


### PR DESCRIPTION
### Description

Add `scripts` to the .npmignore list to prevent them to go in the npm artifact. Customers don't need our build scripts.

Jira: https://oktainc.atlassian.net/browse/OKTA-217531

### Reviewers

@gowthamidommety-okta @robertjd 
