### PR TITLE
Add tests for external logout

### DIFF
--- a/test/app/package.json
+++ b/test/app/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "lint": "eslint .",
     "watch": "webpack --watch",
-    "prestart": "yarn install",
     "start": "webpack-dev-server",
     "start:dev": "yarn start --open",
     "build": "webpack",

--- a/test/app/public/implicit/callback/index.html
+++ b/test/app/public/implicit/callback/index.html
@@ -3,7 +3,6 @@
   <link rel="stylesheet" href="/oidc-app.css"/>
 </head>
 <body class="oidc-app callback">
-  <h1>OIDC CALLBACK</h1>
   <div id="root"></div>
   <script src="/oidc-app.js"></script>
   <script type="text/javascript">

--- a/test/app/public/index.html
+++ b/test/app/public/index.html
@@ -3,7 +3,6 @@
     <link rel="stylesheet" href="/oidc-app.css"/>
   </head>
   <body class="oidc-app landing">
-    <h1>OIDC LANDING</h1>
     <div id="root"></div>
     <script src="/oidc-app.js"></script>
     <script type="text/javascript">

--- a/test/app/src/testApp.js
+++ b/test/app/src/testApp.js
@@ -17,7 +17,7 @@ import { saveConfigToStorage } from './config';
 import { MOUNT_PATH } from './constants';
 import { htmlString, toQueryParams } from './util';
 import { Form, updateForm } from './form';
-import { tokensHTML } from './tokens';
+import { tokensArrayToObject, tokensHTML } from './tokens';
 
 function homeLink(app) {
   return `<a id="return-home" href="${app.originalUrl}">Return Home</a>`;
@@ -234,17 +234,14 @@ Object.assign(TestApp.prototype, {
   },
   saveTokens: function(tokens) {
     tokens = Array.isArray(tokens) ? tokens : [tokens];
-    tokens.forEach((token) => {
-      if (!token) {
-        throw new Error('BAD/EMPTY token returned');
-      } else if (token.idToken) {
-        this.oktaAuth.tokenManager.add('idToken', token);
-      } else if (token.accessToken) {
-        this.oktaAuth.tokenManager.add('accessToken', token);
-      } else {
-        throw new Error('Unknown token returned: ' + JSON.stringify(token));
-      }
-    });
+    tokens = tokensArrayToObject(tokens);
+    const { idToken, accessToken } = tokens;
+    if (idToken) {
+      this.oktaAuth.tokenManager.add('idToken', idToken);
+    }
+    if (accessToken) {
+      this.oktaAuth.tokenManager.add('accessToken', accessToken);
+    }
   },
   getTokens: async function() {
     const accessToken = await this.oktaAuth.tokenManager.get('accessToken');
@@ -331,7 +328,7 @@ Object.assign(TestApp.prototype, {
       </div>
       <hr/>
       ${homeLink(this)}
-      ${ success ? tokensHTML(tokens): '' }
+      ${ success ? tokensHTML(tokensArrayToObject(tokens)): '' }
     `;
     return content;
   }

--- a/test/app/src/tokens.js
+++ b/test/app/src/tokens.js
@@ -1,25 +1,23 @@
 import { htmlString } from './util';
 
-function tokensHTML(tokens) {
-  let accessToken;
-  let idToken;
-  if (!tokens) {
-    return '';
-  } else if (Array.isArray(tokens)) {
-    if (tokens.length < 2) {
-      return '';
-    }
-    accessToken = tokens.filter(token => {
-      return token.accessToken;
-    })[0];
-    idToken = tokens.filter(token => {
-      return token.idToken;
-    })[0];
-  } else {
-    accessToken = tokens.accessToken;
-    idToken = tokens.idToken;
-  }
+function tokensArrayToObject(tokens) {
+  let accessToken = tokens.filter(token => {
+    return token.accessToken;
+  });
+  accessToken = accessToken.length ? accessToken[0] : null;
 
+  let idToken = tokens.filter(token => {
+    return token.idToken;
+  });
+  idToken = idToken.length ? idToken[0] : null;
+  return {
+    accessToken,
+    idToken
+  };
+}
+
+function tokensHTML(tokens) {
+  const { idToken, accessToken } = tokens;
   const claims = idToken.claims;
   const html = `
   <table id="claims">
@@ -51,4 +49,4 @@ function tokensHTML(tokens) {
   return html;
 }
 
-export { tokensHTML };
+export { tokensArrayToObject, tokensHTML };

--- a/test/app/src/tokens.js
+++ b/test/app/src/tokens.js
@@ -1,15 +1,25 @@
 import { htmlString } from './util';
 
 function tokensHTML(tokens) {
-  if (!tokens || tokens.length < 2) {
+  let accessToken;
+  let idToken;
+  if (!tokens) {
     return '';
+  } else if (Array.isArray(tokens)) {
+    if (tokens.length < 2) {
+      return '';
+    }
+    accessToken = tokens.filter(token => {
+      return token.accessToken;
+    })[0];
+    idToken = tokens.filter(token => {
+      return token.idToken;
+    })[0];
+  } else {
+    accessToken = tokens.accessToken;
+    idToken = tokens.idToken;
   }
-  const accessToken = tokens.filter(token => {
-    return token.accessToken;
-  })[0];
-  const idToken = tokens.filter(token => {
-    return token.idToken;
-  })[0];
+
   const claims = idToken.claims;
   const html = `
   <table id="claims">

--- a/test/e2e/.babelrc
+++ b/test/e2e/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": ["@babel/preset-env"],
+  "plugins": ["@babel/plugin-transform-async-to-generator"]
 }

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -10,15 +10,17 @@
     "prestart": "yarn install",
     "start": "node ./runner"
   },
-  "dependencies": {},
+  "dependencies": {
+    "dotenv": "^8.2.0",
+    "regenerator-runtime": "^0.13.3"
+  },
   "devDependencies": {
+    "@babel/plugin-transform-async-to-generator": "^7.5.0",
     "@wdio/cli": "^5.15.1",
     "@wdio/local-runner": "^5.15.1",
     "@wdio/mocha-framework": "^5.15.1",
     "@wdio/spec-reporter": "^5.15.1",
-    "@wdio/sync": "^5.15.1",
     "chromedriver": "^77.0.0",
-    "dotenv": "^8.2.0",
     "eslint": "5.6.1",
     "eslint-plugin-jasmine": "^2.10.1",
     "wait-on": "^3.3.0",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -7,7 +7,6 @@
     "lint": "eslint .",
     "start:runner": "wdio run wdio.conf.js",
     "start:app": "yarn --cwd ../app start --open",
-    "prestart": "yarn install",
     "start": "node ./runner"
   },
   "dependencies": {

--- a/test/e2e/pageobjects/OktaHome.js
+++ b/test/e2e/pageobjects/OktaHome.js
@@ -1,0 +1,16 @@
+/* eslint-disable max-len */
+class OktaLogin {
+  get userMenu() { return $('[data-se="user-menu"] > a.link-button');}
+  get signOutBtn() { return $('[data-se="user-menu"] a[data-se="logout-link"]'); }
+
+  async signOut() {
+    await browser.waitUntil(async () => this.userMenu.then(el => el.isDisplayed()), 5000, 'wait for user menu');
+    await await this.userMenu.then(el => el.click());
+    await browser.waitUntil(async () => this.signOutBtn.then(el => el.isDisplayed()), 5000, 'wait for signout btn');
+    const url = await browser.getUrl();
+    await this.signOutBtn.then(el => el.click());
+    await browser.waitUntil(async () => browser.getUrl().then(cur => (cur !== url)), 5000, 'wait for url change');
+  }
+}
+
+export default new OktaLogin();

--- a/test/e2e/pageobjects/OktaLogin.js
+++ b/test/e2e/pageobjects/OktaLogin.js
@@ -1,20 +1,19 @@
+/* eslint-disable max-len */
 class OktaLogin {
   get signinForm() { return $('form[data-se="o-form"]');}
   get signinUsername() { return $('#okta-signin-username'); }
   get signinPassword() { return $('#okta-signin-password'); }
   get signinSubmitBtn() { return $('#okta-signin-submit'); }
 
-  signin(username, password) {
-    this.waitForLoad();
-    this.signinUsername.setValue(username);
-    this.signinPassword.setValue(password);
-    this.signinSubmitBtn.click();
+  async signin(username, password) {
+    await this.waitForLoad();
+    await this.signinUsername.then(el => el.setValue(username));
+    await this.signinPassword.then(el => el.setValue(password));
+    await this.signinSubmitBtn.then(el => el.click());
   }
 
-  waitForLoad() {
-    if(!this.signinSubmitBtn.isDisplayed()){
-      this.signinSubmitBtn.waitForDisplayed(10000);
-    }
+  async waitForLoad() {
+    return browser.waitUntil(async () => this.signinSubmitBtn.then(el => el.isDisplayed()), 5000, 'wait for signin btn');
   }
 }
 

--- a/test/e2e/pageobjects/TestApp.js
+++ b/test/e2e/pageobjects/TestApp.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import toQueryParams from '../util/toQueryParams';
 
+/* eslint-disable max-len */
 class TestApp {
   get rootSelector() { return $('#root'); }
   get readySelector() { return $('#root.rendered.loaded'); }
@@ -12,6 +13,7 @@ class TestApp {
   get getTokenBtn() { return $('#get-token'); }
   get getUserInfoBtn() { return $('#get-userinfo'); }
   get userInfo() { return $('#user-info'); }
+  get tokenError() { return $('#token-error'); }
 
   // Unauthenticated landing
   get loginRedirectBtn() { return $('#login-redirect'); }
@@ -38,101 +40,112 @@ class TestApp {
   get error() { return $('#error'); }
   get xhrError() { return $('#xhr-error'); }
 
-  open(queryObj) {
-    browser.url(toQueryParams(queryObj));
-    browser.waitUntil(() => this.readySelector.isExisting());
+  async open(queryObj) {
+    await browser.url(toQueryParams(queryObj));
+    await browser.waitUntil(async () => this.readySelector.then(el => el.isExisting()), 5000, 'wait for ready selector');
   }
 
-  loginRedirect() {
-    this.waitForLoginBtn();
-    this.loginRedirectBtn.click();
+  async loginRedirect() {
+    await this.waitForLoginBtn();
+    await this.loginRedirectBtn.then(el => el.click());
   }
 
-  handleCallback() {
-    this.waitForCallback();
-    browser.waitUntil(() => this.handleCallbackBtn.isClickable());
-    this.handleCallbackBtn.click();
+  async handleCallback() {
+    await this.waitForCallback();
+    await browser.waitUntil(async () => this.handleCallbackBtn.then(el => el.isDisplayed()), 5000, 'wait for handle callback btn');
+    await this.handleCallbackBtn.then(el => el.click());
   }
 
-  loginPopup() {
-    this.waitForLoginBtn();
-    this.loginPopupBtn.click();
+  async loginPopup() {
+    await this.waitForLoginBtn();
+    var btn = await this.loginPopupBtn;
+    await btn.click();
   }
 
-  loginDirect() {
-    this.waitForLoginBtn();
-    this.loginDirectBtn.click();
+  async loginDirect() {
+    await this.waitForLoginBtn();
+    await this.loginDirectBtn.then(el => el.click());
   }
 
-  renewToken() {
-    this.renewTokenBtn.click();
+  async renewToken() {
+    const btn = await this.renewTokenBtn;
+    await btn.click();
   }
 
-  getToken() {
-    this.getTokenBtn.click();
+  async getToken() {
+    return this.getTokenBtn.then(el => el.click());
   }
 
-  getUserInfo() {
-    browser.waitUntil(() => this.getUserInfoBtn.isClickable());
-    this.getUserInfoBtn.click();
+  async getUserInfo() {
+    await browser.waitUntil(async () => this.getUserInfoBtn.then(el => el.isDisplayed()));
+    await this.getUserInfoBtn.then(el => el.click());
   }
 
-  returnHome() {
-    browser.waitUntil(() => this.returnHomeBtn.isClickable());
-    this.returnHomeBtn.click();
-    if(!this.landingSelector.isDisplayed()){
-      this.landingSelector.waitForDisplayed(5000);
-    }
+  async returnHome() {
+    await browser.waitUntil(async () => this.returnHomeBtn.then(el => el.isDisplayed()));
+    await this.returnHomeBtn.then(el => el.click());
+    await browser.waitUntil(async () => this.landingSelector.then(el => el.isDisplayed()));
   }
 
-  logout() {
-    this.logoutBtn.click();
-    this.waitForLoginBtn();
+  async logout() {
+    await this.logoutBtn.then(el => el.click());
+    await this.waitForLoginBtn();
   }
 
-  waitForLoginBtn() {
-    if(!this.loginRedirectBtn.isDisplayed()){
-      this.loginRedirectBtn.waitForDisplayed(5000);
-    }
+  async waitForLoginBtn() {
+    return browser.waitUntil(async () => this.loginRedirectBtn.then(el => el.isDisplayed()), 5000, 'wait for login button');
   }
 
-  waitForLogoutBtn() {
-    if(!this.logoutBtn.isDisplayed()){
-      this.logoutBtn.waitForDisplayed(5000);
-    }
+  async waitForLogoutBtn() {
+    return browser.waitUntil(async () => this.logoutBtn.then(el => el.isDisplayed()), 5000, 'wait for logout button');
   }
 
-  waitForCallback() {
-    browser.waitUntil(() => this.callbackSelector.isExisting());
+  async waitForCallback() {
+    return browser.waitUntil(async () => this.callbackSelector.then(el => el.isExisting()), 5000, 'wait for callback');
   }
 
-  waitForCallbackResult() {
-    browser.waitUntil(() => this.callbackHandledSelector.isExisting());
+  async waitForCallbackResult() {
+    return browser.waitUntil(async () => this.callbackHandledSelector.then(el => el.isExisting()), 5000, 'wait for callback result');
   }
 
-  waitForUserInfo() {
-    if(!this.userInfo.isDisplayed()){
-      this.userInfo.waitForDisplayed(10000);
-    }
-  }
-  assertCallbackSuccess() {
-    this.waitForCallbackResult();
-    assert(this.success.getText() !== '');
-    assert(this.error.getText() === '');
-    assert(this.xhrError.getText() === '');
-    assert(this.accessToken.getText().indexOf('expiresAt') > 0);
-    assert(this.idToken.getText().indexOf('claims') > 0);
+  async waitForUserInfo() {
+    return browser.waitUntil(async () => this.userInfo.then(el => el.isDisplayed()), 5000, 'wait for user info');
   }
 
-  assertLoggedIn() {
-    this.waitForLogoutBtn();
-    assert(this.accessToken.getText().indexOf('expiresAt') > 0);
-    assert(this.idToken.getText().indexOf('claims') > 0);
+  async assertCallbackSuccess() {
+    await this.waitForCallbackResult();
+    await this.success.then(el => el.getText()).then(txt => {
+      assert(txt !== '');
+    });
+    await this.error.then(el => el.getText()).then(txt => {
+      assert(txt === '');
+    });
+    await this.xhrError.then(el => el.getText()).then(txt => {
+      assert(txt === '');
+    });
+    await this.accessToken.then(el => el.getText()).then(txt => {
+      assert(txt.indexOf('expiresAt') > 0);
+    });
+    await this.idToken.then(el => el.getText()).then(txt => {
+      assert(txt.indexOf('claims') > 0);
+    });
   }
 
-  assertUserInfo() {
-    this.waitForUserInfo();
-    assert(this.userInfo.getText().indexOf('email') > 0);
+  async assertLoggedIn() {
+    await this.waitForLogoutBtn();
+    await this.accessToken.then(btn => btn.getText()).then(txt => {
+      assert(txt.indexOf('expiresAt') > 0);
+    });
+    await this.idToken.then(btn => btn.getText()).then(txt => {
+      assert(txt.indexOf('claims') > 0);
+    });
+  }
+
+  async assertUserInfo() {
+    await this.waitForUserInfo();
+    await this.userInfo.then(el => el.getText()).then(txt => {
+      assert(txt.indexOf('email') > 0);
+    });
   }
 }
 

--- a/test/e2e/specs/login.js
+++ b/test/e2e/specs/login.js
@@ -3,32 +3,32 @@ import { flows, openImplicit, openPKCE } from '../util/appUtils';
 import { loginRedirect, loginPopup, loginDirect } from '../util/loginUtils';
 
 describe('E2E login', () => {
-  afterEach(() => {
-    TestApp.logout();
-  });
 
   flows.forEach(flow => {
     describe(flow + ' flow', () => {
-      beforeEach(() => {
-        (flow === 'pkce') ? openPKCE() : openImplicit();
+      beforeEach(async () => {
+        (flow === 'pkce') ? await openPKCE() : await openImplicit();
       });
 
-      it('can login using redirect', () => {
-        loginRedirect(flow);
-        TestApp.getUserInfo();
-        TestApp.assertUserInfo();
+      it('can login using redirect', async () => {
+        await loginRedirect(flow);
+        await TestApp.getUserInfo();
+        await TestApp.assertUserInfo();
+        await TestApp.logout();
       });
 
-      it('can login using a popup window', () => {
-        loginPopup(flow);
-        TestApp.getUserInfo();
-        TestApp.assertUserInfo();
+      it('can login using a popup window', async() => {
+        await loginPopup(flow);
+        await TestApp.getUserInfo();
+        await TestApp.assertUserInfo();
+        await TestApp.logout();
       });
 
-      it('can login directly, calling signin() with username and password', () => {
-        loginDirect(flow);
-        TestApp.getUserInfo();
-        TestApp.assertUserInfo();
+      it('can login directly, calling signin() with username and password', async () => {
+        await loginDirect(flow);
+        await TestApp.getUserInfo();
+        await TestApp.assertUserInfo();
+        await TestApp.logout();
       });
     });
   });

--- a/test/e2e/util/appUtils.js
+++ b/test/e2e/util/appUtils.js
@@ -6,18 +6,30 @@ const CLIENT_ID = process.env.CLIENT_ID;
 
 const flows = ['implicit', 'pkce'];
 
-function openImplicit() {
-  TestApp.open({ issuer: ISSUER, clientId: CLIENT_ID });
-  assert(TestApp.pkceOption.isSelected() === false);
-  assert(TestApp.issuer.getValue() === ISSUER);
-  assert(TestApp.clientId.getValue() === CLIENT_ID);
+async function openImplicit() {
+  await TestApp.open({ issuer: ISSUER, clientId: CLIENT_ID });
+  await TestApp.pkceOption.then(el => el.isSelected()).then(isSelected => {
+    assert(isSelected === false);
+  });
+  await TestApp.issuer.then(el => el.getValue()).then(value => {
+    assert(value === ISSUER);
+  });
+  await TestApp.clientId.then(el => el.getValue()).then(value => {
+    assert(value === CLIENT_ID);
+  });
 }
 
-function openPKCE() {
-  TestApp.open({ issuer: ISSUER, clientId: CLIENT_ID, pkce: true });
-  assert(TestApp.pkceOption.isSelected());
-  assert(TestApp.issuer.getValue() === ISSUER);
-  assert(TestApp.clientId.getValue() === CLIENT_ID);
+async function openPKCE() {
+  await TestApp.open({ issuer: ISSUER, clientId: CLIENT_ID, pkce: true });
+  await TestApp.pkceOption.then(el => el.isSelected()).then(isSelected => {
+    assert(isSelected);
+  });
+  await TestApp.issuer.then(el => el.getValue()).then(val => {
+    assert(val === ISSUER);
+  });
+  await TestApp.clientId.then(el => el.getValue()).then(val => {
+    assert(val === CLIENT_ID);
+  });
 }
 
 export { flows, openImplicit, openPKCE };

--- a/test/e2e/util/browserUtils.js
+++ b/test/e2e/util/browserUtils.js
@@ -1,11 +1,26 @@
-function switchToPopupWindow() {
-  browser.waitUntil(() => browser.getWindowHandles().length > 1);
-  browser.switchToWindow(browser.getWindowHandles()[1]);
+
+const URL = require('url');
+const ISSUER = process.env.ISSUER;
+const issuer = URL.parse(ISSUER);
+const BASE_URL = issuer.protocol + issuer.host;
+
+async function openOktaHome() {
+  return browser.newWindow(BASE_URL, 'Okta signin page');
 }
 
-function switchToMainWindow() {
-  browser.switchToWindow(browser.getWindowHandles()[0]);
+async function switchToPopupWindow() {
+  await browser.waitUntil(async () => {
+    const handles = await browser.getWindowHandles();
+    return handles.length > 1;
+  });
+  const handles = await browser.getWindowHandles();
+  return browser.switchToWindow(handles[handles.length - 1]);
 }
 
-export { switchToMainWindow, switchToPopupWindow };
+async function switchToMainWindow() {
+  const handles = await browser.getWindowHandles();
+  return browser.switchToWindow(handles[0]);
+}
+
+export { openOktaHome, switchToMainWindow, switchToPopupWindow };
   

--- a/test/e2e/util/loginUtils.js
+++ b/test/e2e/util/loginUtils.js
@@ -16,34 +16,34 @@ function assertImplicit(url) {
   assert(hash.indexOf('id_token' > 0));
 }
 
-function handleCallback(flow) {
-  TestApp.waitForCallback();
-  const url = browser.getUrl();
+async function handleCallback(flow) {
+  await TestApp.waitForCallback();
+  const url = await browser.getUrl();
   (flow === 'pkce') ? assertPKCE(url) : assertImplicit(url);
-  TestApp.handleCallback();
-  TestApp.assertCallbackSuccess();
-  TestApp.returnHome();
+  await TestApp.handleCallback();
+  await TestApp.assertCallbackSuccess();
+  await TestApp.returnHome();
   return url;
 }
 
-function loginPopup() {
-  TestApp.loginPopup();
-  switchToPopupWindow();
-  OktaLogin.signin(USERNAME, PASSWORD);
-  switchToMainWindow();
-  TestApp.assertLoggedIn();
+async function loginPopup() {
+  await TestApp.loginPopup();
+  await switchToPopupWindow();
+  await OktaLogin.signin(USERNAME, PASSWORD);
+  await switchToMainWindow();
+  await TestApp.assertLoggedIn();
 }
 
-function loginRedirect(flow) {
-  TestApp.loginRedirect();
-  OktaLogin.signin(USERNAME, PASSWORD);
+async function loginRedirect(flow) {
+  await TestApp.loginRedirect();
+  await OktaLogin.signin(USERNAME, PASSWORD);
   return handleCallback(flow);
 }
 
-function loginDirect(flow) {
-  TestApp.username.setValue(USERNAME);
-  TestApp.password.setValue(PASSWORD);
-  TestApp.loginDirect();
+async function loginDirect(flow) {
+  await TestApp.username.then(el => el.setValue(USERNAME));
+  await TestApp.password.then(el => el.setValue(PASSWORD));
+  await TestApp.loginDirect();
   return handleCallback(flow);
 }
 export { loginDirect, loginPopup, loginRedirect };

--- a/test/e2e/wdio.conf.js
+++ b/test/e2e/wdio.conf.js
@@ -1,4 +1,5 @@
 require('@babel/register'); // Allows use of import module syntax
+require('regenerator-runtime'); // Allows use of async/await
 
 const dotenv = require('dotenv');
 const fs = require('fs');
@@ -29,7 +30,8 @@ if (CI) {
 
 exports.config = {
     jasmineNodeOpts: {
-        defaultTimeoutInterval
+        defaultTimeoutInterval,
+        stopSpecOnExpectationFailure: true
     },
 
     //

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,16 +1168,6 @@
     easy-table "^1.1.1"
     pretty-ms "^5.0.0"
 
-"@wdio/sync@^5.15.1":
-  version "5.15.7"
-  resolved "https://registry.yarnpkg.com/@wdio/sync/-/sync-5.15.7.tgz#b5bafe474c762585e990142bf32657b40415af16"
-  integrity sha512-gfzSVrrxgbRvLlsuRmqF7XeaBujk8vpVbODd3RWIK9/TVJ7JFkro5Yy03OcY6bMRzNhwE16jY3MS9TUoPG9mVw==
-  dependencies:
-    "@wdio/logger" "5.13.2"
-  optionalDependencies:
-    fibers "^4.0.1"
-    fibers_node_v8 "^3.1.2"
-
 "@wdio/utils@5.15.1":
   version "5.15.1"
   resolved "https://registry.yarnpkg.com/@wdio/utils/-/utils-5.15.1.tgz#00e76c5415d8269845fbadd1617755b2b4a0ebd1"
@@ -3491,7 +3481,7 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-detect-libc@^1.0.2, detect-libc@^1.0.3:
+detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -4337,20 +4327,6 @@ fd-slicer@~1.0.1:
   integrity sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=
   dependencies:
     pend "~1.2.0"
-
-fibers@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/fibers/-/fibers-4.0.2.tgz#d04f9ccd0aba179588202202faeb4fed65d497f5"
-  integrity sha512-FhICi1K4WZh9D6NC18fh2ODF3EWy1z0gzIdV9P7+s2pRjfRBnCkMDJ6x3bV1DkVymKH8HGrQa/FNOBjYvnJ/tQ==
-  dependencies:
-    detect-libc "^1.0.3"
-
-fibers_node_v8@^3.1.2:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/fibers_node_v8/-/fibers_node_v8-3.1.5.tgz#354b481239e58a1c70eb4bde96c6e459a1e49554"
-  integrity sha512-jcut+gL68TclewWH/9si73yDhFOzu8LhmWg6SZRBw13rk4+7DCtqOMdsBhAyXaWRjI7c1XqcRp4AgebLJnvfCQ==
-  dependencies:
-    detect-libc "^1.0.3"
 
 figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -8656,6 +8632,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"


### PR DESCRIPTION
- Adds e2e tests for the scenario where a user has logged from the okta user home page. In this case, attempting to renew a token should give us an error, and we can recognize that the user is no longer authenticated
- Fix for some flakiness in e2e test harness app (apparently) caused by the use of `h1` and `h2` tags. This is probably related to margin-collapse. These tags have been removed.
- Converts e2e specs to `async/await` syntax. This makes more sense for debugging and removes some "magic". We also seem to get better error stacks.