### PR TITLE
Fix lint and unit tests on bacon

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "yarn test:unit && yarn test:e2e",
     "test:e2e": "yarn --cwd test/e2e start",
     "test:unit": "yarn workspace @okta/okta-auth-js test",
-    "test:report": "yarn test --ci --silent || true",
+    "test:report": "yarn test:unit --ci --silent || true",
     "prepare": "yarn build",
     "start": "yarn --cwd test/app start --open"
   },

--- a/packages/okta-auth-js/jest.browser.js
+++ b/packages/okta-auth-js/jest.browser.js
@@ -2,7 +2,7 @@ var packageJson = require('./package.json');
 var OktaAuth = '<rootDir>/' + packageJson.browser;
 
 module.exports = {
-  'coverageDirectory': './build2/reports/coverage',
+  'coverageDirectory': '<rootDir>/build2/reports/coverage',
   'restoreMocks': true,
   'moduleNameMapper': {
     '^OktaAuth(.*)$': OktaAuth

--- a/packages/okta-auth-js/jest.server.js
+++ b/packages/okta-auth-js/jest.server.js
@@ -2,7 +2,7 @@ var packageJson = require('./package.json');
 var OktaAuth = '<rootDir>/' + packageJson.main;
 
 module.exports = {
-  'coverageDirectory': './build2/reports/coverage',
+  'coverageDirectory': '<rootDir>/build2/reports/coverage',
   'restoreMocks': true,
   'moduleNameMapper': {
     '^OktaAuth(.*)$': OktaAuth

--- a/packages/okta-auth-js/karma.conf.js
+++ b/packages/okta-auth-js/karma.conf.js
@@ -15,7 +15,8 @@
 
 /* global __dirname */
 var path = require('path');
-var REPORTS_DIR = path.join(__dirname, 'build2', 'reports', 'karma');
+var ROOT_DIR = path.resolve(__dirname, '..', '..');
+var REPORTS_DIR = path.join(ROOT_DIR, 'build2', 'reports', 'karma');
 var webpackConf = {
   devtool: 'inline-source-map',
   module: {

--- a/packages/okta-auth-js/package.json
+++ b/packages/okta-auth-js/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "lint:report": "eslint -f checkstyle -o build2/reports/lint/eslint-checkstyle-result.xml .",
+    "lint:report": "eslint -f checkstyle -o ../../build2/reports/lint/eslint-checkstyle-result.xml .",
     "test": "yarn test:karma && yarn test:browser && yarn test:server",
     "test:karma": "karma start --single-run",
     "test:browser": "jest --config ./jest.browser.js",
@@ -76,6 +76,7 @@
     "PKCE_STORAGE_NAME": "okta-pkce-storage"
   },
   "jest-junit": {
-    "output": "./build2/reports/unit/junit-result.xml"
+    "outputDirectory": "../../build2/reports/unit/",
+    "outputName": "junit-result.xml"
   }
 }

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/bin/bash -xe
 
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 
 export TEST_SUITE_TYPE="checkstyle"
 export TEST_RESULT_FILE_DIR="${REPO}/build2"
 
-if ! yarn lint:report; then
+if ! yarn workspace @okta/okta-auth-js lint:report; then
   echo "lint failed! Exiting..."
   exit ${TEST_FAILURE}
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -xe
 
 cd ${OKTA_HOME}/${REPO}
 
@@ -17,10 +17,14 @@ OKTA_REGISTRY=${ARTIFACTORY_URL}/api/npm/npm-okta-master
 # Replace yarn artifactory with Okta's
 sed -i "s#${YARN_REGISTRY}#${OKTA_REGISTRY}#g" yarn.lock
 
-if ! yarn install; then
+# Install dependences. --ignore-scripts will prevent chromedriver from attempting to install
+if ! yarn install --frozen-lockfile --ignore-scripts; then
   echo "yarn install failed! Exiting..."
   exit ${FAILED_SETUP}
 fi
+
+# Build config
+yarn workspace @okta/okta-auth-js prepare
 
 # Revert the origional change
 # sed -i "s#${OKTA_REGISTRY}#${YARN_REGISTRY}#" yarn.lock

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -17,7 +17,7 @@
     "@wdio/mocha-framework": "^5.15.1",
     "@wdio/spec-reporter": "^5.15.1",
     "@wdio/sync": "^5.15.1",
-    "chromedriver": "^77.0.0",
+    "chromedriver": "^78.0.0",
     "dotenv": "^8.2.0",
     "eslint": "5.6.1",
     "eslint-plugin-jasmine": "^2.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2496,10 +2496,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^77.0.0:
-  version "77.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-77.0.0.tgz#bd916cc87a0ccb7a6e4fb4b43cb2368bc54db6a0"
-  integrity sha512-mZa1IVx4HD8rDaItWbnS470mmypgiWsDiu98r0NkiT4uLm3qrANl4vOU6no6vtWtLQiW5kt1POcIbjeNpsLbXA==
+chromedriver@^78.0.0:
+  version "78.0.1"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-78.0.1.tgz#2db3425a2cba6fcaf1a41d9538b16c3d06fa74a8"
+  integrity sha512-eOsyFk4xb9EECs1VMrDbxO713qN+Bu1XUE8K9AuePc3839TPdAegg72kpXSzkeNqRNZiHbnJUItIVCLFkDqceA==
   dependencies:
     del "^4.1.1"
     extract-zip "^1.6.7"


### PR DESCRIPTION
- Outputs reports to the top-level `build2` directory (rather than inside `packages/okta-auth-js`)
- Avoids installing chromedriver when running only unit tests on bacon