### PR TITLE
fix: Misuse of 'maxClockSkew'. Adds support for 'localClockOffset' option

### DIFF
--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -142,9 +142,9 @@ function renew(sdk, tokenMgmtRef, storage, key) {
       var freshToken = freshTokens;
       // With PKCE flow we will receive multiple tokens. Find the one we are looking for
       if (freshTokens instanceof Array) {
-        freshToken = freshTokens.filter(function(freshToken) {
+        freshToken = freshTokens.find(function(freshToken) {
           return (freshToken.idToken && token.idToken) || (freshToken.accessToken && token.accessToken);
-        }).pop();
+        });
       }
 
       var oldToken = get(storage, key);

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -47,10 +47,7 @@ function clearExpireEventTimeoutAll(tokenMgmtRef) {
 }
 
 function setExpireEventTimeout(sdk, tokenMgmtRef, key, token) {
-  var expiresAt = token.expiresAt * 1000;
-  var clockSkew = sdk.options.clockSkew;
-  var now = Date.now() + clockSkew;
-  var expireEventWait = Math.max(expiresAt - now, 0);
+  var expireEventWait = Math.max(token.expiresAt - sdk.clock.now(), 0) * 1000;
 
   // Clear any existing timeout
   clearExpireEventTimeout(tokenMgmtRef, key);
@@ -103,10 +100,7 @@ function get(storage, key) {
 function getAsync(sdk, tokenMgmtRef, storage, key) {
   return Q.Promise(function(resolve) {
     var token = get(storage, key);
-    var expiresAt = token ? token.expiresAt * 1000 : 0;
-    var clockSkew = sdk.options.clockSkew;
-    var now = Date.now() + clockSkew;
-    if (!token || expiresAt > now) {
+    if (!token || token.expiresAt > sdk.clock.now()) {
       return resolve(token);
     }
 
@@ -145,29 +139,27 @@ function renew(sdk, tokenMgmtRef, storage, key) {
   if (!tokenMgmtRef.renewPromise[key]) {
     tokenMgmtRef.renewPromise[key] = sdk.token.renew(token)
     .then(function(freshTokens) {
-      // We may receive more tokens than we requested
-      var map = {};
-      if (freshTokens instanceof Array === false) {
-        freshTokens = [freshTokens];
+      var freshToken = freshTokens;
+      // With PKCE flow we will receive multiple tokens. Find the one we are looking for
+      if (freshTokens instanceof Array) {
+        freshToken = freshTokens.filter(function(freshToken) {
+          return (freshToken.idToken && token.idToken) || (freshToken.accessToken && token.accessToken);
+        }).pop();
       }
-      freshTokens.forEach(function(freshToken) {
-        var inferredKey = freshToken.idToken ? 'idToken' : freshToken.accessToken ? 'accessToken' : key;
-        map[inferredKey] = freshToken;
 
-        var oldToken = get(storage, inferredKey);
-        if (!oldToken) {
-          // It is possible to enter a state where the tokens have been cleared
-          // after a renewal request was triggered. To ensure we do not store a
-          // renewed token, we verify the promise key doesn't exist and return.
-          return;
-        }
-        add(sdk, tokenMgmtRef, storage, inferredKey, freshToken);
-        tokenMgmtRef.emitter.emit('renewed', inferredKey, freshToken, oldToken);
-      });
-
+      var oldToken = get(storage, key);
+      if (!oldToken) {
+        // It is possible to enter a state where the tokens have been cleared
+        // after a renewal request was triggered. To ensure we do not store a
+        // renewed token, we verify the promise key doesn't exist and return.
+        return;
+      }
+      add(sdk, tokenMgmtRef, storage, key, freshToken);
+      tokenMgmtRef.emitter.emit('renewed', key, freshToken, oldToken);
+      
       // Remove existing promise key
       delete tokenMgmtRef.renewPromise[key];
-      return map[key]; // return the specific token requested
+      return freshToken;
     })
     .fail(function(err) {
       if (err.name === 'OAuthError') {

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -47,8 +47,10 @@ function clearExpireEventTimeoutAll(tokenMgmtRef) {
 }
 
 function setExpireEventTimeout(sdk, tokenMgmtRef, key, token) {
-  var clockSkew = sdk.options.maxClockSkew * 1000;
-  var expireEventWait = (token.expiresAt * 1000) - (Date.now() - clockSkew);
+  var expiresAt = token.expiresAt * 1000;
+  var clockSkew = sdk.options.clockSkew;
+  var now = Date.now() + clockSkew;
+  var expireEventWait = Math.max(expiresAt - now, 0);
 
   // Clear any existing timeout
   clearExpireEventTimeout(tokenMgmtRef, key);
@@ -101,8 +103,10 @@ function get(storage, key) {
 function getAsync(sdk, tokenMgmtRef, storage, key) {
   return Q.Promise(function(resolve) {
     var token = get(storage, key);
-    var clockSkew = sdk.options.maxClockSkew * 1000;
-    if (!token || (token.expiresAt * 1000 - clockSkew) > Date.now()) {
+    var expiresAt = token ? token.expiresAt * 1000 : 0;
+    var clockSkew = sdk.options.clockSkew;
+    var now = Date.now() + clockSkew;
+    if (!token || expiresAt > now) {
       return resolve(token);
     }
 

--- a/lib/browser/browser.js
+++ b/lib/browser/browser.js
@@ -65,6 +65,9 @@ function OktaAuthBuilder(args) {
     this.options.maxClockSkew = args.maxClockSkew;
   }
 
+  // Calculated local clock skew (in milliseconds). Can be positive or negative.
+  this.options.clockSkew = args.clockSkew || 0;
+
   // Give the developer the ability to disable token signature
   // validation.
   this.options.ignoreSignature = !!args.ignoreSignature;

--- a/lib/browser/browser.js
+++ b/lib/browser/browser.js
@@ -25,6 +25,7 @@ var session           = require('../session');
 var token             = require('../token');
 var TokenManager      = require('../TokenManager');
 var tx                = require('../tx');
+var clock             = require('../clock');
 var util              = require('../util');
 
 function OktaAuthBuilder(args) {
@@ -65,8 +66,11 @@ function OktaAuthBuilder(args) {
     this.options.maxClockSkew = args.maxClockSkew;
   }
 
-  // Calculated local clock skew (in milliseconds). Can be positive or negative.
-  this.options.clockSkew = args.clockSkew || 0;
+  // Calculated local clock offset from server time (in milliseconds). Can be positive or negative.
+  this.options.localClockOffset = args.localClockOffset || 0;
+  sdk.clock = {
+    now: util.bind(clock.getLocalAdjustedTime, null, sdk)
+  };
 
   // Give the developer the ability to disable token signature
   // validation.

--- a/lib/clock.js
+++ b/lib/clock.js
@@ -1,0 +1,9 @@
+function getLocalAdjustedTime(sdk) {
+  var localClockOffset = parseInt(sdk.options.localClockOffset || 0);
+  var now = (Date.now() + localClockOffset) / 1000;
+  return now;
+}
+
+module.exports = {
+  getLocalAdjustedTime: getLocalAdjustedTime
+};

--- a/lib/oauthUtil.js
+++ b/lib/oauthUtil.js
@@ -135,7 +135,7 @@ function validateClaims(sdk, claims, validationParams) {
     throw new AuthSdkError('OAuth flow response nonce doesn\'t match request nonce');
   }
 
-  var now = Math.floor(new Date().getTime()/1000);
+  var now = Math.floor(Date.now()/1000);
 
   if (claims.iss !== iss) {
     throw new AuthSdkError('The issuer [' + claims.iss + '] ' +

--- a/test/app/src/index.js
+++ b/test/app/src/index.js
@@ -21,10 +21,12 @@ const url = new URL(window.location.href);
 const grantType = url.searchParams.get('grantType');
 const scopes = (url.searchParams.get('scopes') || 'openid,email').split(',');
 const responseType = (url.searchParams.get('responseType') || 'id_token,token').split(',');
+const maxClockSkew = parseInt(url.searchParams.get('maxClockSkew') || 300);
 Object.assign(config, {
   grantType,
   scopes,
   responseType,
+  maxClockSkew,
 });
 
 // Create the app as a function of config

--- a/test/spec/clock.js
+++ b/test/spec/clock.js
@@ -1,0 +1,77 @@
+var clock = require('../../lib/clock');
+
+describe('clock', function() {
+
+  describe('getLocalAdjustedTime', function() {
+    it('returns the local time / 1000', function() {
+      var fakeDate = 4200;
+      jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
+      var sdk = {
+        options: {
+          localClockOffset: 0
+        }
+      };
+      expect(clock.getLocalAdjustedTime(sdk)).toBe(fakeDate / 1000);
+    });
+
+    it('can have a positive offset', function() {
+      var fakeDate = 4200;
+      jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
+      var offset = 2300;
+      var sdk = {
+        options: {
+          localClockOffset: offset
+        }
+      };
+      expect(clock.getLocalAdjustedTime(sdk)).toBe((fakeDate + offset) / 1000);
+    });
+
+    it('can have a negative offset', function() {
+      var fakeDate = 4200;
+      jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
+      var offset = -2300;
+      var sdk = {
+        options: {
+          localClockOffset: offset
+        }
+      };
+      expect(clock.getLocalAdjustedTime(sdk)).toBe((fakeDate + offset) / 1000);
+    });
+
+    it('returns a valid number even if offset is a string', function() {
+      var fakeDate = 4200;
+      jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
+      var sdk = {
+        options: {
+          localClockOffset: "0"
+        }
+      };
+      expect(clock.getLocalAdjustedTime(sdk)).toBe(fakeDate / 1000);
+    });
+
+
+    it('returns a valid number even if offset is not set', function() {
+      var fakeDate = 4200;
+      jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
+      var sdk = {
+        options: {
+
+        }
+      };
+      expect(clock.getLocalAdjustedTime(sdk)).toBe(fakeDate / 1000);
+    });
+
+
+    it('will be NaN if offset is NaN', function() {
+      var fakeDate = 4200;
+      jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
+      var sdk = {
+        options: {
+          localClockOffset: "definitelyNotanumber"
+        }
+      };
+      expect(clock.getLocalAdjustedTime(sdk)).toBe(Number.NaN);
+    });
+
+  });
+})

--- a/test/spec/features.js
+++ b/test/spec/features.js
@@ -1,6 +1,6 @@
 var OktaAuth = require('OktaAuth');
 
-fdescribe('features', function() {
+describe('features', function() {
 
   describe('functions exist', function() {
     var funcs = [

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -562,7 +562,7 @@ describe('TokenManager', function() {
       util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
     });
 
-    it('accounts for local clock offset when emittting "expired"', function() {
+    it('accounts for local clock offset when emitting "expired"', function() {
       util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
       var client = setupSync({
         // local client is 2 seconds fast

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -9,7 +9,7 @@ function setupSync(options) {
     issuer: 'https://auth-js-test.okta.com',
     clientId: 'NPSfOkH5eZrTy8PMDlvx',
     redirectUri: 'https://example.com/redirect',
-    maxClockSkew: options.maxClockSkew || 1, // set default to 1 second
+    clockSkew: options.clockSkew || 0, // by default there is no skew
     tokenManager: {
       storage: options.tokenManager.type,
       autoRenew: options.tokenManager.autoRenew || false,
@@ -126,18 +126,18 @@ describe('TokenManager', function() {
   });
 
   describe('renew', function() {
-    it('allows renewing an idToken', function(done) {
+    it('allows renewing an idToken', function() {
       return oauthUtil.setupFrame({
         authClient: setupSync(),
         tokenManagerAddKeys: {
-          'test-idToken': {
+          'idToken': {
             idToken: 'testInitialToken',
             claims: {'fake': 'claims'},
             expiresAt: 0,
             scopes: ['openid', 'email']
           }
         },
-        tokenManagerRenewArgs: ['test-idToken'],
+        tokenManagerRenewArgs: ['idToken'],
         postMessageSrc: {
           baseUri: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
           queryParams: {
@@ -159,24 +159,27 @@ describe('TokenManager', function() {
       })
       .then(function() {
         oauthUtil.expectTokenStorageToEqual(localStorage, {
-          'test-idToken': tokens.standardIdTokenParsed
+          'idToken': tokens.standardIdTokenParsed
         });
-      })
-      .fin(done);
+      });
     });
 
-    it('allows renewing an accessToken', function(done) {
+    it('allows renewing an accessToken', function() {
+      var expiresAt = tokens.standardAccessTokenParsed.expiresAt;
+      var mockTime = expiresAt - 3600;
+
       return oauthUtil.setupFrame({
         authClient: setupSync(),
         tokenManagerAddKeys: {
-          'test-accessToken': {
+          'accessToken': {
             accessToken: 'testInitialToken',
-            expiresAt: 1449703529,
+            expiresAt: mockTime + 100,
             scopes: ['openid', 'email'],
             tokenType: 'Bearer'
           }
         },
-        tokenManagerRenewArgs: ['test-accessToken'],
+        time: mockTime,
+        tokenManagerRenewArgs: ['accessToken'],
         postMessageSrc: {
           baseUri: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
           queryParams: {
@@ -200,10 +203,9 @@ describe('TokenManager', function() {
       })
       .then(function() {
         oauthUtil.expectTokenStorageToEqual(localStorage, {
-          'test-accessToken': tokens.standardAccessTokenParsed
+          'accessToken': tokens.standardAccessTokenParsed
         });
-      })
-      .fin(done);
+      });
     });
 
     oauthUtil.itpErrorsCorrectly('throws an errors when a token doesn\'t exist',
@@ -222,7 +224,7 @@ describe('TokenManager', function() {
       }
     );
 
-    it('throws an errors when the token is mangled', function(done) {
+    it('throws an errors when the token is mangled', function() {
       localStorage.setItem('okta-token-storage', '#unparseableJson#');
       return oauthUtil.setupFrame({
         authClient: setupSync(),
@@ -242,8 +244,7 @@ describe('TokenManager', function() {
           errorId: 'INTERNAL',
           errorCauses: []
         });
-      })
-      .fin(done);
+      });
     });
 
     oauthUtil.itpErrorsCorrectly('throws an error if there\'s an issue renewing',
@@ -282,7 +283,7 @@ describe('TokenManager', function() {
       }
     );
 
-    it('removes token if an OAuthError is thrown while renewing', function(done) {
+    it('removes token if an OAuthError is thrown while renewing', function() {
       return oauthUtil.setupFrame({
         authClient: setupSync(),
         willFail: true,
@@ -307,8 +308,7 @@ describe('TokenManager', function() {
         oauthUtil.expectTokenStorageToEqual(localStorage, {
           'test-idToken': tokens.standardIdTokenParsed
         });
-      })
-      .fin(done);
+      });
     });
   });
 
@@ -317,7 +317,7 @@ describe('TokenManager', function() {
       jest.useFakeTimers();
     });
 
-    it('automatically renews a token by default', function(done) {
+    it('automatically renews a token by default', function() {
       var expiresAt = tokens.standardIdTokenParsed.expiresAt;
       return oauthUtil.setupFrame({
         authClient: setupSync({
@@ -327,10 +327,10 @@ describe('TokenManager', function() {
         }),
         autoRenew: true,
         fastForwardToTime: true,
-        autoRenewTokenKey: 'test-idToken',
+        autoRenewTokenKey: 'idToken',
         time: expiresAt + 1,
         tokenManagerAddKeys: {
-          'test-idToken': {
+          'idToken': {
             idToken: 'testInitialToken',
             claims: {'fake': 'claims'},
             expiresAt: expiresAt,
@@ -357,28 +357,27 @@ describe('TokenManager', function() {
       })
       .then(function() {
         oauthUtil.expectTokenStorageToEqual(localStorage, {
-          'test-idToken': tokens.standardIdTokenParsed
+          'idToken': tokens.standardIdTokenParsed
         });
-      })
-      .fin(done);
+      });
     });
 
-    it('automatically renews a token early when clock skew is considered', function(done) {
+    it('automatically renews a token early when clock skew is considered', function() {
       var expiresAt = tokens.standardIdTokenParsed.expiresAt;
       return oauthUtil.setupFrame({
         authClient: setupSync({
-          // Account for 10 min of clock skew
-          maxClockSkew: 600,
+          // skew the clock by 10 seconds
+          clockSkew: 10000,
           tokenManager: {
             autoRenew: true
           }
         }),
         autoRenew: true,
         fastForwardToTime: true,
-        autoRenewTokenKey: 'test-idToken',
-        time: expiresAt - 10,
+        autoRenewTokenKey: 'idToken',
+        time: expiresAt - 10, // 10 seconds until expiration
         tokenManagerAddKeys: {
-          'test-idToken': {
+          'idToken': {
             idToken: 'testInitialToken',
             claims: {'fake': 'claims'},
             expiresAt: expiresAt,
@@ -405,13 +404,12 @@ describe('TokenManager', function() {
       })
       .then(function() {
         oauthUtil.expectTokenStorageToEqual(localStorage, {
-          'test-idToken': tokens.standardIdTokenParsed
+          'idToken': tokens.standardIdTokenParsed
         });
-      })
-      .fin(done);
+      });
     });
 
-    it('does not return the token after tokens were cleared before renew promise was resolved', function(done) {
+    it('does not return the token after tokens were cleared before renew promise was resolved', function() {
       var expiresAt = tokens.standardIdTokenParsed.expiresAt;
       return oauthUtil.setupFrame({
         authClient: setupSync({
@@ -455,11 +453,10 @@ describe('TokenManager', function() {
       })
       .then(function() {
         oauthUtil.expectTokenStorageToEqual(localStorage, {});
-      })
-      .fin(done);
+      });
     });
 
-    it('removes a token on OAuth failure', function(done) {
+    it('removes a token on OAuth failure', function() {
       return oauthUtil.setupFrame({
         authClient: setupSync({
           tokenManager: {
@@ -488,14 +485,12 @@ describe('TokenManager', function() {
           errorSummary: 'something went wrong'
         });
         oauthUtil.expectTokenStorageToEqual(localStorage, {});
-      })
-      .fin(done);
+      });
     });
 
     it('does not renew the token if the token has not expired', function() {
-      var CLOCK_SKEW = 600;
       var CURRENT_TIME = 0;
-      var EXPIRATION_TIME = CURRENT_TIME + CLOCK_SKEW + 10;
+      var EXPIRATION_TIME = CURRENT_TIME + 10;
       util.warpToUnixTime(CURRENT_TIME);
       var TokenManager = require('../../lib/TokenManager');
       var sdk = {
@@ -503,7 +498,7 @@ describe('TokenManager', function() {
           renew: jest.fn(),
         },
         options: {
-          maxClockSkew: CLOCK_SKEW
+          clockSkew: 0
         }
       };
       var tokenManager = new TokenManager(sdk);
@@ -547,38 +542,36 @@ describe('TokenManager', function() {
       util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
     });
 
-    it('returns undefined for a token that has expired when autoRenew is disabled', function(done) {
+    it('returns undefined for a token that has expired when autoRenew is disabled', function() {
       util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
       localStorage.setItem('okta-token-storage', JSON.stringify({
         'test-idToken': tokens.standardIdTokenParsed
       }));
       var client = setupSync({ tokenManager: { autoRenew: false } });
       util.warpToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
-      client.tokenManager.get('test-idToken')
+      return client.tokenManager.get('test-idToken')
       .then(function(token) {
         expect(token).toBeUndefined();
-        done();
       });
     });
 
     it('returns undefined for an active token when autoRenew is disabled, accounting' +
-        'for clock skew', function(done) {
+        'for clock skew', function() {
       util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
       localStorage.setItem('okta-token-storage', JSON.stringify({
         'test-idToken': tokens.standardIdTokenParsed
       }));
       var client = setupSync({
-        // Account for 10 min of clock skew
-        maxClockSkew: 600,
+        clockSkew: 5000, // local clock is 5 seconds behind server
         tokenManager: {
           autoRenew: false
         }
       });
+      // Set local time to server expiration minus 5 seconds
       util.warpToUnixTime(tokens.standardIdTokenParsed.expiresAt - 5);
-      client.tokenManager.get('test-idToken')
+      return client.tokenManager.get('test-idToken')
       .then(function(token) {
         expect(token).toBeUndefined();
-        done();
       });
     });
   });
@@ -604,30 +597,26 @@ describe('TokenManager', function() {
     });
 
     describe('get', function() {
-      it('returns a token', function(done) {
+      it('returns a token', function() {
         var client = localStorageSetup();
         localStorage.setItem('okta-token-storage', JSON.stringify({
           'test-idToken': tokens.standardIdTokenParsed
         }));
         util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
-        client.tokenManager.get('test-idToken')
+        return client.tokenManager.get('test-idToken')
         .then(function(token) {
           expect(token).toEqual(tokens.standardIdTokenParsed);
-          done();
         });
-        // Warp back to current time
-        util.warpToUnixTime(Date.now());
       });
 
-      it('returns undefined for an expired token', function(done) {
+      it('returns undefined for an expired token', function() {
         var client = localStorageSetup();
         localStorage.setItem('okta-token-storage', JSON.stringify({
           'test-idToken': tokens.standardIdTokenParsed
         }));
-        client.tokenManager.get('test-idToken')
+        return client.tokenManager.get('test-idToken')
         .then(function(token) {
           expect(token).toBeUndefined();
-          done();
         });
       });
     });
@@ -680,30 +669,26 @@ describe('TokenManager', function() {
     });
 
     describe('get', function() {
-      it('returns a token', function(done) {
+      it('returns a token', function() {
         var client = sessionStorageSetup();
         sessionStorage.setItem('okta-token-storage', JSON.stringify({
           'test-idToken': tokens.standardIdTokenParsed
         }));
         util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
-        client.tokenManager.get('test-idToken')
+        return client.tokenManager.get('test-idToken')
         .then(function(token) {
           expect(token).toEqual(tokens.standardIdTokenParsed);
-          done();
         });
-        // Warp back to current time
-        util.warpToUnixTime(Date.now());
       });
 
-      it('returns undefined for an expired token', function(done) {
+      it('returns undefined for an expired token', function() {
         var client = sessionStorageSetup();
         sessionStorage.setItem('okta-token-storage', JSON.stringify({
           'test-idToken': tokens.standardIdTokenParsed
         }));
-        client.tokenManager.get('test-idToken')
+        return client.tokenManager.get('test-idToken')
         .then(function(token) {
           expect(token).toBeUndefined();
-          done();
         });
       });
     });
@@ -775,26 +760,22 @@ describe('TokenManager', function() {
     });
 
     describe('get', function() {
-      it('returns a token', function(done) {
+      it('returns a token', function() {
         var client = cookieStorageSetup();
         client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
         util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
-        client.tokenManager.get('test-idToken')
+        return client.tokenManager.get('test-idToken')
         .then(function(token) {
           expect(token).toEqual(tokens.standardIdTokenParsed);
-          done();
         });
-        // Warp back to current time
-        util.warpToUnixTime(Date.now());
       });
 
-      it('returns undefined for an expired token', function(done) {
+      it('returns undefined for an expired token', function() {
         var client = cookieStorageSetup();
         client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
-        client.tokenManager.get('test-idToken')
+        return client.tokenManager.get('test-idToken')
         .then(function(token) {
           expect(token).toBeUndefined();
-          done();
         });
       });
     });

--- a/test/util/oauthUtil.js
+++ b/test/util/oauthUtil.js
@@ -264,7 +264,7 @@ oauthUtil.setupFrame = function(opts) {
 
   function iframeWasCreated() {
     expect(body.appendChild).toHaveBeenCalled();
-    var el = body.appendChild.calls.mostRecent()[0];
+    var el = body.appendChild.mock.calls[0][0];
     expect(el.tagName).toEqual('IFRAME');
     expect(el.style.display).toEqual('none');
   }

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -24,7 +24,7 @@ util.warpToDistantPast = function () {
 };
 
 util.warpToUnixTime = function (unixTime) {
-  jest.spyOn(Date, 'now').mockReturnValue(new Date(unixTime * 1000));
+  jest.spyOn(Date, 'now').mockReturnValue(unixTime * 1000);
 };
 
 util.warpByTicksToUnixTime = function (unixTime) {


### PR DESCRIPTION
- fixes logic involving 'maxClockSkew' to instead use a 'localClockOffset'. This value may be positive or negative and should be calculated (somehow)
- adds a new method `sdk.clock.now()` which will return the adjusted local time, *in seconds*. This value can be directly compared to `token.expiresAt`
- fixes many tests which were silently catching errors
- corrects regression involving custom key names on token manager

This PR does not contain any logic for calculating or setting the 'localClockOffset'. Until there is a method for this, the value will be 0 in production. This will still fix an  issue caused by misuse of 'maxClockSkew'