### PR TITLE
Add introspect API

### DIFF
--- a/lib/browser/browser.js
+++ b/lib/browser/browser.js
@@ -82,7 +82,8 @@ function OktaAuthBuilder(args) {
   sdk.tx = {
     status: util.bind(tx.transactionStatus, null, sdk),
     resume: util.bind(tx.resumeTransaction, null, sdk),
-    exists: util.bind(tx.transactionExists, null, sdk)
+    exists: util.bind(tx.transactionExists, null, sdk),
+    introspect: util.bind(tx.introspect, null, sdk)
   };
 
   // This is exposed so we can mock document.cookie in our tests

--- a/lib/tx.js
+++ b/lib/tx.js
@@ -57,6 +57,28 @@ function resumeTransaction(sdk, args) {
     });
 }
 
+function introspect (sdk, args) {
+  if (!args || !args.stateToken) {
+    var stateToken = sdk.tx.exists._get(config.STATE_TOKEN_KEY_NAME);
+    if (stateToken) {
+      args = {
+        stateToken: stateToken
+      };
+    } else {
+      return Q.reject(new AuthSdkError('No transaction to evaluate'));
+    }
+  }
+  return transactionStep(sdk, args)
+    .then(function (res) {
+      return new AuthTransaction(sdk, res);
+    });
+}
+
+function transactionStep(sdk, args) {
+  args = addStateToken(sdk, args);
+  return http.post(sdk, sdk.options.url + '/idp/idx/introspect', args);
+}
+
 function transactionExists(sdk) {
   // We have a cookie state token
   return !!sdk.tx.exists._get(config.STATE_TOKEN_KEY_NAME);
@@ -352,5 +374,6 @@ module.exports = {
   transactionStatus: transactionStatus,
   resumeTransaction: resumeTransaction,
   transactionExists: transactionExists,
-  postToTransaction: postToTransaction
+  postToTransaction: postToTransaction,
+  introspect: introspect,
 };


### PR DESCRIPTION
- Update API url to `/idp/idx/introspect`
- This is the only place where the url is hardcoded to hit `/idx`
- Note: we also want to publish a version of auth-js with this change to consume in the widget for OIE, since currently we are using version of auth js in the widget that is based on a hash and is throwing errors on bacon during build. 

@haishengwu-okta @royalchan-okta @VadymYaremchuk-okta 