### PR TITLE
feat: Allows custom storage in TokenManager

### DIFF
--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -188,18 +188,19 @@ function TokenManager(sdk, options) {
   }
 
   var storage;
-  switch(options.storage) {
-    case 'localStorage':
-      storage = storageBuilder(localStorage, config.TOKEN_STORAGE_NAME);
-      break;
-    case 'sessionStorage':
-      storage = storageBuilder(sessionStorage, config.TOKEN_STORAGE_NAME);
-      break;
-    case 'cookie':
-      storage = storageBuilder(storageUtil.getCookieStorage(options), config.TOKEN_STORAGE_NAME);
-      break;
-    default:
-      throw new AuthSdkError('Unrecognized storage option');
+  if (options.storage === 'localStorage') {
+    storage = storageBuilder(localStorage, config.TOKEN_STORAGE_NAME);
+  } else if (options.storage === 'sessionStorage') {
+    storage = storageBuilder(sessionStorage, config.TOKEN_STORAGE_NAME);
+  } else if (options.storage === 'cookie') {
+    storage = storageBuilder(storageUtil.getCookieStorage(options), config.TOKEN_STORAGE_NAME);
+  } else if (typeof options.storage === 'object' &&
+      options.storage !== null &&
+      options.storage.getItem &&
+      options.storage.setItem) {
+    storage = storageBuilder(options.storage, config.TOKEN_STORAGE_NAME);
+  } else {
+    throw new AuthSdkError('Unrecognized storage option');
   }
 
   var tokenMgmtRef = {

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -198,6 +198,19 @@ function TokenManager(sdk, options) {
       options.storage !== null &&
       options.storage.getItem &&
       options.storage.setItem) {
+    try {
+      options.storage.setItem('test', 'test');
+    } catch(e) {
+      throw new AuthSdkError('Custom storage not implemented correctly. Unable to write to storage.');
+    }
+    try {
+      var val = options.storage.getItem('test');
+    } catch(e) {
+      throw new AuthSdkError('Custom storage not implemented correctly. Unable to read from storage.');
+    }
+    if (val !== 'test') {
+      throw new AuthSdkError('Custom storage not implemented correctly. Read value does not equal written value.');
+    }
     storage = storageBuilder(options.storage, config.TOKEN_STORAGE_NAME);
   } else {
     throw new AuthSdkError('Unrecognized storage option');

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -840,16 +840,87 @@ describe('TokenManager', function() {
         tokenManager: {
           type: {
             customStorage: options.customStorage,
-            getItem: function (key) {
+            getItem: options.getItem || function (key) {
               return options.customStorage[key];
             },
-            setItem: function (key, val) {
+            setItem: options.setItem || function (key, val) {
               options.customStorage[key] = val;
             }
           }
         }
       });
     }
+
+    describe('throws errors if not set up correctly', function() {
+      it('has an invalid setItem function', function() {
+        var customStorage = {};
+        try {
+          customStorageSetup( {
+            customStorage: customStorage,
+            setItem: "not a function"
+          });
+
+          // Should never hit this since setItem should fail if not a function
+          expect(true).toEqual(false);
+        } catch (e) {
+          util.expectErrorToEqual(e, {
+            name: 'AuthSdkError',
+            message: 'Custom storage not implemented correctly. Unable to write to storage.',
+            errorCode: 'INTERNAL',
+            errorSummary: 'Custom storage not implemented correctly. Unable to write to storage.',
+            errorLink: 'INTERNAL',
+            errorId: 'INTERNAL',
+            errorCauses: []
+          });
+        }
+      });
+      it('has an invalid getItem function', function() {
+        var customStorage = {};
+        try {
+          customStorageSetup( {
+            customStorage: customStorage,
+            getItem: "not a function"
+          });
+
+          // Should never hit this since setItem should fail if not a function
+          expect(true).toEqual(false);
+        } catch (e) {
+          util.expectErrorToEqual(e, {
+            name: 'AuthSdkError',
+            message: 'Custom storage not implemented correctly. Unable to read from storage.',
+            errorCode: 'INTERNAL',
+            errorSummary: 'Custom storage not implemented correctly. Unable to read from storage.',
+            errorLink: 'INTERNAL',
+            errorId: 'INTERNAL',
+            errorCauses: []
+          });
+        }
+      });
+      it('getItem does not return value set by setItem', function() {
+        var customStorage = {};
+        try {
+          customStorageSetup( {
+            customStorage: customStorage,
+            getItem: function (key) {
+              return customStorage[key] + "random addition to string";
+            }
+          });
+
+          // Should never hit this since setItem should fail if not a function
+          expect(true).toEqual(false);
+        } catch (e) {
+          util.expectErrorToEqual(e, {
+            name: 'AuthSdkError',
+            message: 'Custom storage not implemented correctly. Read value does not equal written value.',
+            errorCode: 'INTERNAL',
+            errorSummary: 'Custom storage not implemented correctly. Read value does not equal written value.',
+            errorLink: 'INTERNAL',
+            errorId: 'INTERNAL',
+            errorCauses: []
+          });
+        }
+      });
+    });
 
     describe('add', function() {
       it('adds a token', function() {


### PR DESCRIPTION
Allows storage to be set to an object with getItem and setItem in order to utilize custom ways to manage tokens. Also, changed from a switch to if / else if statements to allow for deeper check on the storage key.

Resolves: #211