### PR TITLE
fix: SDK_VERSION for server

### DIFF
--- a/packages/okta-auth-js/jest.server.js
+++ b/packages/okta-auth-js/jest.server.js
@@ -1,12 +1,8 @@
 var packageJson = require('./package.json');
 var OktaAuth = '<rootDir>/' + packageJson.main;
-var SDK_VERSION = require('./package.json').version;
 
 module.exports = {
   'coverageDirectory': '<rootDir>/build2/reports/coverage',
-  'globals': {
-    SDK_VERSION: SDK_VERSION
-  },
   'restoreMocks': true,
   'moduleNameMapper': {
     '^OktaAuth(.*)$': OktaAuth

--- a/packages/okta-auth-js/lib/browser/browser.js
+++ b/packages/okta-auth-js/lib/browser/browser.js
@@ -11,6 +11,8 @@
  */
 /* eslint-disable complexity */
 /* eslint-disable max-statements */
+/* SDK_VERSION is defined in webpack config */ 
+/* global SDK_VERSION */
 
 require('../vendor/polyfills');
 
@@ -52,7 +54,7 @@ function OktaAuthBuilder(args) {
     throw new AuthSdkError('This browser doesn\'t support PKCE');
   }
 
-  this.userAgent = 'okta-auth-js-' + constants.SDK_VERSION;
+  this.userAgent = 'okta-auth-js-' + SDK_VERSION;
 
   // Digital clocks will drift over time, so the server
   // can misalign with the time reported by the browser.

--- a/packages/okta-auth-js/lib/constants.js
+++ b/packages/okta-auth-js/lib/constants.js
@@ -1,6 +1,3 @@
-/* SDK_VERSION is defined in webpack config */ 
-/* global SDK_VERSION */
-
 module.exports = {
   'STATE_TOKEN_KEY_NAME': 'oktaStateToken',
   'DEFAULT_POLLING_DELAY': 500,
@@ -11,6 +8,5 @@ module.exports = {
   'REDIRECT_NONCE_COOKIE_NAME': 'okta-oauth-nonce',
   'TOKEN_STORAGE_NAME': 'okta-token-storage',
   'CACHE_STORAGE_NAME': 'okta-cache-storage',
-  'PKCE_STORAGE_NAME': 'okta-pkce-storage',
-  'SDK_VERSION': SDK_VERSION
+  'PKCE_STORAGE_NAME': 'okta-pkce-storage'
 };

--- a/packages/okta-auth-js/lib/server/server.js
+++ b/packages/okta-auth-js/lib/server/server.js
@@ -15,7 +15,7 @@
 require('../vendor/polyfills');
 
 var builderUtil       = require('../builderUtil');
-var constants         = require('../constants');
+var SDK_VERSION       = require('../../package.json').version;
 var storage           = require('./serverStorage').storage;
 var tx                = require('../tx');
 var util              = require('../util');
@@ -31,7 +31,7 @@ function OktaAuthBuilder(args) {
     headers: args.headers
   };
 
-  this.userAgent = 'okta-auth-js-server' + constants.SDK_VERSION;
+  this.userAgent = 'okta-auth-js-server' + SDK_VERSION;
 
   sdk.tx = {
     status: util.bind(tx.transactionStatus, null, sdk),


### PR DESCRIPTION
- removes SDK_VERSION from the set of "constants"
- for browser bundle, use a global variable set by webpack
- for server entry, read from package json