### PR TITLE
Add 'expireEarly' option. Document 'maxClockSkew' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,11 @@ tokenManager: {
 }
 ```
 
-By default, the `expired` event will fire 30 seconds before actual expiration time. You can customize this by setting the `expireEarly` option. If `autoRenew` is set to true, tokens will also be automatically renewed early by this amount.
+Renewing tokens slightly early helps ensure a stable user experience. By default, the `expired` event will fire 30 seconds before actual expiration time. If `autoRenew` is set to true, tokens will be renewed within 30 seconds of expiration. You can customize this value by setting the `expireEarly` option. The value should be large enough to account for network latency between the client and Okta's servers.
 
 ```javascript
-// Renew tokens 2 minutes before expiration
+// Emit expired event 2 minutes before expiration
+// Tokens auto-renew within 2 minutes of expiration
 tokenManager: {
   expireEarly: 120
 }

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ tokenManager: {
 | `tokenUrl`  | Specify a custom tokenUrl. Defaults to the issuer plus "/v1/token". |
 | `ignoreSignature` | ID token signatures are validated by default when `token.getWithoutPrompt`, `token.getWithPopup`,  `token.getWithRedirect`, and `token.verify` are called. To disable ID token signature validation for these methods, set this value to `true`. |
 | | This option should be used only for browser support and testing purposes. |
+| `maxClockSkew` | Defaults to 300 (five minutes). This is the maximum difference allowed between a client's clock and Okta's, in seconds, when validating tokens. Setting this to 0 is not recommended, because it increases the likelihood that valid tokens will fail validation.
 
 ##### Example Client
 

--- a/README.md
+++ b/README.md
@@ -146,12 +146,20 @@ tokenManager: {
 }
 ```
 
-
 By default, the `tokenManager` will attempt to renew expired tokens. When an expired token is requested by the `tokenManager.get()` method, a renewal request is executed to update the token. If you wish to manually control token renewal, set `autoRenew` to false to disable this feature. You can listen to  [`expired`](#tokenmanageronevent-callback-context) events to know when the token has expired.
 
 ```javascript
 tokenManager: {
   autoRenew: false
+}
+```
+
+By default, the `expired` event will fire 30 seconds before actual expiration time. You can customize this by setting the `expireEarly` option. If `autoRenew` is set to true, tokens will also be automatically renewed early by this amount.
+
+```javascript
+// Renew tokens 2 minutes before expiration
+tokenManager: {
+  expireEarly: 120
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -154,13 +154,13 @@ tokenManager: {
 }
 ```
 
-Renewing tokens slightly early helps ensure a stable user experience. By default, the `expired` event will fire 30 seconds before actual expiration time. If `autoRenew` is set to true, tokens will be renewed within 30 seconds of expiration. You can customize this value by setting the `expireEarly` option. The value should be large enough to account for network latency between the client and Okta's servers.
+Renewing tokens slightly early helps ensure a stable user experience. By default, the `expired` event will fire 30 seconds before actual expiration time. If `autoRenew` is set to true, tokens will be renewed within 30 seconds of expiration, if accessed with `tokenManager.get()`. You can customize this value by setting the `expireEarlySeconds` option. The value should be large enough to account for network latency between the client and Okta's servers.
 
 ```javascript
 // Emit expired event 2 minutes before expiration
-// Tokens auto-renew within 2 minutes of expiration
+// Tokens accessed with tokenManager.get() will auto-renew within 2 minutes of expiration
 tokenManager: {
-  expireEarly: 120
+  expireEarlySeconds: 120
 }
 ```
 

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -21,6 +21,22 @@ var config = require('./config');
 var storageBuilder = require('./storageBuilder');
 var SdkClock = require('./clock');
 
+var DEFAULT_OPTIONS = {
+  autoRenew: true,
+  storage: 'localStorage',
+  expireEarly: 30 // in seconds
+};
+
+function getExpireTime(tokenMgmtRef, token) {
+  var expireTime = token.expiresAt - tokenMgmtRef.options.expireEarly;
+  return expireTime;
+}
+
+function hasExpired(tokenMgmtRef, token) {
+  var expireTime = getExpireTime(tokenMgmtRef, token);
+  return expireTime <= tokenMgmtRef.clock.now();
+}
+
 function emitExpired(tokenMgmtRef, key, token) {
   tokenMgmtRef.emitter.emit('expired', key, token);
 }
@@ -48,7 +64,8 @@ function clearExpireEventTimeoutAll(tokenMgmtRef) {
 }
 
 function setExpireEventTimeout(sdk, tokenMgmtRef, key, token) {
-  var expireEventWait = Math.max(token.expiresAt - tokenMgmtRef.clock.now(), 0) * 1000;
+  var expireTime = getExpireTime(tokenMgmtRef, token);
+  var expireEventWait = Math.max(expireTime - tokenMgmtRef.clock.now(), 0) * 1000;
 
   // Clear any existing timeout
   clearExpireEventTimeout(tokenMgmtRef, key);
@@ -101,11 +118,11 @@ function get(storage, key) {
 function getAsync(sdk, tokenMgmtRef, storage, key) {
   return Q.Promise(function(resolve) {
     var token = get(storage, key);
-    if (!token || token.expiresAt > tokenMgmtRef.clock.now()) {
+    if (!token || !hasExpired(tokenMgmtRef, token)) {
       return resolve(token);
     }
 
-    var tokenPromise = tokenMgmtRef.autoRenew
+    var tokenPromise = tokenMgmtRef.options.autoRenew
       ? renew(sdk, tokenMgmtRef, storage, key)
       : remove(tokenMgmtRef, storage, key);
 
@@ -180,11 +197,7 @@ function clear(tokenMgmtRef, storage) {
 }
 
 function TokenManager(sdk, options) {
-  options = options || {};
-  options.storage = options.storage || 'localStorage';
-  if (!options.autoRenew && options.autoRenew !== false) {
-    options.autoRenew = true;
-  }
+  options = Object.assign({}, DEFAULT_OPTIONS, util.removeNils(options));
 
   if (options.storage === 'localStorage' && !storageUtil.browserHasLocalStorage()) {
     util.warn('This browser doesn\'t support localStorage. Switching to sessionStorage.');
@@ -211,10 +224,11 @@ function TokenManager(sdk, options) {
       throw new AuthSdkError('Unrecognized storage option');
   }
 
+  var clock = SdkClock.create(sdk, options);
   var tokenMgmtRef = {
-    clock: SdkClock.create(sdk, options),
+    clock: clock,
+    options: options,
     emitter: new Emitter(),
-    autoRenew: options.autoRenew,
     expireTimeouts: {},
     renewPromise: {}
   };

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -24,11 +24,11 @@ var SdkClock = require('./clock');
 var DEFAULT_OPTIONS = {
   autoRenew: true,
   storage: 'localStorage',
-  expireEarly: 30 // in seconds
+  expireEarlySeconds: 30
 };
 
 function getExpireTime(tokenMgmtRef, token) {
-  var expireTime = token.expiresAt - tokenMgmtRef.options.expireEarly;
+  var expireTime = token.expiresAt - tokenMgmtRef.options.expireEarlySeconds;
   return expireTime;
 }
 

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -19,6 +19,7 @@ var Q = require('q');
 var Emitter = require('tiny-emitter');
 var config = require('./config');
 var storageBuilder = require('./storageBuilder');
+var SdkClock = require('./clock');
 
 function emitExpired(tokenMgmtRef, key, token) {
   tokenMgmtRef.emitter.emit('expired', key, token);
@@ -47,7 +48,7 @@ function clearExpireEventTimeoutAll(tokenMgmtRef) {
 }
 
 function setExpireEventTimeout(sdk, tokenMgmtRef, key, token) {
-  var expireEventWait = Math.max(token.expiresAt - sdk.clock.now(), 0) * 1000;
+  var expireEventWait = Math.max(token.expiresAt - tokenMgmtRef.clock.now(), 0) * 1000;
 
   // Clear any existing timeout
   clearExpireEventTimeout(tokenMgmtRef, key);
@@ -100,7 +101,7 @@ function get(storage, key) {
 function getAsync(sdk, tokenMgmtRef, storage, key) {
   return Q.Promise(function(resolve) {
     var token = get(storage, key);
-    if (!token || token.expiresAt > sdk.clock.now()) {
+    if (!token || token.expiresAt > tokenMgmtRef.clock.now()) {
       return resolve(token);
     }
 
@@ -211,6 +212,7 @@ function TokenManager(sdk, options) {
   }
 
   var tokenMgmtRef = {
+    clock: SdkClock.create(sdk, options),
     emitter: new Emitter(),
     autoRenew: options.autoRenew,
     expireTimeouts: {},

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -197,7 +197,7 @@ function clear(tokenMgmtRef, storage) {
 }
 
 function TokenManager(sdk, options) {
-  options = Object.assign({}, DEFAULT_OPTIONS, util.removeNils(options));
+  options = util.extend({}, DEFAULT_OPTIONS, util.removeNils(options));
 
   if (options.storage === 'localStorage' && !storageUtil.browserHasLocalStorage()) {
     util.warn('This browser doesn\'t support localStorage. Switching to sessionStorage.');

--- a/lib/browser/browser.js
+++ b/lib/browser/browser.js
@@ -25,7 +25,6 @@ var session           = require('../session');
 var token             = require('../token');
 var TokenManager      = require('../TokenManager');
 var tx                = require('../tx');
-var clock             = require('../clock');
 var util              = require('../util');
 
 function OktaAuthBuilder(args) {
@@ -65,12 +64,6 @@ function OktaAuthBuilder(args) {
   } else {
     this.options.maxClockSkew = args.maxClockSkew;
   }
-
-  // Calculated local clock offset from server time (in milliseconds). Can be positive or negative.
-  this.options.localClockOffset = args.localClockOffset || 0;
-  sdk.clock = {
-    now: util.bind(clock.getLocalAdjustedTime, null, sdk)
-  };
 
   // Give the developer the ability to disable token signature
   // validation.

--- a/lib/clock.js
+++ b/lib/clock.js
@@ -1,9 +1,19 @@
-function getLocalAdjustedTime(sdk) {
-  var localClockOffset = parseInt(sdk.options.localClockOffset || 0);
-  var now = (Date.now() + localClockOffset) / 1000;
-  return now;
+function SdkClock(localOffset) {
+  // Calculated local clock offset from server time (in milliseconds). Can be positive or negative.
+  this.localOffset = parseInt(localOffset || 0);
 }
 
-module.exports = {
-  getLocalAdjustedTime: getLocalAdjustedTime
+Object.assign(SdkClock.prototype, {
+  // Return the current time (in seconds)
+  now: function() {
+    var now = (Date.now() + this.localOffset) / 1000;
+    return now;
+  }
+});
+
+SdkClock.create = function(/* sdk, options */) {
+  // TODO: calculate localOffset
+  return new SdkClock();
 };
+
+module.exports = SdkClock;

--- a/lib/clock.js
+++ b/lib/clock.js
@@ -1,9 +1,11 @@
+var util = require('./util');
+
 function SdkClock(localOffset) {
   // Calculated local clock offset from server time (in milliseconds). Can be positive or negative.
   this.localOffset = parseInt(localOffset || 0);
 }
 
-Object.assign(SdkClock.prototype, {
+util.extend(SdkClock.prototype, {
   // Return the current time (in seconds)
   now: function() {
     var now = (Date.now() + this.localOffset) / 1000;
@@ -11,9 +13,11 @@ Object.assign(SdkClock.prototype, {
   }
 });
 
+// factory method. Create an instance of a clock from current context.
 SdkClock.create = function(/* sdk, options */) {
   // TODO: calculate localOffset
-  return new SdkClock();
+  var localOffset = 0;
+  return new SdkClock(localOffset);
 };
 
 module.exports = SdkClock;

--- a/lib/util.js
+++ b/lib/util.js
@@ -127,15 +127,19 @@ util.genRandomString = function(length) {
 };
 
 util.extend = function() {
+  // First object will be modified!
   var obj1 = arguments[0];
+  // Properties from other objects will be copied over
   var objArray = [].slice.call(arguments, 1);
   objArray.forEach(function(obj) {
     for (var prop in obj) {
-      if (obj.hasOwnProperty(prop)) {
+      // copy over all properties with defined values
+      if (obj.hasOwnProperty(prop) && obj[prop] !== undefined) {
         obj1[prop] = obj[prop];
       }
     }
   });
+  return obj1; // return the modified object
 };
 
 util.removeNils = function(obj) {

--- a/test/spec/clock.js
+++ b/test/spec/clock.js
@@ -1,76 +1,54 @@
-var clock = require('../../lib/clock');
+var SdkClock = require('../../lib/clock');
 
-describe('clock', function() {
+describe('SdkClock', function() {
 
-  describe('getLocalAdjustedTime', function() {
+  describe('now', function() {
     it('returns the local time / 1000', function() {
       var fakeDate = 4200;
       jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
-      var sdk = {
-        options: {
-          localClockOffset: 0
-        }
-      };
-      expect(clock.getLocalAdjustedTime(sdk)).toBe(fakeDate / 1000);
+      var offset = 0;
+      var clock = new SdkClock(offset);
+      expect(clock.now()).toBe(fakeDate / 1000);
     });
 
     it('can have a positive offset', function() {
       var fakeDate = 4200;
       jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
       var offset = 2300;
-      var sdk = {
-        options: {
-          localClockOffset: offset
-        }
-      };
-      expect(clock.getLocalAdjustedTime(sdk)).toBe((fakeDate + offset) / 1000);
+      var clock = new SdkClock(offset);
+      expect(clock.now()).toBe((fakeDate + offset) / 1000);
     });
 
     it('can have a negative offset', function() {
       var fakeDate = 4200;
       jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
       var offset = -2300;
-      var sdk = {
-        options: {
-          localClockOffset: offset
-        }
-      };
-      expect(clock.getLocalAdjustedTime(sdk)).toBe((fakeDate + offset) / 1000);
+      var clock = new SdkClock(offset);
+      expect(clock.now()).toBe((fakeDate + offset) / 1000);
     });
 
     it('returns a valid number even if offset is a string', function() {
       var fakeDate = 4200;
       jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
-      var sdk = {
-        options: {
-          localClockOffset: "0"
-        }
-      };
-      expect(clock.getLocalAdjustedTime(sdk)).toBe(fakeDate / 1000);
+      var offset = "0";
+      var clock = new SdkClock(offset);
+      expect(clock.now()).toBe(fakeDate / 1000);
     });
-
 
     it('returns a valid number even if offset is not set', function() {
       var fakeDate = 4200;
       jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
-      var sdk = {
-        options: {
-
-        }
-      };
-      expect(clock.getLocalAdjustedTime(sdk)).toBe(fakeDate / 1000);
+      var offset = null;
+      var clock = new SdkClock(offset);
+      expect(clock.now()).toBe(fakeDate / 1000);
     });
-
 
     it('will be NaN if offset is NaN', function() {
       var fakeDate = 4200;
       jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
-      var sdk = {
-        options: {
-          localClockOffset: "definitelyNotanumber"
-        }
-      };
-      expect(clock.getLocalAdjustedTime(sdk)).toBe(Number.NaN);
+      var offset = "definitelyNotanumber";
+      var clock = new SdkClock(offset);
+      expect(clock.now()).toBe(Number.NaN);
     });
 
   });

--- a/test/spec/clock.js
+++ b/test/spec/clock.js
@@ -1,55 +1,62 @@
 var SdkClock = require('../../lib/clock');
 
-describe('SdkClock', function() {
-
-  describe('now', function() {
-    it('returns the local time / 1000', function() {
-      var fakeDate = 4200;
-      jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
-      var offset = 0;
-      var clock = new SdkClock(offset);
-      expect(clock.now()).toBe(fakeDate / 1000);
+describe('clock', function() {
+  describe('create', function() {
+    it('returns an instance of SdkClock', function() {
+      expect(SdkClock.create() instanceof SdkClock).toBe(true);
     });
+  });
+  
+  describe('SdkClock', function() {
+    describe('now', function() {
+      it('returns the local time / 1000', function() {
+        var fakeDate = 4200;
+        jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
+        var offset = 0;
+        var clock = new SdkClock(offset);
+        expect(clock.now()).toBe(fakeDate / 1000);
+      });
 
-    it('can have a positive offset', function() {
-      var fakeDate = 4200;
-      jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
-      var offset = 2300;
-      var clock = new SdkClock(offset);
-      expect(clock.now()).toBe((fakeDate + offset) / 1000);
+      it('can have a positive offset', function() {
+        var fakeDate = 4200;
+        jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
+        var offset = 2300;
+        var clock = new SdkClock(offset);
+        expect(clock.now()).toBe((fakeDate + offset) / 1000);
+      });
+
+      it('can have a negative offset', function() {
+        var fakeDate = 4200;
+        jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
+        var offset = -2300;
+        var clock = new SdkClock(offset);
+        expect(clock.now()).toBe((fakeDate + offset) / 1000);
+      });
+
+      it('returns a valid number even if offset is a string', function() {
+        var fakeDate = 4200;
+        jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
+        var offset = "0";
+        var clock = new SdkClock(offset);
+        expect(clock.now()).toBe(fakeDate / 1000);
+      });
+
+      it('returns a valid number even if offset is not set', function() {
+        var fakeDate = 4200;
+        jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
+        var offset = null;
+        var clock = new SdkClock(offset);
+        expect(clock.now()).toBe(fakeDate / 1000);
+      });
+
+      it('will be NaN if offset is NaN', function() {
+        var fakeDate = 4200;
+        jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
+        var offset = "definitelyNotanumber";
+        var clock = new SdkClock(offset);
+        expect(clock.now()).toBe(Number.NaN);
+      });
+
     });
-
-    it('can have a negative offset', function() {
-      var fakeDate = 4200;
-      jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
-      var offset = -2300;
-      var clock = new SdkClock(offset);
-      expect(clock.now()).toBe((fakeDate + offset) / 1000);
-    });
-
-    it('returns a valid number even if offset is a string', function() {
-      var fakeDate = 4200;
-      jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
-      var offset = "0";
-      var clock = new SdkClock(offset);
-      expect(clock.now()).toBe(fakeDate / 1000);
-    });
-
-    it('returns a valid number even if offset is not set', function() {
-      var fakeDate = 4200;
-      jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
-      var offset = null;
-      var clock = new SdkClock(offset);
-      expect(clock.now()).toBe(fakeDate / 1000);
-    });
-
-    it('will be NaN if offset is NaN', function() {
-      var fakeDate = 4200;
-      jest.spyOn(Date, 'now').mockReturnValue(fakeDate);
-      var offset = "definitelyNotanumber";
-      var clock = new SdkClock(offset);
-      expect(clock.now()).toBe(Number.NaN);
-    });
-
   });
 })

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -563,18 +563,16 @@ describe('TokenManager', function() {
     });
 
     it('accounts for local clock offset when emitting "expired"', function() {
-      util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
+      util.warpToUnixTime(tokens.standardIdTokenClaims.expiresAt);
+      var localClockOffset = -2000; // local client is 2 seconds fast
       var client = setupSync({
-        // local client is 2 seconds fast
-        localClockOffset: -2000
+        localClockOffset: localClockOffset
       });
       var callback = jest.fn();
-      client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
       client.tokenManager.on('expired', callback);
+      client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
       expect(callback).not.toHaveBeenCalled();
-      util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
-      expect(callback).not.toHaveBeenCalled();
-      util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt);
+      jest.advanceTimersByTime(-localClockOffset);
       expect(callback).toHaveBeenCalled();
     });
   

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -13,7 +13,7 @@ function setupSync(options) {
     clientId: 'NPSfOkH5eZrTy8PMDlvx',
     redirectUri: 'https://example.com/redirect',
     tokenManager: {
-      expireEarly: options.tokenManager.expireEarly || 0,
+      expireEarlySeconds: options.tokenManager.expireEarlySeconds || 0,
       storage: options.tokenManager.type,
       autoRenew: options.tokenManager.autoRenew || false,
       secure: options.tokenManager.secure // used by cookie storage
@@ -412,13 +412,13 @@ describe('TokenManager', function() {
       });
     });
 
-    it('renews a token early when "expireEarly" option is considered', function() {
+    it('renews a token early when "expireEarlySeconds" option is considered', function() {
       var expiresAt = tokens.standardIdTokenParsed.expiresAt;
       return oauthUtil.setupFrame({
         authClient: setupSync({
           tokenManager: {
             autoRenew: true,
-            expireEarly: 10
+            expireEarlySeconds: 10
           }
         }),
         autoRenew: true,
@@ -546,7 +546,7 @@ describe('TokenManager', function() {
       var sdk = setupSync();
       jest.spyOn(sdk.token, 'renew');
       var tokenManager = new TokenManager(sdk, {
-        expireEarly: 0
+        expireEarlySeconds: 0
       });
       var expiresAt = EXPIRATION_TIME;
       var token = {
@@ -573,7 +573,7 @@ describe('TokenManager', function() {
       });
       jest.spyOn(sdk.token, 'renew');
       var tokenManager = new TokenManager(sdk, {
-        expireEarly: 0
+        expireEarlySeconds: 0
       });
       var expiresAt = EXPIRATION_TIME;
       var token = {
@@ -630,12 +630,12 @@ describe('TokenManager', function() {
       expect(callback).toHaveBeenCalled();
     });
   
-    it('accounts for "expireEarly" option when emitting "expired"', function() {
-      var expireEarly = 10;
-      util.warpToUnixTime(tokens.standardIdTokenClaims.exp - (expireEarly + 1));
+    it('accounts for "expireEarlySeconds" option when emitting "expired"', function() {
+      var expireEarlySeconds = 10;
+      util.warpToUnixTime(tokens.standardIdTokenClaims.exp - (expireEarlySeconds + 1));
       var client = setupSync({
         tokenManager: {
-          expireEarly: expireEarly
+          expireEarlySeconds: expireEarlySeconds
         }
       });
       var callback = jest.fn();

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -2,15 +2,16 @@ var OktaAuth = require('OktaAuth');
 var tokens = require('../util/tokens');
 var util = require('../util/util');
 var oauthUtil = require('../util/oauthUtil');
+var SdkClock = require('../../lib/clock');
 
 function setupSync(options) {
   options = options || {};
   options.tokenManager = options.tokenManager || {};
+  jest.spyOn(SdkClock, 'create').mockReturnValue(new SdkClock(options.localClockOffset));
   return new OktaAuth({
     issuer: 'https://auth-js-test.okta.com',
     clientId: 'NPSfOkH5eZrTy8PMDlvx',
     redirectUri: 'https://example.com/redirect',
-    localClockOffset: options.localClockOffset || 0,
     tokenManager: {
       storage: options.tokenManager.type,
       autoRenew: options.tokenManager.autoRenew || false,

--- a/test/spec/util.js
+++ b/test/spec/util.js
@@ -61,6 +61,40 @@ describe('util', function() {
         'prop3': 'test prop3'
       }));
     });
+
+    it('returns the first argument as the modified object', function() {
+      var obj1 = {
+        // empty
+      };
+      var obj2 = {
+        'prop1': 'test prop1'
+      };
+      var obj3 = {
+        'prop2': 'test prop2'
+      };
+      util.extend(obj1, obj2, obj3);
+      var res = util.extend(obj1);
+      expect(res).toBe(obj1);
+      expect(obj1).toEqual(expect.objectContaining({
+        'prop1': 'test prop1',
+        'prop2': 'test prop2'
+      }));
+    });
+
+    it('does not copy properties with undefined values', function() {
+      var obj1 = {
+        'prop1': 'test prop1',
+        'prop2': 'test prop2'
+      };
+      var obj2 = {
+        'prop3': undefined
+      };
+      util.extend(obj1, obj2);
+      expect(obj1).toEqual(expect.objectContaining({
+        'prop1': 'test prop1',
+        'prop2': 'test prop2'
+      }));
+    });
   });
 
   describe('isIE11OrLess', function() {

--- a/test/spec/util.js
+++ b/test/spec/util.js
@@ -87,7 +87,7 @@ describe('util', function() {
         'prop2': 'test prop2'
       };
       var obj2 = {
-        'prop3': undefined
+        'prop2': undefined
       };
       util.extend(obj1, obj2);
       expect(obj1).toEqual(expect.objectContaining({

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -24,6 +24,7 @@ util.warpToDistantPast = function () {
 };
 
 util.warpToUnixTime = function (unixTime) {
+  expect(isNaN(unixTime)).toBe(false);
   jest.spyOn(Date, 'now').mockReturnValue(unixTime * 1000);
 };
 


### PR DESCRIPTION
- Adds new TokenManager option 'expireEarly', with a default value of 30 (seconds)