### PR TITLE
Fix for popup blocker

### DIFF
--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -467,12 +467,15 @@ function getToken(sdk, oauthOptions, options) {
         var popupDeferred = Q.defer();
         /* eslint-disable-next-line no-case-declarations, no-inner-declarations */
         function hasClosed(win) {
-          if (win.closed) {
+          if (!win || win.closed) {
             popupDeferred.reject(new AuthSdkError('Unable to parse OAuth flow response'));
+            return true;
           }
         }
         var closePoller = setInterval(function() {
-          hasClosed(windowEl);
+          if (hasClosed(windowEl)) {
+            clearInterval(closePoller);
+          }
         }, 500);
 
         // Proxy the promise results into the deferred
@@ -489,8 +492,8 @@ function getToken(sdk, oauthOptions, options) {
             return handleOAuthResponse(sdk, oauthParams, res, urls);
           })
           .fin(function() {
-            if (!windowEl.closed) {
-              clearInterval(closePoller);
+            clearInterval(closePoller);
+            if (windowEl && !windowEl.closed) {
               windowEl.close();
             }
           });

--- a/packages/okta-auth-js/test/spec/tokenManager.js
+++ b/packages/okta-auth-js/test/spec/tokenManager.js
@@ -430,7 +430,9 @@ describe('TokenManager', function() {
     beforeEach(function() {
       jest.useFakeTimers();
     });
-
+    afterEach(function() {
+      jest.useRealTimers();
+    });
     it('automatically renews a token by default', function() {
       var expiresAt = tokens.standardIdTokenParsed.expiresAt;
       return oauthUtil.setupFrame({


### PR DESCRIPTION
- behavior is seen on firefox, not chrome. Popup blocker leaves us with an "undefined" window object
- fix potential infinite loop with closePoller() - polling will stop as soon as window is closed or promise is resolved. The promise should only reject one time.
- add test for popup block case
- add test for popup timeout 

Fixes: https://github.com/okta/okta-auth-js/issues/221