### PR TITLE
Fix: getWithRedirect: set responseMode to "query" for non PKCE code flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build2
 test/SpecRunner.html
 npm-debug.log
 lib/config.js
+testenv

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ tokenManager: {
 | `issuer`       | Specify a custom issuer to perform the OIDC flow. Defaults to the base url parameter if not provided. |
 | `clientId`     | Client Id pre-registered with Okta for the OIDC authentication flow. |
 | `redirectUri`  | The url that is redirected to when using `token.getWithRedirect`. This must be pre-registered as part of client registration. If no `redirectUri` is provided, defaults to the current origin. |
-| `grantType`  | Specify `grantType` for this Application. Supported types are `implicit` and `authorization_code`. Defaults to `implicit` |
+| `pkce`  | If set to true, the authorization flow will automatically use PKCE.  The authorize request will use `response_type=code`, and `grant_type=authorization_code` will be used on the token request.  All these details are handled for you, including the creation and verification of code verifiers. |
 | `authorizeUrl` | Specify a custom authorizeUrl to perform the OIDC flow. Defaults to the issuer plus "/v1/authorize". |
 | `userinfoUrl`  | Specify a custom userinfoUrl. Defaults to the issuer plus "/v1/userinfo". |
 | `tokenUrl`  | Specify a custom tokenUrl. Defaults to the issuer plus "/v1/token". |
@@ -209,12 +209,12 @@ var authClient = new OktaAuth(config);
 
 By default the `implicit` OAuth flow will be used. It is widely supported by most browsers. PKCE is a newer flow which is more secure, but does require certain capabilities from the browser.
 
-To use PKCE flow, set `grantType` to `authorization_code` in your config.
+To use PKCE flow, set `pkce` to `true` in your config.
 
 ```javascript
 
 var config = {
-  grantType:  'authorization_code',
+  pkce:  true,
 
   // other config
   issuer: 'https://{yourOktaDomain}/oauth2/default',
@@ -1404,7 +1404,7 @@ The following configuration options can **only** be included in `token.getWithou
 | :-------: | ----------|
 | `sessionToken` | Specify an Okta sessionToken to skip reauthentication when the user already authenticated using the Authentication Flow. |
 | `responseMode` | Specify how the authorization response should be returned. You will generally not need to set this unless you want to override the default values for `token.getWithRedirect`. See [Parameter Details](https://developer.okta.com/docs/api/resources/oidc#parameter-details) for a list of available modes. |
-| `responseType` | Specify the [response type](https://developer.okta.com/docs/api/resources/oidc#request-parameters) for OIDC authentication. The default value is based on the configured `grantType`. If `grantType` is `implicit` (the default setting), `responseType` will have a default value of `id_token`. If `grantType` is `authorization_code`, the default value will be `code`. |
+| `responseType` | Specify the [response type](https://developer.okta.com/docs/api/resources/oidc#request-parameters) for OIDC authentication. The default value is `id_token`. If `pkce` is `true`, this option will be ingored. |
 | | Use an array if specifying multiple response types - in this case, the response will contain both an ID Token and an Access Token. `responseType: ['id_token', 'token']` |
 | `scopes` | Specify what information to make available in the returned `id_token` or `access_token`. For OIDC, you must include `openid` as one of the scopes. Defaults to `['openid', 'email']`. For a list of available scopes, see [Scopes and Claims](https://developer.okta.com/docs/api/resources/oidc#access-token-scopes-and-claims). |
 | `state` | Specify a state that will be validated in an OAuth response. This is usually only provided during redirect flows to obtain an authorization code. Defaults to a random string. |

--- a/lib/browser/browser.js
+++ b/lib/browser/browser.js
@@ -38,7 +38,7 @@ function OktaAuthBuilder(args) {
     authorizeUrl: util.removeTrailingSlash(args.authorizeUrl),
     userinfoUrl: util.removeTrailingSlash(args.userinfoUrl),
     tokenUrl: util.removeTrailingSlash(args.tokenUrl),
-    grantType: args.grantType,
+    pkce: args.pkce,
     redirectUri: args.redirectUri,
     httpRequestClient: args.httpRequestClient,
     storageUtil: args.storageUtil,
@@ -46,7 +46,7 @@ function OktaAuthBuilder(args) {
     headers: args.headers
   };
 
-  if (this.options.grantType === 'authorization_code' && !sdk.features.isPKCESupported()) {
+  if (this.options.pkce && !sdk.features.isPKCESupported()) {
     throw new AuthSdkError('This browser doesn\'t support PKCE');
   }
 

--- a/lib/pkce.js
+++ b/lib/pkce.js
@@ -85,10 +85,6 @@ function validateOptions(oauthOptions) {
   if (!oauthOptions.codeVerifier) {
     throw new AuthSdkError('The "codeVerifier" (generated and saved by your app) must be passed to /token');
   }
-
-  if (oauthOptions.grantType !== 'authorization_code') {
-    throw new AuthSdkError('Expecting "grantType" to equal "authorization_code"');
-  }
 }
 
 function getPostData(options) {
@@ -96,7 +92,7 @@ function getPostData(options) {
   var params = util.removeNils({
     'client_id': options.clientId,
     'redirect_uri': options.redirectUri,
-    'grant_type': options.grantType,
+    'grant_type': 'authorization_code',
     'code': options.authorizationCode,
     'code_verifier': options.codeVerifier
   });

--- a/lib/token.js
+++ b/lib/token.js
@@ -21,7 +21,7 @@ var AuthSdkError  = require('./errors/AuthSdkError');
 var OAuthError    = require('./errors/OAuthError');
 var config        = require('./config');
 var cookies       = require('./browser/browserStorage').storage;
-var pkce          = require('./pkce');
+var PKCE          = require('./pkce');
 
 function decodeToken(token) {
   var jwt = token.split('.');
@@ -131,21 +131,20 @@ function addFragmentListener(sdk, windowEl, timeout) {
 function exchangeCodeForToken(sdk, oauthParams, authorizationCode, urls) {
   // PKCE authorization_code flow
   // Retrieve saved values and build oauthParams for call to /token
-  var meta = pkce.loadMeta(sdk);
+  var meta = PKCE.loadMeta(sdk);
   var getTokenParams = {
     clientId: oauthParams.clientId,
-    grantType: 'authorization_code',
     authorizationCode: authorizationCode,
     codeVerifier: meta.codeVerifier,
     redirectUri: meta.redirectUri
   };
-  return pkce.getToken(sdk, getTokenParams, urls)
+  return PKCE.getToken(sdk, getTokenParams, urls)
   .then(function(res) {
     validateResponse(res, getTokenParams);
     return res;
   })
   .fin(function() {
-    pkce.clearMeta(sdk);
+    PKCE.clearMeta(sdk);
   });
 }
 
@@ -248,13 +247,11 @@ function handleOAuthResponse(sdk, oauthParams, res, urls) {
 function getDefaultOAuthParams(sdk, oauthOptions) {
   oauthOptions = util.clone(oauthOptions) || {};
 
-  var grantType = sdk.options.grantType || 'implicit';
-  var responseType = grantType === 'authorization_code' ? 'code' : 'id_token';
   var defaults = {
-    grantType: grantType,
+    pkce: sdk.options.pkce || false,
     clientId: sdk.options.clientId,
     redirectUri: sdk.options.redirectUri || window.location.href,
-    responseType: responseType,
+    responseType: 'id_token',
     responseMode: 'okta_post_message',
     state: oauthUtil.generateState(),
     nonce: oauthUtil.generateNonce(),
@@ -263,8 +260,9 @@ function getDefaultOAuthParams(sdk, oauthOptions) {
   };
   util.extend(defaults, oauthOptions);
 
-  if (defaults.grantType === 'authorization_code' && !defaults.codeChallengeMethod) {
-    defaults.codeChallengeMethod = pkce.DEFAULT_CODE_CHALLENGE_METHOD;
+  // PKCE flow, set default code challenge method
+  if (defaults.pkce && !defaults.codeChallengeMethod) {
+    defaults.codeChallengeMethod = PKCE.DEFAULT_CODE_CHALLENGE_METHOD;
   }
 
   return defaults;
@@ -522,26 +520,17 @@ function getWithPopup(sdk, oauthOptions, options) {
 
 function prepareOauthParams(sdk, oauthOptions) {
   var oauthParams = getDefaultOAuthParams(sdk, oauthOptions);
-
-  var responseType = oauthParams.responseType;
-  if (typeof responseType === 'string') {
-    responseType = [responseType];
-  }
-
-  if (oauthParams.grantType !== 'authorization_code') {
-    if (responseType.includes('code')) {
-      return Q.reject(new AuthSdkError('When responseType is "code", grantType should be "authorization_code"'));
-    }
+  if (oauthParams.pkce !== true) {
     return Q.resolve(oauthParams);
   }
 
+  // PKCE flow
   if (!sdk.features.isPKCESupported()) {
     return Q.reject(new AuthSdkError('This browser doesn\'t support PKCE'));
   }
 
-  if (responseType.length !== 1 || responseType[0] !== 'code') {
-    return Q.reject(new AuthSdkError('When grantType is "authorization_code", responseType should be "code"'));
-  }
+  // responseType is forced
+  oauthParams.responseType = 'code';
 
   return oauthUtil.getWellKnown(sdk, null)
     .then(function(res) {
@@ -552,20 +541,20 @@ function prepareOauthParams(sdk, oauthOptions) {
     })
     .then(function() {
       // PKCE authorization_code flow
-      var codeVerifier = pkce.generateVerifier(oauthParams.codeVerifier);
+      var codeVerifier = PKCE.generateVerifier(oauthParams.codeVerifier);
 
       // We will need these values after redirect when we call /token
       var meta = {
         codeVerifier: codeVerifier,
         redirectUri: oauthParams.redirectUri
       };
-      pkce.saveMeta(sdk, meta);
+      PKCE.saveMeta(sdk, meta);
 
-      return pkce.computeChallenge(codeVerifier);
+      return PKCE.computeChallenge(codeVerifier);
     })
     .then(function(codeChallenge) {
 
-      // Clone/copy the params. Set codeChallenge and responseType for authorization_code
+      // Clone/copy the params. Set codeChallenge
       var clonedParams = util.clone(oauthParams) || {};
       util.extend(clonedParams, oauthParams, {
         codeChallenge: codeChallenge,
@@ -576,11 +565,22 @@ function prepareOauthParams(sdk, oauthOptions) {
 
 function getWithRedirect(sdk, oauthOptions, options) {
   oauthOptions = util.clone(oauthOptions) || {};
-  if (!oauthOptions.responseMode) {
-    oauthOptions.responseMode = 'fragment';
-  }
+
   return prepareOauthParams(sdk, oauthOptions)
     .then(function(oauthParams) {
+
+      // Dynamically set the responseMode unless the user has provided one
+      // Server-side flow requires query. Client-side apps usually prefer fragment.
+      if (!oauthOptions.responseMode) {
+        if (oauthParams.responseType.includes('code') && !oauthParams.pkce) {
+          // server-side flows using authorization_code
+          oauthParams.responseMode = 'query';
+        } else {
+          // general case, client-side flow.
+          oauthParams.responseMode = 'fragment';
+        }
+      }
+
       var urls = oauthUtil.getOAuthUrls(sdk, oauthParams, options);
       var requestUrl = urls.authorizeUrl + buildAuthorizeParams(oauthParams);
 
@@ -612,7 +612,7 @@ function renewToken(sdk, token) {
   }
 
   var responseType;
-  if (sdk.options.grantType === 'authorization_code') {
+  if (sdk.options.pkce) {
     responseType = 'code';
   } else if (token.accessToken) {
     responseType = 'token';

--- a/test/app/README.md
+++ b/test/app/README.md
@@ -3,13 +3,13 @@
 The following enironment variables are **required**. You can use a [.env file](https://github.com/motdotla/dotenv#usage) in this directory.
 
 * `CLIENT_ID` - abc12
-* `DOMAIN` - x.okta.com
+* `ISSUER` - x.okta.com/oauth2/default
 
 The following parameters are accepted in the URL:
 
-* `grantType` - set the default grantType (needed for PKCE token renew)
+* `pkce` - set PKCE flow
 * `scopes` - set the scopes passed during OAuth flow. Comma delimited.
 * `responseType` - set the responseType passed during OAuth flow. Comma delimited.
 
-All params can be used together:
-`http://localhost:8080/?scopes=openid,email&responseType=id_token,token&grantType=authorization_code`
+Params can be used together:
+`http://localhost:8080/?scopes=openid,email&responseType=id_token,token`

--- a/test/app/src/index.js
+++ b/test/app/src/index.js
@@ -2,11 +2,10 @@
 import TestApp from './testApp';
 
 /* eslint-disable prefer-destructuring */
-const DOMAIN = process.env.DOMAIN;
+const ISSUER = process.env.ISSUER;
 const CLIENT_ID = process.env.CLIENT_ID;
 /* eslint-enable prefer-destructuring */
 
-const ISSUER = `https://${DOMAIN}/oauth2/default`;
 const HOST = window.location.host;
 const REDIRECT_URI = `http://${HOST}/implicit/callback`;
 
@@ -18,12 +17,12 @@ const config = {
 
 // Allow setting some values by URL params
 const url = new URL(window.location.href);
-const grantType = url.searchParams.get('grantType');
+const pkce = !!url.searchParams.get('pkce');
 const scopes = (url.searchParams.get('scopes') || 'openid,email').split(',');
 const responseType = (url.searchParams.get('responseType') || 'id_token,token').split(',');
 const maxClockSkew = parseInt(url.searchParams.get('maxClockSkew') || 300);
 Object.assign(config, {
-  grantType,
+  pkce,
   scopes,
   responseType,
   maxClockSkew,

--- a/test/app/src/testApp.js
+++ b/test/app/src/testApp.js
@@ -18,30 +18,27 @@ function bindFunctions(testApp, window) {
 
   // getWithRedirect
   window.loginRedirectPKCE = testApp.loginRedirect.bind(testApp, {
-    grantType: 'authorization_code',
-    responseType: 'code'
+    pkce: true,
   });
   window.loginRedirectImplicit = testApp.loginRedirect.bind(testApp, {
-    grantType: 'implicit'
+
   });
 
   // getWithPopup
   window.loginPopupPKCE = testApp.loginPopup.bind(testApp, {
-    grantType: 'authorization_code',
-    responseType: 'code'
+    pkce: true,
   });
   window.loginPopupImplicit = testApp.loginPopup.bind(testApp, {
-    grantType: 'implicit'
+
   });
 
   // getWithoutPrompt
   window.getTokenPKCE = testApp.getToken.bind(testApp, {
-    grantType: 'authorization_code',
-    responseType: 'code'
+    pkce: true,
   });
 
   window.getTokenImplicit = testApp.getToken.bind(testApp, {
-    grantType: 'implicit'
+
   });
 
   window.logout = testApp.logout.bind(testApp);
@@ -130,7 +127,7 @@ Object.assign(TestApp.prototype, {
       this.render();
     });
   },
-  // grantType must be already set before calling this method
+  // pkce must be already set before calling this method
   renewToken: async function(event) {
     event && event.preventDefault(); // prevent navigation / page reload
     return this.oktaAuth.tokenManager.renew('idToken')
@@ -188,12 +185,12 @@ Object.assign(TestApp.prototype, {
       <ul>
         <li>
           <a id="renewtoken" href="/" onclick="renewToken(event)"><b>Renew Token</b></a>
-          <p>(must set grantType via constructor)
+          <p>(must set pkce via constructor)
           <div>
-            <b>grantType:</b>
-            <a href="/?grantType=authorization_code">authorization_code</a>
+            <b>pkce:</b>
+            <a href="/?pkce=1">pkce flow</a>
               &nbsp;|&nbsp;
-            <a href="/?grantType=implicit">implicit</a>
+            <a href="/">implicit flow</a>
           </div>
           </p>
         </li>

--- a/test/app/webpack.config.js
+++ b/test/app/webpack.config.js
@@ -1,8 +1,15 @@
 /* global process, __dirname */
-require('dotenv').config();
+const dotenv = require('dotenv');
+const fs = require('fs');
+const path = require('path');
+
+// Read environment variables from "testenv". Override environment vars if they are already set.
+const envConfig = dotenv.parse(fs.readFileSync(path.resolve(__dirname, '../..', 'testenv')));
+Object.keys(envConfig).forEach((k) => {
+  process.env[k] = envConfig[k];
+});
 
 var webpack = require('webpack');
-var path = require('path');
 const ROOT_DIR = path.resolve(__dirname, '..', '..');
 const PACKAGE_JSON = require(path.join(ROOT_DIR, 'package.json'));
 const MAIN_ENTRY = path.resolve(ROOT_DIR, PACKAGE_JSON.browser);
@@ -17,7 +24,7 @@ module.exports = {
     }
   },
   plugins: [
-    new webpack.EnvironmentPlugin(['CLIENT_ID', 'DOMAIN']),
+    new webpack.EnvironmentPlugin(['CLIENT_ID', 'ISSUER']),
   ],
   devServer: {
     contentBase: path.join(__dirname, 'public'),

--- a/test/karma/spec/loginFlow.js
+++ b/test/karma/spec/loginFlow.js
@@ -109,12 +109,11 @@ describe('Complete login flow', function() {
     });
   }
 
-  it('grantType: implicit', function() {
+  it('implicit login flow', function() {
     // First hit /authorize
     return bootstrap({})
     .then(function(app) {
       return app.loginRedirect({
-        grantType: 'implicit',
         nonce: NONCE
       });
     })
@@ -159,14 +158,13 @@ describe('Complete login flow', function() {
     });
   });
 
-  it('grantType: authorization_code', function() {
+  it('PKCE login flow', function() {
     // First hit /authorize
     return bootstrap()
     .then(function(app) {
       mockWellKnown();
       return app.loginRedirect({
-        grantType: 'authorization_code',
-        responseType: 'code',
+        pkce: true,
         nonce: NONCE,
         codeVerifier: CODE_VERIFIER
       });
@@ -245,14 +243,13 @@ describe('Complete login flow', function() {
     });
   });
 
-  it('throws for invalid code_challenge_method', function() {
+  it('PKCE: throws for invalid code_challenge_method', function() {
     // First hit /authorize
     return bootstrap()
     .then(function(app) {
       mockWellKnown();
       return app.loginRedirect({
-        grantType: 'authorization_code',
-        responseType: 'code',
+        pkce: true,
         nonce: NONCE,
         codeVerifier: CODE_VERIFIER,
         codeChallengeMethod: 'invalid'

--- a/test/karma/spec/renewToken.js
+++ b/test/karma/spec/renewToken.js
@@ -115,9 +115,9 @@ describe('Renew token', function() {
     });
   });
 
-  it('grantType: implicit', function() {
+  it('implicit flow', function() {
     return bootstrap({
-      grantType: 'implicit'
+
     })
     .then(() => {
       sdk.tokenManager.add('accessToken', ACCCESS_TOKEN_PARSED);
@@ -160,11 +160,11 @@ describe('Renew token', function() {
     });
   });
 
-  it('grantType: authorization_code', function() {
+  it('PKCE flow', function() {
     var codeChallenge, codeVerifier;
 
     return bootstrap({
-      grantType: 'authorization_code',
+      pkce: true,
     })
     .then(() => {
       sdk.tokenManager.add('accessToken', ACCCESS_TOKEN_PARSED);

--- a/test/spec/features.js
+++ b/test/spec/features.js
@@ -88,13 +88,13 @@ describe('features', function() {
     });
 
 
-    it('throw an error during construction if grantType is "authorization_code" and PKCE is not supported', function () {
+    it('throw an error during construction if pkce is true and PKCE is not supported', function () {
       var err;
       spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(false);
       try {
         new OktaAuth({
           url: 'https://dev-12345.oktapreview.com',
-          grantType: 'authorization_code',
+          pkce: true,
         });
       } catch (e) {
         err = e;


### PR DESCRIPTION
This fixes non-SPA apps which are using the auth-js library (including SIW). The responseMode was being incorrectly set to "fragment" in getWithRedirect()

- restores test for non PKCE "code" flow
- restores previous behavior, where responseMode is set to "query" if responseType is "code" (and not using PKCE)
- adds some tests for PKCE