### PR TITLE
Pkce2

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ tokenManager: {
 | `redirectUri`  | The url that is redirected to when using `token.getWithRedirect`. This must be pre-registered as part of client registration. If no `redirectUri` is provided, defaults to the current origin. |
 | `authorizeUrl` | Specify a custom authorizeUrl to perform the OIDC flow. Defaults to the issuer plus "/v1/authorize". |
 | `userinfoUrl`  | Specify a custom userinfoUrl. Defaults to the issuer plus "/v1/userinfo". |
+| `tokenUrl`  | Specify a custom tokenUrl. Defaults to the issuer plus "/v1/token". |
 | `ignoreSignature` | ID token signatures are validated by default when `token.getWithoutPrompt`, `token.getWithPopup`,  `token.getWithRedirect`, and `token.verify` are called. To disable ID token signature validation for these methods, set this value to `true`. |
 | | This option should be used only for browser support and testing purposes. |
 
@@ -1365,6 +1366,7 @@ The following configuration options can **only** be included in `token.getWithou
 
 | Options | Description |
 | :-------: | ----------|
+| `grantType`  | Specify grantType for this Application. Supported types are "implicit" and "authorization_code". Defaults to "implicit" |
 | `sessionToken` | Specify an Okta sessionToken to skip reauthentication when the user already authenticated using the Authentication Flow. |
 | `responseMode` | Specify how the authorization response should be returned. You will generally not need to set this unless you want to override the default values for `token.getWithRedirect`. See [Parameter Details](https://developer.okta.com/docs/api/resources/oidc#parameter-details) for a list of available modes. |
 | `responseType` | Specify the [response type](https://developer.okta.com/docs/api/resources/oidc#request-parameters) for OIDC authentication. Defaults to `id_token`. |
@@ -1440,12 +1442,20 @@ Create token using a redirect.
 * `oauthOptions` - See [Extended OpenID Connect options](#extended-openid-connect-options)
 
 ```javascript
-authClient.token.getWithRedirect(oauthOptions);
+authClient.token.getWithRedirect({
+  grantType: 'authorization_code',
+  responseType: ['id_token', 'token'])
+})
 ```
 
 #### `token.parseFromUrl(options)`
 
-Parses the access or ID Tokens from the url after a successful authentication redirect. If an ID token is present, it will be [verified and validated](https://github.com/okta/okta-auth-js/blob/master/lib/token.js#L186-L190) before available for use.
+Parses the authorization code, access, or ID Tokens from the URL after a successful authentication redirect. 
+
+If an authorization code is present, it will be exchanged for token(s) by posting to the `tokenUrl` endpoint. 
+
+The ID token will be [verified and validated](https://github.com/okta/okta-auth-js/blob/master/lib/token.js#L186-L190) before available for use.
+
 
 ```javascript
 authClient.token.parseFromUrl()

--- a/fetch/fetchRequest.js
+++ b/fetch/fetchRequest.js
@@ -16,7 +16,7 @@ function fetchRequest(method, url, args) {
   var body = args.data;
 
   // JSON encode body (if appropriate)
-  if (body && args.headers['Content-Type'] === 'application/json' && typeof body !== 'string') {
+  if (body && args.headers && args.headers['Content-Type'] === 'application/json' && typeof body !== 'string') {
     body = JSON.stringify(body);
   }
 
@@ -24,7 +24,7 @@ function fetchRequest(method, url, args) {
     method: method,
     headers: args.headers,
     body: body,
-    credentials: !args.withCredentials ? 'omit' : 'include'
+    credentials: args.withCredentials === false ? 'omit' : 'include'
   })
   .then(function(response) {
     var error = !response.ok;

--- a/lib/browser/browser.js
+++ b/lib/browser/browser.js
@@ -95,6 +95,8 @@ function OktaAuthBuilder(args) {
 
   sdk.pkce = {
     generateVerifier: pkce.generateVerifier,
+    saveVerifier: util.bind(pkce.saveVerifier, null, sdk),
+    loadVerifier: util.bind(pkce.loadVerifier, null, sdk),
     computeChallenge: pkce.computeChallenge,
     exchangeForToken: util.bind(pkce.exchangeForToken, null, sdk)
   };

--- a/lib/browser/browser.js
+++ b/lib/browser/browser.js
@@ -95,10 +95,11 @@ function OktaAuthBuilder(args) {
 
   sdk.pkce = {
     generateVerifier: pkce.generateVerifier,
-    saveVerifier: util.bind(pkce.saveVerifier, null, sdk),
-    loadVerifier: util.bind(pkce.loadVerifier, null, sdk),
+    clearMeta: util.bind(pkce.clearMeta, null, sdk),
+    saveMeta: util.bind(pkce.saveMeta, null, sdk),
+    loadMeta: util.bind(pkce.loadMeta, null, sdk),
     computeChallenge: pkce.computeChallenge,
-    exchangeForToken: util.bind(pkce.exchangeForToken, null, sdk)
+    getToken: util.bind(pkce.getToken, null, sdk)
   };
 
   sdk.token = {

--- a/lib/browser/browserStorage.js
+++ b/lib/browser/browserStorage.js
@@ -38,6 +38,16 @@ storageUtil.browserHasSessionStorage = function() {
   }
 };
 
+storageUtil.getPKCEStorage = function() {
+  if (storageUtil.browserHasLocalStorage()) {
+    return storageBuilder(storageUtil.getLocalStorage(), config.PKCE_STORAGE_NAME);
+  } else if (storageUtil.browserHasSessionStorage()) {
+    return storageBuilder(storageUtil.getSessionStorage(), config.PKCE_STORAGE_NAME);
+  } else {
+    return storageBuilder(storageUtil.getCookieStorage(), config.PKCE_STORAGE_NAME);
+  }
+};
+
 storageUtil.getHttpCache = function() {
   if (storageUtil.browserHasLocalStorage()) {
     return storageBuilder(storageUtil.getLocalStorage(), config.CACHE_STORAGE_NAME);

--- a/lib/pkce.js
+++ b/lib/pkce.js
@@ -14,32 +14,35 @@
  /* eslint-disable complexity, max-statements */
 var http          = require('./http');
 var util          = require('./util');
-var oauthUtil     = require('./oauthUtil');
 var AuthSdkError  = require('./errors/AuthSdkError');
-var token      = require('./token');
 
 // Code verifier: Random URL-safe string with a minimum length of 43 characters.
 // Code challenge: Base64 URL-encoded SHA-256 hash of the code verifier.
 var MIN_VERIFIER_LENGTH = 43;
+var MAX_VERIFIER_LENGTH = 128;
+
 function generateVerifier(prefix) {
   var verifier = prefix || '';
   if (verifier.length < MIN_VERIFIER_LENGTH) {
     verifier = verifier + util.genRandomString(MIN_VERIFIER_LENGTH - verifier.length);
   }
-  return encodeURIComponent(verifier);
+  return encodeURIComponent(verifier).slice(0, MAX_VERIFIER_LENGTH);
 }
 
-function saveVerifier(sdk, codeVerifier) {
+function saveMeta(sdk, meta) {
   var storage = sdk.options.storageUtil.getPKCEStorage();
-  storage.setStorage({
-    'code_verifier': codeVerifier
-  });
+  storage.setStorage(meta);
 }
 
-function loadVerifier(sdk) {
+function loadMeta(sdk) {
   var storage = sdk.options.storageUtil.getPKCEStorage();
   var obj = storage.getStorage();
-  return obj['code_verifier'];
+  return obj;
+}
+
+function clearMeta(sdk) {
+  var storage = sdk.options.storageUtil.getPKCEStorage();
+  storage.clearStorage();
 }
 
 /* global Uint8Array, TextEncoder */
@@ -52,22 +55,27 @@ function computeChallenge(str) {
   });
 }
 
-// for /v1/token endpoint
-function setDefaultOptions(sdk, options) {
-  options = util.clone(options) || {};
-  var defaults = {
-    clientId: sdk.options.clientId,
-    redirectUri: sdk.options.redirectUri || window.location.href,
-    grantType: 'authorization_code'
-  };
-  util.extend(defaults, options);
-  return defaults;
-}
 
 function validateOptions(oauthOptions) {
   // Quick validation
   if (!oauthOptions.clientId) {
     throw new AuthSdkError('A clientId must be specified in the OktaAuth constructor to get a token');
+  }
+
+  if (!oauthOptions.redirectUri) {
+    throw new AuthSdkError('The redirectUri passed to /authorize must also be passed to /token');
+  }
+
+  if (!oauthOptions.authorizationCode) {
+    throw new AuthSdkError('An authorization code (returned from /authorize) must be passed to /token');
+  }
+
+  if (!oauthOptions.codeVerifier) {
+    throw new AuthSdkError('The "codeVerifier" (generated and saved by your app) must be passed to /token');
+  }
+
+  if (oauthOptions.grantType !== 'authorization_code') {
+    throw new AuthSdkError('Expecting "grantType" to equal "authorization_code"');
   }
 }
 
@@ -77,7 +85,7 @@ function getPostData(options) {
     'client_id': options.clientId,
     'redirect_uri': options.redirectUri,
     'grant_type': options.grantType,
-    'code': options.code,
+    'code': options.authorizationCode,
     'code_verifier': options.codeVerifier
   });
   // Encode as URL string
@@ -85,18 +93,13 @@ function getPostData(options) {
 }
 
 // exchange authorization code for an access token
-function exchangeForToken(sdk, oauthOptions, options) {
-  oauthOptions = setDefaultOptions(sdk, oauthOptions || {});
-  options = options || {};
-
-  if (!oauthOptions.codeVerifier) {
-    oauthOptions.codeVerifier = loadVerifier(sdk);
-  }
+function getToken(sdk, oauthOptions, urls) {
+  // if (!oauthOptions.codeVerifier) {
+  //   oauthOptions.codeVerifier = loadMeta(sdk).codeVerifier;
+  // }
 
   validateOptions(oauthOptions);
-
   var data = getPostData(oauthOptions);
-  var urls = oauthUtil.getOAuthUrls(sdk, oauthOptions, options);
 
   return http.httpRequest(sdk, {
     url: urls.tokenUrl,
@@ -106,21 +109,14 @@ function exchangeForToken(sdk, oauthOptions, options) {
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded'
     }
-  })
-  .then(function(res) {
-    if (!oauthOptions.responseType) {
-      oauthOptions.responseType = ['id_token', 'token'];
-    }
-    // scopes were passed in original /authorize call and are returned to us in this response 
-    oauthOptions.scopes = res.scope.split(' ');
-    return token.handleOAuthResponse(sdk, oauthOptions, res, urls);
   });
 }
 
 module.exports = {
   generateVerifier: generateVerifier,
-  saveVerifier: saveVerifier,
-  loadVerifier: loadVerifier,
+  clearMeta: clearMeta,
+  saveMeta: saveMeta,
+  loadMeta: loadMeta,
   computeChallenge: computeChallenge,
-  exchangeForToken: exchangeForToken
+  getToken: getToken
 };

--- a/lib/pkce.js
+++ b/lib/pkce.js
@@ -29,6 +29,19 @@ function generateVerifier(prefix) {
   return encodeURIComponent(verifier);
 }
 
+function saveVerifier(sdk, codeVerifier) {
+  var storage = sdk.options.storageUtil.getPKCEStorage();
+  storage.setStorage({
+    'code_verifier': codeVerifier
+  });
+}
+
+function loadVerifier(sdk) {
+  var storage = sdk.options.storageUtil.getPKCEStorage();
+  var obj = storage.getStorage();
+  return obj['code_verifier'];
+}
+
 /* global Uint8Array, TextEncoder */
 function computeChallenge(str) {  
   var buffer = new TextEncoder().encode(str);
@@ -76,6 +89,10 @@ function exchangeForToken(sdk, oauthOptions, options) {
   oauthOptions = setDefaultOptions(sdk, oauthOptions || {});
   options = options || {};
 
+  if (!oauthOptions.codeVerifier) {
+    oauthOptions.codeVerifier = loadVerifier(sdk);
+  }
+
   validateOptions(oauthOptions);
 
   var data = getPostData(oauthOptions);
@@ -102,6 +119,8 @@ function exchangeForToken(sdk, oauthOptions, options) {
 
 module.exports = {
   generateVerifier: generateVerifier,
+  saveVerifier: saveVerifier,
+  loadVerifier: loadVerifier,
   computeChallenge: computeChallenge,
   exchangeForToken: exchangeForToken
 };

--- a/lib/pkce.js
+++ b/lib/pkce.js
@@ -94,10 +94,6 @@ function getPostData(options) {
 
 // exchange authorization code for an access token
 function getToken(sdk, oauthOptions, urls) {
-  // if (!oauthOptions.codeVerifier) {
-  //   oauthOptions.codeVerifier = loadMeta(sdk).codeVerifier;
-  // }
-
   validateOptions(oauthOptions);
   var data = getPostData(oauthOptions);
 

--- a/lib/token.js
+++ b/lib/token.js
@@ -509,7 +509,7 @@ function prepareOauthParams(sdk, oauthOptions) {
 function getWithRedirect(sdk, oauthOptions, options) {
   oauthOptions = util.clone(oauthOptions) || {};
 
-  prepareOauthParams(sdk, oauthOptions)
+  return prepareOauthParams(sdk, oauthOptions)
     .then(function(oauthParams) {
       var urls = oauthUtil.getOAuthUrls(sdk, oauthParams, options);
       var requestUrl = urls.authorizeUrl + buildAuthorizeParams(oauthParams);

--- a/lib/token.js
+++ b/lib/token.js
@@ -221,10 +221,11 @@ function getDefaultOAuthParams(sdk, oauthOptions) {
   oauthOptions = util.clone(oauthOptions) || {};
 
   var defaults = {
+    grantType: 'implicit',
     clientId: sdk.options.clientId,
     redirectUri: sdk.options.redirectUri || window.location.href,
     responseType: 'id_token',
-    responseMode: 'okta_post_message',
+    responseMode: 'fragment',
     state: util.genRandomString(64),
     nonce: util.genRandomString(64),
     scopes: ['openid', 'email'],
@@ -482,48 +483,56 @@ function getWithPopup(sdk, oauthOptions, options) {
   return getToken(sdk, oauthParams, options);
 }
 
-function getWithRedirect(sdk, oauthOptions, options) {
-  oauthOptions = util.clone(oauthOptions) || {};
+function prepareOauthParams(sdk, oauthOptions) {
   var oauthParams = getDefaultOAuthParams(sdk, oauthOptions);
-  // If the user didn't specify a responseMode
-  if (!oauthOptions.responseMode) {
-    // And it's only an auth code request (responseType could be an array)
-    var respType = oauthParams.responseType;
-    if (respType.indexOf('code') !== -1 &&
-        (util.isString(respType) || (Array.isArray(respType) && respType.length === 1))) {
-        // Default the responseMode to query
-        util.extend(oauthParams, {
-          responseMode: 'query'
-        });
-    // Otherwise, default to fragment
-    } else {
-      util.extend(oauthParams, {
-        responseMode: 'fragment'
-      });
-    }
+
+  if (oauthParams.grantType !== 'code') {
+    return Q.resolve(oauthParams);
   }
 
-  var urls = oauthUtil.getOAuthUrls(sdk, oauthParams, options);
-  var requestUrl = urls.authorizeUrl + buildAuthorizeParams(oauthParams);
+  var codeVerifier = sdk.pkce.generateVerifier(oauthParams.codeVerifier || '');
+  sdk.pkce.saveVerifier(codeVerifier);
 
-  // Set session cookie to store the oauthParams
-  cookies.set(config.REDIRECT_OAUTH_PARAMS_COOKIE_NAME, JSON.stringify({
-    responseType: oauthParams.responseType,
-    state: oauthParams.state,
-    nonce: oauthParams.nonce,
-    scopes: oauthParams.scopes,
-    clientId: oauthParams.clientId,
-    urls: urls,
-    ignoreSignature: oauthParams.ignoreSignature
-  }));
 
-  // Set nonce cookie for servers to validate nonce in id_token
-  cookies.set(config.REDIRECT_NONCE_COOKIE_NAME, oauthParams.nonce);
+  return sdk.pkce.computeChallenge(codeVerifier)
+    .then(function(codeChallenge) {
 
-  // Set state cookie for servers to validate state
-  cookies.set(config.REDIRECT_STATE_COOKIE_NAME, oauthParams.state);
 
-  sdk.token.getWithRedirect._setLocation(requestUrl);
+      util.extend(oauthParams, {
+        codeChallenge: codeChallenge,
+        responseType: 'code'
+      });
+      return oauthParams;
+    });
+}
+
+function getWithRedirect(sdk, oauthOptions, options) {
+  oauthOptions = util.clone(oauthOptions) || {};
+
+  prepareOauthParams(sdk, oauthOptions)
+    .then(function(oauthParams) {
+      var urls = oauthUtil.getOAuthUrls(sdk, oauthParams, options);
+      var requestUrl = urls.authorizeUrl + buildAuthorizeParams(oauthParams);
+
+      // Set session cookie to store the oauthParams
+      cookies.set(config.REDIRECT_OAUTH_PARAMS_COOKIE_NAME, JSON.stringify({
+        responseType: oauthParams.responseType,
+        state: oauthParams.state,
+        nonce: oauthParams.nonce,
+        scopes: oauthParams.scopes,
+        clientId: oauthParams.clientId,
+        urls: urls,
+        ignoreSignature: oauthParams.ignoreSignature
+      }));
+
+      // Set nonce cookie for servers to validate nonce in id_token
+      cookies.set(config.REDIRECT_NONCE_COOKIE_NAME, oauthParams.nonce);
+
+      // Set state cookie for servers to validate state
+      cookies.set(config.REDIRECT_STATE_COOKIE_NAME, oauthParams.state);
+
+      sdk.token.getWithRedirect._setLocation(requestUrl);
+    });
 }
 
 function renewToken(sdk, token) {

--- a/lib/token.js
+++ b/lib/token.js
@@ -146,6 +146,12 @@ function handleOAuthResponse(sdk, oauthParams, res, urls) {
 
     var tokenDict = {};
 
+
+    if (res['code']) {
+      tokenDict['code'] = res['code'];
+      return tokenDict;
+    }
+
     if (res['access_token']) {
       tokenDict['token'] = {
         accessToken: res['access_token'],
@@ -154,12 +160,6 @@ function handleOAuthResponse(sdk, oauthParams, res, urls) {
         scopes: scopes,
         authorizeUrl: urls.authorizeUrl,
         userinfoUrl: urls.userinfoUrl
-      };
-    }
-
-    if (res['code']) {
-      tokenDict['code'] = {
-        authorizationCode: res['code']
       };
     }
 
@@ -486,23 +486,31 @@ function getWithPopup(sdk, oauthOptions, options) {
 function prepareOauthParams(sdk, oauthOptions) {
   var oauthParams = getDefaultOAuthParams(sdk, oauthOptions);
 
-  if (oauthParams.grantType !== 'code') {
+  if (oauthParams.grantType !== 'authorization_code') {
     return Q.resolve(oauthParams);
   }
 
+  // PKCE authorization_code flow
   var codeVerifier = sdk.pkce.generateVerifier(oauthParams.codeVerifier || '');
-  sdk.pkce.saveVerifier(codeVerifier);
 
+  // We will need these values after redirect when we call /token
+  var meta = {
+    codeVerifier: codeVerifier,
+    responseType: oauthParams.responseType,
+    redirectUri: oauthParams.redirectUri
+  };
+  sdk.pkce.saveMeta(meta);
 
   return sdk.pkce.computeChallenge(codeVerifier)
     .then(function(codeChallenge) {
 
-
-      util.extend(oauthParams, {
+      // Clone/copy the params. Set codeChallenge and responseType for authorization_code
+      var clonedParams = util.clone(oauthParams) || {};
+      util.extend(clonedParams, oauthParams, {
         codeChallenge: codeChallenge,
         responseType: 'code'
       });
-      return oauthParams;
+      return clonedParams;
     });
 }
 
@@ -600,7 +608,33 @@ function parseFromUrl(sdk, url) {
         // Remove the hash from the url
         removeHash(sdk);
       }
-      return handleOAuthResponse(sdk, oauthParams, res, urls);
+      return handleOAuthResponse(sdk, oauthParams, res, urls)
+      .then(function(res) {
+        if (oauthParams.responseType !== 'code') {
+          return res;
+        }
+
+        // PKCE authorization_code flow
+        // Retreive saved values and build oauthParans for call to /token
+        var meta = sdk.pkce.loadMeta();
+        var clonedParams = util.clone(oauthParams) || {};
+        util.extend(clonedParams, {
+          grantType: 'authorization_code',
+          authorizationCode: res,
+          codeVerifier: meta.codeVerifier,
+          responseType: meta.responseType,
+          redirectUri: meta.redirectUri
+        });
+        delete clonedParams.state;
+        return sdk.pkce.getToken(clonedParams, urls)
+        .then(function(res) {
+          return handleOAuthResponse(sdk, clonedParams, res, urls);
+        })
+        .fin(function() {
+          sdk.pkce.clearMeta();
+        });
+
+      });
     });
 }
 

--- a/test/spec/errors.js
+++ b/test/spec/errors.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var _ = require('lodash'),
     util = require('../util/util'),
     OktaAuth = require('OktaAuth');

--- a/test/spec/factor-enroll.js
+++ b/test/spec/factor-enroll.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var util = require('../util/util'),
     _ = require('lodash');
 

--- a/test/spec/fetch-request.js
+++ b/test/spec/fetch-request.js
@@ -1,0 +1,87 @@
+describe('fetchRequest', function () {
+  var Q = require('q');
+  var mockFetchResult;
+  var mockFetchObj = {
+    fetch: function mockFetchFunc() {
+      return Q.resolve(mockFetchResult);
+    }
+  }
+  jest.setMock('cross-fetch', function() {
+    return mockFetchObj.fetch.apply(null, arguments);
+  });
+
+  var fetchRequest = require('../../fetch/fetchRequest');
+
+  beforeEach(function() {
+    /* global Map */
+    mockFetchResult = {
+      headers: new Map(),
+      json: function() {
+        return Q.resolve();
+      },
+      text: function() {
+        return Q.resolve();
+      }
+    }
+  });
+
+  it('JSON encodes request body if request Content-Type is application/json', function() {
+    var spy = jest.spyOn(mockFetchObj, 'fetch');
+    var method = 'GET';
+    var url = 'http://fakey.local';
+    var headers = {
+      'Content-Type': 'application/json'
+    };
+    var obj = {
+      foo: 'bar'
+    };
+    var jsonObj = JSON.stringify(obj);
+
+    fetchRequest(method, url, {
+      headers: headers,
+      data: obj
+    });
+
+    expect(spy).toHaveBeenCalledWith(url, {
+      method: method,
+      headers: headers,
+      body: jsonObj,
+      credentials: 'include'
+    });
+  });
+
+  it('Leaves request body unchanged if request Content-Type is NOT application/json', function() {
+    var spy = jest.spyOn(mockFetchObj, 'fetch');
+    var method = 'GET';
+    var url = 'http://fakey.local';
+    var obj = {
+      foo: 'bar'
+    };
+
+    fetchRequest(method, url, {
+      data: obj
+    });
+
+    expect(spy).toHaveBeenCalledWith(url, {
+      method: method,
+      body: obj,
+      credentials: 'include'
+    });
+  });
+
+  it('Can omit credentials', function() {
+    var spy = jest.spyOn(mockFetchObj, 'fetch');
+    var method = 'GET';
+    var url = 'http://fakey.local';
+
+    fetchRequest(method, url, {
+      withCredentials: false
+    });
+
+    expect(spy).toHaveBeenCalledWith(url, {
+      method: method,
+      credentials: 'omit'
+    });
+  });
+
+});

--- a/test/spec/fingerprint.js
+++ b/test/spec/fingerprint.js
@@ -1,8 +1,8 @@
+jest.mock('cross-fetch');
+
 var OktaAuth = require('OktaAuth');
 var util = require('../util/util');
 var packageJson = require('../../package.json');
-
-jest.mock('cross-fetch');
 
 describe('fingerprint', function() {
   function setup(options) {

--- a/test/spec/general.js
+++ b/test/spec/general.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var util = require('../util/util');
 var _ = require('lodash');
 var packageJson = require('../../package.json');

--- a/test/spec/locked-out.js
+++ b/test/spec/locked-out.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var util = require('../util/util');
 
 describe('LOCKED_OUT', function () {

--- a/test/spec/mfa-challenge.js
+++ b/test/spec/mfa-challenge.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var util = require('../util/util');
 
 describe('MFA_CHALLENGE', function () {

--- a/test/spec/mfa-enroll-activate.js
+++ b/test/spec/mfa-enroll-activate.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var util = require('../util/util');
 
 describe('MFA_ENROLL_ACTIVATE', function () {

--- a/test/spec/mfa-enroll.js
+++ b/test/spec/mfa-enroll.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var util = require('../util/util'),
     _ = require('lodash');
 

--- a/test/spec/mfa-required.js
+++ b/test/spec/mfa-required.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var util = require('../util/util'),
     _ = require('lodash');
 

--- a/test/spec/no-auth-status.js
+++ b/test/spec/no-auth-status.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var util = require('../util/util');
 
 describe('NO AUTH STATUS', function () {

--- a/test/spec/oauthUtil.js
+++ b/test/spec/oauthUtil.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var OktaAuth = require('OktaAuth');
 var oauthUtil = require('../../lib/oauthUtil');
 var libUtil = require('../../lib/util');
@@ -6,8 +8,6 @@ var util = require('../util/util');
 var wellKnown = require('../xhr/well-known');
 var keys = require('../xhr/keys');
 var tokens = require('../util/tokens');
-
-jest.mock('cross-fetch');
 
 describe('getWellKnown', function() {
   util.itMakesCorrectRequestResponse({

--- a/test/spec/password-expired.js
+++ b/test/spec/password-expired.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var util = require('../util/util');
 
 describe('PASSWORD_EXPIRED', function () {

--- a/test/spec/password-reset.js
+++ b/test/spec/password-reset.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var util = require('../util/util');
 
 describe('PASSWORD_RESET', function () {

--- a/test/spec/password-warn.js
+++ b/test/spec/password-warn.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var util = require('../util/util');
 
 describe('PASSWORD_WARN', function () {

--- a/test/spec/pkce.js
+++ b/test/spec/pkce.js
@@ -1,8 +1,7 @@
+jest.mock('cross-fetch');
 require('../util/webcrypto').polyFill();
 
-// Must be required before any code that uses 'cross-fetch'
 var util = require('../util/util');
-
 var OktaAuth = require('../../lib/browser/browserIndex');
 var packageJson = require('../../package.json');
 

--- a/test/spec/pkce.js
+++ b/test/spec/pkce.js
@@ -67,10 +67,14 @@ describe('pkce', function() {
     })
   });
 
-  describe('exchangeForToken', function() {
+  describe('getToken', function() {
     var ISSUER = 'http://example.okta.com';
     var REDIRECT_URI = 'http://fake.local';
     var CLIENT_ID = 'fake';
+    var endpoint = '/oauth2/v1/token';
+    var codeVerifier = 'superfake';
+    var authorizationCode = 'notreal';
+    var grantType = 'authorization_code';
 
     util.itMakesCorrectRequestResponse({
       title: 'requests a token',
@@ -81,11 +85,11 @@ describe('pkce', function() {
           {
             request: {
               method: 'post',
-              uri: '/oauth2/v1/token',
+              uri: endpoint,
               withCredentials: false,
               data: {
                 client_id: CLIENT_ID,
-                grant_type: 'authorization_code',
+                grant_type: grantType,
                 redirect_uri: REDIRECT_URI
               },
               headers: {
@@ -107,11 +111,14 @@ describe('pkce', function() {
         ]
       },
       execute: function (test) {
-        return test.oa.pkce.exchangeForToken({
+        return test.oa.pkce.getToken({
           clientId: CLIENT_ID,
-          redirectUri: REDIRECT_URI
+          redirectUri: REDIRECT_URI,
+          authorizationCode: authorizationCode,
+          codeVerifier: codeVerifier,
+          grantType: grantType,
         }, {
-          issuer: ISSUER
+          tokenUrl: ISSUER + endpoint
         });
       }
     })

--- a/test/spec/pkce.js
+++ b/test/spec/pkce.js
@@ -82,6 +82,7 @@ describe('pkce', function() {
             request: {
               method: 'post',
               uri: '/oauth2/v1/token',
+              withCredentials: false,
               data: {
                 client_id: CLIENT_ID,
                 grant_type: 'authorization_code',
@@ -89,7 +90,7 @@ describe('pkce', function() {
               },
               headers: {
                 'Accept': 'application/json',
-                'Content-Type': null,
+                'Content-Type': 'application/x-www-form-urlencoded',
                 'X-Okta-User-Agent-Extended': 'okta-auth-js-' + packageJson.version
               }
             },

--- a/test/spec/recovery.js
+++ b/test/spec/recovery.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var util = require('../util/util');
 
 describe('RECOVERY', function () {

--- a/test/spec/recovery_challenge.js
+++ b/test/spec/recovery_challenge.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var util = require('../util/util');
 
 describe('RECOVERY_CHALLENGE', function () {

--- a/test/spec/token.js
+++ b/test/spec/token.js
@@ -1275,7 +1275,7 @@ describe('token.getWithRedirect', function() {
     });
   });
 
-  xit('sets authorize url for authorization code requests, defaulting responseMode to query', function() {
+  it('sets authorize url for authorization code requests', function() {
     return oauthUtil.setupRedirect({
       getWithRedirectArgs: {
         sessionToken: 'testToken',
@@ -1312,7 +1312,7 @@ describe('token.getWithRedirect', function() {
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_type=code&' +
-                            'response_mode=query&' +
+                            'response_mode=fragment&' +
                             'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
                             'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
                             'sessionToken=testToken&' +
@@ -1320,7 +1320,7 @@ describe('token.getWithRedirect', function() {
     });
   });
 
-  xit('sets authorize url for authorization code requests with an authorization server', function() {
+  it('sets authorize url for authorization code requests with an authorization server', function() {
     return oauthUtil.setupRedirect({
       oktaAuthArgs: {
         issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
@@ -1362,7 +1362,7 @@ describe('token.getWithRedirect', function() {
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_type=code&' +
-                            'response_mode=query&' +
+                            'response_mode=fragment&' +
                             'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
                             'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
                             'sessionToken=testToken&' +
@@ -1370,7 +1370,7 @@ describe('token.getWithRedirect', function() {
     });
   });
 
-  xit('sets authorize url for authorization code (as an array) requests, ' +
+  it('sets authorize url for authorization code (as an array) requests, ' +
     'defaulting responseMode to query', function() {
     return oauthUtil.setupRedirect({
       getWithRedirectArgs: {
@@ -1408,7 +1408,7 @@ describe('token.getWithRedirect', function() {
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_type=code&' +
-                            'response_mode=query&' +
+                            'response_mode=fragment&' +
                             'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
                             'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
                             'sessionToken=testToken&' +

--- a/test/spec/token.js
+++ b/test/spec/token.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var OktaAuth = require('OktaAuth');
 var tokens = require('../util/tokens');
 var util = require('../util/util');
@@ -5,8 +7,6 @@ var oauthUtil = require('../util/oauthUtil');
 var packageJson = require('../../package.json');
 var _ = require('lodash');
 var Q = require('q');
-
-jest.mock('cross-fetch');
 
 function setupSync() {
   return new OktaAuth({ issuer: 'http://example.okta.com' });

--- a/test/spec/token.js
+++ b/test/spec/token.js
@@ -938,7 +938,7 @@ describe('token.getWithPopup', function() {
 
 describe('token.getWithRedirect', function() {
   it('sets authorize url and cookie for id_token using sessionToken', function() {
-    oauthUtil.setupRedirect({
+    return oauthUtil.setupRedirect({
       getWithRedirectArgs: {
         sessionToken: 'testToken'
       },
@@ -982,7 +982,7 @@ describe('token.getWithRedirect', function() {
   });
 
   it('sets authorize url and cookie for id_token using sessionToken and authorization server', function() {
-    oauthUtil.setupRedirect({
+    return oauthUtil.setupRedirect({
       oktaAuthArgs: {
         issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
         clientId: 'NPSfOkH5eZrTy8PMDlvx',
@@ -1031,7 +1031,7 @@ describe('token.getWithRedirect', function() {
   });
 
   it('allows passing issuer through getWithRedirect, which takes precedence', function() {
-    oauthUtil.setupRedirect({
+    return oauthUtil.setupRedirect({
       oktaAuthArgs: {
         issuer: 'https://auth-js-test.okta.com/oauth2/ORIGINAL_AUTH_SERVER_ID',
         clientId: 'NPSfOkH5eZrTy8PMDlvx',
@@ -1084,7 +1084,7 @@ describe('token.getWithRedirect', function() {
   });
 
   it('sets authorize url for access_token and don\'t throw an error if openid isn\'t included in scope', function() {
-    oauthUtil.setupRedirect({
+    return oauthUtil.setupRedirect({
       getWithRedirectArgs: {
         responseType: 'token',
         scopes: ['email'],
@@ -1130,7 +1130,7 @@ describe('token.getWithRedirect', function() {
   });
 
   it('sets authorize url and cookie for access_token using sessionToken and authorization server', function() {
-    oauthUtil.setupRedirect({
+    return oauthUtil.setupRedirect({
       oktaAuthArgs: {
         issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
         clientId: 'NPSfOkH5eZrTy8PMDlvx',
@@ -1181,7 +1181,7 @@ describe('token.getWithRedirect', function() {
   });
 
   it('sets authorize url for access_token and id_token using idp', function() {
-    oauthUtil.setupRedirect({
+    return oauthUtil.setupRedirect({
       getWithRedirectArgs: {
         responseType: ['token', 'id_token'],
         idp: 'testIdp'
@@ -1226,7 +1226,7 @@ describe('token.getWithRedirect', function() {
   });
 
   it('sets authorize url for access_token and id_token using idp and authorization server', function() {
-    oauthUtil.setupRedirect({
+    return oauthUtil.setupRedirect({
       oktaAuthArgs: {
         issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
         clientId: 'NPSfOkH5eZrTy8PMDlvx',
@@ -1275,8 +1275,8 @@ describe('token.getWithRedirect', function() {
     });
   });
 
-  it('sets authorize url for authorization code requests, defaulting responseMode to query', function() {
-    oauthUtil.setupRedirect({
+  xit('sets authorize url for authorization code requests, defaulting responseMode to query', function() {
+    return oauthUtil.setupRedirect({
       getWithRedirectArgs: {
         sessionToken: 'testToken',
         responseType: 'code'
@@ -1320,8 +1320,8 @@ describe('token.getWithRedirect', function() {
     });
   });
 
-  it('sets authorize url for authorization code requests with an authorization server', function() {
-    oauthUtil.setupRedirect({
+  xit('sets authorize url for authorization code requests with an authorization server', function() {
+    return oauthUtil.setupRedirect({
       oktaAuthArgs: {
         issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
         clientId: 'NPSfOkH5eZrTy8PMDlvx',
@@ -1370,9 +1370,9 @@ describe('token.getWithRedirect', function() {
     });
   });
 
-  it('sets authorize url for authorization code (as an array) requests, ' +
+  xit('sets authorize url for authorization code (as an array) requests, ' +
     'defaulting responseMode to query', function() {
-    oauthUtil.setupRedirect({
+    return oauthUtil.setupRedirect({
       getWithRedirectArgs: {
         sessionToken: 'testToken',
         responseType: ['code']
@@ -1418,7 +1418,7 @@ describe('token.getWithRedirect', function() {
 
   it('sets authorize url for authorization code and id_token requests,' +
     ' defaulting responseMode to fragment', function() {
-    oauthUtil.setupRedirect({
+    return oauthUtil.setupRedirect({
       getWithRedirectArgs: {
         sessionToken: 'testToken',
         responseType: ['code', 'id_token']
@@ -1463,7 +1463,7 @@ describe('token.getWithRedirect', function() {
   });
 
   it('sets authorize url for authorization code requests, allowing form_post responseMode', function() {
-    oauthUtil.setupRedirect({
+    return oauthUtil.setupRedirect({
       getWithRedirectArgs: {
         sessionToken: 'testToken',
         responseType: 'code',

--- a/test/spec/webfinger.js
+++ b/test/spec/webfinger.js
@@ -1,3 +1,5 @@
+jest.mock('cross-fetch');
+
 var util = require('../util/util');
 
 describe('webfinger', function () {

--- a/test/util/oauthUtil.js
+++ b/test/util/oauthUtil.js
@@ -352,15 +352,18 @@ oauthUtil.setupRedirect = function(opts) {
   var windowLocationMock = util.mockSetWindowLocation(client);
   var setCookieMock = util.mockSetCookie();
 
+  var promise;
   if (Array.isArray(opts.getWithRedirectArgs)) {
-    client.token.getWithRedirect.apply(null, opts.getWithRedirectArgs);
+    promise = client.token.getWithRedirect.apply(null, opts.getWithRedirectArgs);
   } else {
-    client.token.getWithRedirect(opts.getWithRedirectArgs);
+    promise = client.token.getWithRedirect(opts.getWithRedirectArgs);
   }
 
-  expect(windowLocationMock).toHaveBeenCalledWith(opts.expectedRedirectUrl);
-
-  expect(setCookieMock.mock.calls).toEqual(opts.expectedCookies);
+  return promise
+    .then(function() {
+      expect(windowLocationMock).toHaveBeenCalledWith(opts.expectedRedirectUrl);
+      expect(setCookieMock.mock.calls).toEqual(opts.expectedCookies);
+    });
 };
 
 oauthUtil.setupParseUrl = function(opts) {

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -116,11 +116,6 @@ function mockAjax(pairs) {
     if (pair.request) {
       expect(pair.request.uri).toEqual(url);
 
-      // TODO: this is testing fetchRequest. move this to a unit test
-      // if (pair.request.data || args.body) {
-      //   expect(pair.request.data).toEqual(JSON.parse(args.body));
-      // }
-  
       if (pair.request.headers) {
         expect(pair.request.headers).toEqual(args.headers);
       }

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -1,13 +1,12 @@
 /* globals expect, JSON */
 /* eslint-disable max-statements, complexity */
+
 var Q = require('q'),
     _ = require('lodash'),
     OktaAuth = require('OktaAuth'),
     cookies = require('../../lib/browser/browserStorage').storage,
     sdkUtil = require('../../lib/util'),
     fetch = require('cross-fetch');
-
-jest.mock('cross-fetch');
 
 var util = {};
 

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -109,14 +109,19 @@ function mockAjax(pairs) {
       throw new Error('We are making a request that we have not anticipated.');
     }
 
-    // Make sure every request is attaching cookies
-    expect(args.credentials).toEqual('include');
+    if (pair.request.withCredentials !== false) {
+      // Make sure every request is attaching cookies
+      expect(args.credentials).toEqual('include');
+    }
 
     if (pair.request) {
       expect(pair.request.uri).toEqual(url);
-      if (pair.request.data || args.body) {
-        expect(pair.request.data).toEqual(JSON.parse(args.body));
-      }
+
+      // TODO: this is testing fetchRequest. move this to a unit test
+      // if (pair.request.data || args.body) {
+      //   expect(pair.request.data).toEqual(JSON.parse(args.body));
+      // }
+  
       if (pair.request.headers) {
         expect(pair.request.headers).toEqual(args.headers);
       }


### PR DESCRIPTION
This PR changes the PKCE flow so that it matches the implicit flow (from the point of view of the customer). As with implicit flow, it begins with a call to `getWithRedirect()`, then on the callback page `parseFromURL()` will return the tokens.  

With the changes in this PR, all that is necessary is to pass `grantType: 'authorization_code` to`getWithRedirect`. 

Approving this PR will merge it into the PKCE branch (which is still pending review). There are still a few items to take care of before this feature is ready for final review. Here we are mostly looking for feedback on the external api.

https://github.com/okta/okta-auth-js/pull/210/commits/abd878fecfdc6b95ab002782eaac19f8219ce94f