### PR TITLE
fix: token renew promise sometimes does not resolve

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,11 +7,26 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Jest Current File",
+      "name": "Jest Current File (browser)",
       "program": "${workspaceFolder}/node_modules/jest/bin/jest",
       "args": [
         "--runInBand",
         "--no-cache",
+        "--config=jest.browser.js",
+        "${relativeFile}"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Current File (server)",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "args": [
+        "--runInBand",
+        "--no-cache",
+        "--config=jest.server.js",
         "${relativeFile}"
       ],
       "console": "integratedTerminal",

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -141,6 +141,12 @@ function remove(tokenMgmtRef, storage, key) {
 }
 
 function renew(sdk, tokenMgmtRef, storage, key) {
+  // Multiple callers may receive the same promise. They will all resolve or reject from the same request.
+  var existingPromise = tokenMgmtRef.renewPromise[key];
+  if (existingPromise) {
+    return existingPromise;
+  }
+
   try {
     var token = get(storage, key);
     if (!token) {
@@ -154,8 +160,7 @@ function renew(sdk, tokenMgmtRef, storage, key) {
   clearExpireEventTimeout(tokenMgmtRef, key);
 
   // Store the renew promise state, to avoid renewing again
-  if (!tokenMgmtRef.renewPromise[key]) {
-    tokenMgmtRef.renewPromise[key] = sdk.token.renew(token)
+  tokenMgmtRef.renewPromise[key] = sdk.token.renew(token)
     .then(function(freshTokens) {
       var freshToken = freshTokens;
       // With PKCE flow we will receive multiple tokens. Find the one we are looking for
@@ -174,20 +179,20 @@ function renew(sdk, tokenMgmtRef, storage, key) {
       }
       add(sdk, tokenMgmtRef, storage, key, freshToken);
       tokenMgmtRef.emitter.emit('renewed', key, freshToken, oldToken);
-      
-      // Remove existing promise key
-      delete tokenMgmtRef.renewPromise[key];
       return freshToken;
     })
-    .fail(function(err) {
+    .catch(function(err) {
       if (err.name === 'OAuthError') {
         remove(tokenMgmtRef, storage, key);
         emitError(tokenMgmtRef, err);
       }
-
       throw err;
+    })
+    .finally(function() {
+      // Remove existing promise key
+      delete tokenMgmtRef.renewPromise[key];
     });
-  }
+
   return tokenMgmtRef.renewPromise[key];
 }
 

--- a/lib/token.js
+++ b/lib/token.js
@@ -83,11 +83,19 @@ function addPostMessageListener(sdk, timeout, state) {
   var deferred = Q.defer();
 
   function responseHandler(e) {
-    if (!e.data ||
-        e.origin !== sdk.options.url ||
-        (e.data && util.isString(state) && e.data.state !== state)) {
+    if (!e.data || e.data.state !== state) {
+      // A message not meant for us
       return;
     }
+
+    // Configuration mismatch between saved token and current app instance
+    // This may happen if apps with different issuers are running on the same host url
+    // If they share the same storage key, they may read and write tokens in the same location.
+    // Common when developing against http://localhost
+    if (e.origin !== sdk.options.url) {
+      return deferred.reject(new AuthSdkError('The request does not match client configuration'));
+    }
+
     deferred.resolve(e.data);
   }
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^3.0.5",
     "lodash": "4.17.11",
+    "promise.allsettled": "^1.0.1",
     "webpack": "^3.0.0"
   },
   "okta-auth-js": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "karma-webpack": "^3.0.5",
     "lodash": "4.17.11",
     "promise.allsettled": "^1.0.1",
+    "promise.prototype.finally": "^3.1.1",
     "webpack": "^3.0.0"
   },
   "okta-auth-js": {

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -3,5 +3,8 @@
   "env": {
     "jest": true,
     "jasmine": true
+  },
+  "globals": {
+    "Promise": "readonly"
   }
 }

--- a/test/spec/token.js
+++ b/test/spec/token.js
@@ -141,7 +141,7 @@ describe('token.getWithoutPrompt', function() {
             errorId: 'INTERNAL',
             errorCauses: []
           });
-        })
+        });
       });
     });
   });

--- a/test/spec/token.js
+++ b/test/spec/token.js
@@ -1,4 +1,6 @@
 jest.mock('cross-fetch');
+var allSettled = require('promise.allsettled');
+allSettled.shim(); // will be a no-op if not needed
 
 var OktaAuth = require('OktaAuth');
 var tokens = require('../util/tokens');
@@ -9,6 +11,7 @@ var _ = require('lodash');
 var Q = require('q');
 var sdkUtil = require('../../lib/oauthUtil');
 var pkce = require('../../lib/pkce');
+var waitFor = require('../util/waitFor');
 
 function setupSync() {
   return new OktaAuth({ issuer: 'http://example.okta.com' });
@@ -37,6 +40,144 @@ describe('token.decode', function() {
 });
 
 describe('token.getWithoutPrompt', function() {
+  
+  describe('concurrent requests', function() {
+    var authClient;
+    var states;
+    var messageCallbacks;
+
+    function fireCallback(index, origin) {
+      var fn = messageCallbacks[index];
+      fn({
+        data: {
+          'id_token': tokens.standardIdToken,
+          state: states[index],
+        },
+        origin: origin || 'https://auth-js-test.okta.com'
+      });
+    }
+
+    beforeEach(function() {
+      var oktaAuthArgs = {
+        issuer: 'https://auth-js-test.okta.com',
+        clientId: 'NPSfOkH5eZrTy8PMDlvx',
+        redirectUri: 'https://example.com/redirect'
+      };
+      authClient = new OktaAuth(oktaAuthArgs);
+      states = [];
+      messageCallbacks = [];
+
+      // Mock the well-known and keys request
+      oauthUtil.loadWellKnownAndKeysCache();
+      oauthUtil.mockStateAndNonce();
+      util.warpToUnixTime(oauthUtil.getTime());
+  
+      // Unique state per request
+      var stateCounter = 0;
+      jest.spyOn(sdkUtil, 'generateState').mockImplementation(function() {
+        stateCounter++;
+        states.push(stateCounter);
+        return states[states.length - 1];
+      });
+  
+      // Simulate the postMessage between the window and the popup or iframe
+      jest.spyOn(window, 'addEventListener').mockImplementation(function(eventName, fn) {
+        if (eventName === 'message') {
+          messageCallbacks.push(fn);
+        }
+      });
+
+      // Capture the iframe
+      var body = document.getElementsByTagName('body')[0];
+      var origAppend = body.appendChild;
+      jest.spyOn(body, 'appendChild').mockImplementation(function (el) {
+        if (el.tagName === 'IFRAME') {
+          // Remove the src so it doesn't actually load
+          el.src = '';
+          return origAppend.call(this, el);
+        }
+        return origAppend.apply(this, arguments);
+      });
+
+    });
+
+    it('multiple valid will resolve', function() {
+      var p1 = authClient.token.getWithoutPrompt();
+      var p2 = authClient.token.getWithoutPrompt();
+      var p3 = authClient.token.getWithoutPrompt();
+      return waitFor(function() {
+        return messageCallbacks.length === 3;
+      }).then(function() {
+        // manually fire callbacks in mixed order. All promises should resolve
+        fireCallback(1);
+        fireCallback(2);
+        fireCallback(0);
+        return Promise.all([p1, p2, p3]);
+      });
+    });
+
+    it('multiple invalid will fail (authorizeUrl mismatch)', function() {
+      var p1 = authClient.token.getWithoutPrompt();
+      var p2 = authClient.token.getWithoutPrompt();
+      var p3 = authClient.token.getWithoutPrompt();
+      return waitFor(function() {
+        return messageCallbacks.length === 3;
+      }).then(function() {
+        // manually fire callbacks in mixed order. All promises should reject
+        fireCallback(1, 'bogus');
+        fireCallback(2, 'bogus');
+        fireCallback(0, 'bogus');
+        return Promise.allSettled([p1, p2, p3]);
+      }).then(function(results) {
+        expect(results).toHaveLength(3);
+        results.forEach(function(result) {
+          expect(result.status).toBe('rejected');
+          util.expectErrorToEqual(result.reason, {
+            name: 'AuthSdkError',
+            message: 'The request does not match client configuration',
+            errorCode: 'INTERNAL',
+            errorSummary: 'The request does not match client configuration',
+            errorLink: 'INTERNAL',
+            errorId: 'INTERNAL',
+            errorCauses: []
+          });
+        })
+      });
+    });
+  });
+
+  it('If authorizeUrl does not match configured issuer, promise will reject', function() {
+    return oauthUtil.setupFrame({
+      willFail: true,
+      oktaAuthArgs: {
+        issuer: 'https://auth-js-test.okta.com',
+        clientId: 'NPSfOkH5eZrTy8PMDlvx',
+        redirectUri: 'https://example.com/redirect'
+      },
+      getWithoutPromptArgs: [{
+        sessionToken: 'testSessionToken'
+      }, {
+        authorizeUrl: 'https://bogus',
+      }],
+      postMessageSrc: {
+        baseUri: 'https://bogus'
+      }
+    })
+    .then(function() {
+      expect(true).toEqual(false);
+    })
+    .fail(function(err) {
+      util.expectErrorToEqual(err, {
+        name: 'AuthSdkError',
+        message: 'The request does not match client configuration',
+        errorCode: 'INTERNAL',
+        errorSummary: 'The request does not match client configuration',
+        errorLink: 'INTERNAL',
+        errorId: 'INTERNAL',
+        errorCauses: []
+      });
+    });
+  });
 
   it('returns id_token using sessionToken', function(done) {
     return oauthUtil.setupFrame({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,7 +1142,7 @@ default-require-extensions@^2.0.0:
   dependencies:
     strip-bom "^3.0.0"
 
-define-properties@^1.1.2:
+define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   dependencies:
@@ -1333,6 +1333,22 @@ error-ex@^1.2.0:
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.13.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.14.1.tgz#6e8d84b445ec9c610781e74a6d52cc31aac5b4ca"
+  integrity sha512-cp/Tb1oA/rh2X7vqeSOvM+TSo3UkJLX70eNihgVEvnzwAgikjkTFr/QVgRCaxjm0knCNQzNoxxxcw2zO2LJdZA==
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.0"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-inspect "^1.6.0"
+    object-keys "^1.1.1"
+    string.prototype.trimleft "^2.0.0"
+    string.prototype.trimright "^2.0.0"
 
 es-abstract@^1.5.1:
   version "1.13.0"
@@ -1827,7 +1843,7 @@ fsevents@^1.2.3, fsevents@^1.2.7:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
 
-function-bind@^1.1.1:
+function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
@@ -3564,7 +3580,12 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-keys@^1.0.11, object-keys@^1.0.12:
+object-inspect@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
+  integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
+
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
 
@@ -3868,6 +3889,15 @@ process@^0.11.10:
 progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+
+promise.allsettled@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/promise.allsettled/-/promise.allsettled-1.0.1.tgz#afe4bfcc13b26e2263a97a7fbbb19b8ca6eb619c"
+  integrity sha512-3ST7RS7TY3TYLOIe+OACZFvcWVe1osbgz2x07nTb446pa3t4GUZWidMDzQ4zf9jC2l6mRa1/3X81icFYbi+D/g==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.13.0"
+    function-bind "^1.1.1"
 
 prompts@^0.1.9:
   version "0.1.14"
@@ -4550,6 +4580,22 @@ string-width@^1.0.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string.prototype.trimleft@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz#68b6aa8e162c6a80e76e3a8a0c2e747186e271ff"
+  integrity sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.0.2"
+
+string.prototype.trimright@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz#ab4a56d802a01fbe7293e11e84f24dc8164661dd"
+  integrity sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.0.2"
 
 string_decoder@^1.0.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3899,6 +3899,15 @@ promise.allsettled@^1.0.1:
     es-abstract "^1.13.0"
     function-bind "^1.1.1"
 
+promise.prototype.finally@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/promise.prototype.finally/-/promise.prototype.finally-3.1.1.tgz#cb279d3a5020ca6403b3d92357f8e22d50ed92aa"
+  integrity sha512-gnt8tThx0heJoI3Ms8a/JdkYBVhYP/wv+T7yQimR+kdOEJL21xTFbiJhMRqnSPcr54UVvMbsscDk2w+ivyaLPw==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.13.0"
+    function-bind "^1.1.1"
+
 prompts@^0.1.9:
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.14.tgz#a8e15c612c5c9ec8f8111847df3337c9cbd443b2"


### PR DESCRIPTION
- fixes condition where token request would fail, but not reject. This occurred when the authorizeUrl saved in the token does not match the configured issuer.
- fixes behavior in TokenManager: multiple calls to renew() while a request is in process should not produce extra requests, but each caller should receive the same promise.