### PR TITLE
Improve error handling, doc, add tests for TokenManager "error" event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1673,11 +1673,15 @@ authClient.tokenManager.on('renewed', function (key, newToken, oldToken) {
 
 // Triggered when an OAuthError is returned via the API
 authClient.tokenManager.on('error', function (err) {
-  console.log('TokenManager error:', err.message);
+  console.log('TokenManager error:', err);
   // err.name
   // err.message
   // err.errorCode
   // err.errorSummary
+
+  if (err.errorCode === 'login_required') {
+    // Return to unauthenticated state
+  }
 });
 ```
 

--- a/lib/TokenManager.js
+++ b/lib/TokenManager.js
@@ -182,7 +182,7 @@ function renew(sdk, tokenMgmtRef, storage, key) {
       return freshToken;
     })
     .catch(function(err) {
-      if (err.name === 'OAuthError') {
+      if (err.name === 'OAuthError' || err.name === 'AuthSdkError') {
         remove(tokenMgmtRef, storage, key);
         emitError(tokenMgmtRef, err);
       }

--- a/test/app/src/testApp.js
+++ b/test/app/src/testApp.js
@@ -49,6 +49,12 @@ function bindFunctions(testApp, window) {
 function TestApp(config) {
   this.config = config;
   this.oktaAuth = new OktaAuth(config);
+  this.oktaAuth.tokenManager.on('error', e => {
+    console.error('Token manager error:', e);
+    if (e.errorCode === 'login_required') {
+      this.render();
+    }
+  });
 }
 
 export default TestApp;

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -392,6 +392,38 @@ describe('TokenManager', function() {
         });
       });
     });
+
+    it('removes token if an AuthSdkError is thrown while renewing', function() {
+      return oauthUtil.setupFrame({
+        authClient: setupSync(),
+        willFail: true,
+        tokenManagerAddKeys: {
+          'test-accessToken': tokens.standardAccessTokenParsed,
+          'test-idToken': tokens.standardIdTokenParsed
+        },
+        tokenManagerRenewArgs: ['test-accessToken'],
+        postMessageSrc: {
+          baseUri: 'http://obviously.fake.foo',
+        },
+        postMessageResp: {
+          state: oauthUtil.mockedState
+        }
+      })
+      .fail(function(e) {
+        util.expectErrorToEqual(e, {
+          name: 'AuthSdkError',
+          message: 'The request does not match client configuration',
+          errorCode: 'INTERNAL',
+          errorSummary: 'The request does not match client configuration',
+          errorLink: 'INTERNAL',
+          errorId: 'INTERNAL',
+          errorCauses: [],
+        });
+        oauthUtil.expectTokenStorageToEqual(localStorage, {
+          'test-idToken': tokens.standardIdTokenParsed
+        });
+      });
+    });
   });
 
   describe('autoRenew', function() {
@@ -630,6 +662,58 @@ describe('TokenManager', function() {
       });
     });
 
+    it('Emits an "error" event on AuthSdkError', function() {
+      var authClient = setupSync({
+        tokenManager: {
+          autoRenew: true
+        }
+      });
+      var errorEventCallback = jest.fn().mockImplementation(function(err) {
+        util.expectErrorToEqual(err, {
+          name: 'AuthSdkError',
+          message: 'The request does not match client configuration',
+          errorCode: 'INTERNAL',
+          errorSummary: 'The request does not match client configuration',
+          errorLink: 'INTERNAL',
+          errorId: 'INTERNAL',
+          errorCauses: [],
+        });
+      })
+      authClient.tokenManager.on('error', errorEventCallback);
+
+      return oauthUtil.setupFrame({
+        authClient: authClient,
+        autoRenew: true,
+        willFail: true,
+        fastForwardToTime: true,
+        autoRenewTokenKey: 'test-idToken',
+        time: tokens.standardIdTokenParsed.expiresAt + 1,
+        tokenManagerAddKeys: {
+          'test-idToken': tokens.standardIdTokenParsed
+        },
+        postMessageSrc: {
+          baseUri: 'http://obviously.fake.foo',
+        },
+        postMessageResp: {
+          state: oauthUtil.mockedState
+        }
+      })
+      .fail(function(err) {
+        util.expectErrorToEqual(err, {
+          name: 'AuthSdkError',
+          message: 'The request does not match client configuration',
+          errorCode: 'INTERNAL',
+          errorSummary: 'The request does not match client configuration',
+          errorLink: 'INTERNAL',
+          errorId: 'INTERNAL',
+          errorCauses: [],
+        });
+        oauthUtil.expectTokenStorageToEqual(localStorage, {});
+
+        expect(errorEventCallback).toHaveBeenCalled();
+      });
+    });
+
     it('removes a token on OAuth failure', function() {
       return oauthUtil.setupFrame({
         authClient: setupSync({
@@ -657,6 +741,42 @@ describe('TokenManager', function() {
           message: 'something went wrong',
           errorCode: 'sampleErrorCode',
           errorSummary: 'something went wrong'
+        });
+        oauthUtil.expectTokenStorageToEqual(localStorage, {});
+      });
+    });
+
+    it('removes a token on AuthSdkError', function() {
+      return oauthUtil.setupFrame({
+        authClient: setupSync({
+          tokenManager: {
+            autoRenew: true
+          }
+        }),
+        autoRenew: true,
+        willFail: true,
+        fastForwardToTime: true,
+        autoRenewTokenKey: 'test-idToken',
+        time: tokens.standardIdTokenParsed.expiresAt + 1,
+        tokenManagerAddKeys: {
+          'test-idToken': tokens.standardIdTokenParsed
+        },
+        postMessageSrc: {
+          baseUri: 'http://obviously.fake.foo',
+        },
+        postMessageResp: {
+          state: oauthUtil.mockedState
+        }
+      })
+      .fail(function(e) {
+        util.expectErrorToEqual(e, {
+          name: 'AuthSdkError',
+          message: 'The request does not match client configuration',
+          errorCode: 'INTERNAL',
+          errorSummary: 'The request does not match client configuration',
+          errorLink: 'INTERNAL',
+          errorId: 'INTERNAL',
+          errorCauses: [],
         });
         oauthUtil.expectTokenStorageToEqual(localStorage, {});
       });


### PR DESCRIPTION
Add some tests and minor documentation additions around TokenManager "error" event. This event is emitted when `renew()` fails because session is expired or invalid.

Will also remove token and emit "error" event if, while renewing, an `AuthSdkError` is thrown. 