### PR TITLE
Add "onSessionExpired" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.11.2
+
+### Features
+
+- [#271](https://github.com/okta/okta-auth-js/pull/271) - New option `onSessionExpired`
+
 ## 2.11.1
 
 ### Other

--- a/packages/okta-auth-js/lib/TokenManager.js
+++ b/packages/okta-auth-js/lib/TokenManager.js
@@ -16,7 +16,6 @@ var util = require('./util');
 var AuthSdkError = require('./errors/AuthSdkError');
 var storageUtil = require('./browser/browserStorage');
 var Q = require('q');
-var Emitter = require('tiny-emitter');
 var constants = require('./constants');
 var storageBuilder = require('./storageBuilder');
 var SdkClock = require('./clock');
@@ -184,6 +183,8 @@ function renew(sdk, tokenMgmtRef, storage, key) {
     .catch(function(err) {
       if (err.name === 'OAuthError' || err.name === 'AuthSdkError') {
         remove(tokenMgmtRef, storage, key);
+        err.tokenKey = key;
+        err.accessToken = !!token.accessToken;
         emitError(tokenMgmtRef, err);
       }
       throw err;
@@ -242,7 +243,7 @@ function TokenManager(sdk, options) {
   var tokenMgmtRef = {
     clock: clock,
     options: options,
-    emitter: new Emitter(),
+    emitter: sdk.emitter,
     expireTimeouts: {},
     renewPromise: {}
   };

--- a/packages/okta-auth-js/package.json
+++ b/packages/okta-auth-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "lib/server/serverIndex.js",

--- a/test/app/src/testApp.js
+++ b/test/app/src/testApp.js
@@ -36,6 +36,7 @@ const Footer = `
 
 const Layout = `
   <div id="layout">
+    <div id="session-expired" style="color: orange"></div>
     <div id="token-error" style="color: red"></div>
     <div id="token-msg" style="color: green"></div>
     <div id="page-content"></div>
@@ -78,6 +79,9 @@ function bindFunctions(testApp, window) {
 
 function TestApp(config) {
   this.config = config;
+  Object.assign(this.config, {
+    onSessionExpired: this._onSessionExpired.bind(this)
+  });
 }
 
 export default TestApp;
@@ -113,6 +117,9 @@ Object.assign(TestApp.prototype, {
   },
   _onTokenError: function(error) {
     document.getElementById('token-error').innerText = error;
+  },
+  _onSessionExpired: function() {
+    document.getElementById('session-expired').innerText = 'SESSION EXPIRED';
   },
   bootstrapCallback: async function() {
     const content = `
@@ -222,7 +229,7 @@ Object.assign(TestApp.prototype, {
     });
   },
   renewToken: async function() {
-    return this.oktaAuth.tokenManager.renew('idToken')
+    return this.oktaAuth.tokenManager.renew('accessToken')
       .then(() => {
         this.render();
       });

--- a/test/e2e/pageobjects/TestApp.js
+++ b/test/e2e/pageobjects/TestApp.js
@@ -17,9 +17,11 @@ class TestApp {
   get clearTokensBtn() { return $('#clear-tokens'); }
   get getUserInfoBtn() { return $('#get-userinfo'); }
   get userInfo() { return $('#user-info'); }
+  get sessionExpired() { return $('#session-expired'); }
+  
   get tokenError() { return $('#token-error'); }
   get tokenMsg() { return $('#token-msg'); }
-
+  
   // Unauthenticated landing
   get loginRedirectBtn() { return $('#login-redirect'); }
   get loginPopupBtn() { return $('#login-popup'); }

--- a/test/e2e/specs/tokens.js
+++ b/test/e2e/specs/tokens.js
@@ -43,12 +43,12 @@ describe('E2E token flows', () => {
         (flow === 'pkce') ? await openPKCE() : await openImplicit();
       });
 
-      it('can renew the id token', async () => {
+      it('can renew the access token', async () => {
         await loginPopup(flow);
-        const prevToken = await TestApp.idToken.then(el => el.getText());
+        const prevToken = await TestApp.accessToken.then(el => el.getText());
         await TestApp.renewToken();
         await browser.waitUntil(async () => {
-          const txt = await TestApp.idToken.then(el => el.getText());
+          const txt = await TestApp.accessToken.then(el => el.getText());
           return txt !== prevToken;
         }, 10000);
         await TestApp.assertLoggedIn();
@@ -89,6 +89,9 @@ describe('E2E token flows', () => {
         }, 10000, 'wait for token error');
         await TestApp.tokenError.then(el => el.getText()).then(msg => {
           assert(msg.trim() === 'OAuthError: The client specified not to prompt, but the user is not logged in.');
+        });
+        await TestApp.sessionExpired.then(el => el.getText()).then(txt => {
+          assert(txt === 'SESSION EXPIRED');
         });
         await browser.refresh();
         await TestApp.waitForLoginBtn(); // assert we are logged out

--- a/test/support/util.js
+++ b/test/support/util.js
@@ -370,6 +370,17 @@ util.expectErrorToEqual = function (actual, expected) {
     expect(actual.errorId).toBeUndefined();
     expect(actual.errorCauses).toBeUndefined();
   }
+  if (expected.tokenKey) {
+    expect(actual.tokenKey).toEqual(expected.tokenKey);
+  } else {
+    expect(actual.tokenKey).toBeUndefined();
+  }
+
+  if (typeof expected.accessToken !== 'undefined') {
+    expect(actual.accessToken).toEqual(expected.accessToken);
+  } else {
+    expect(actual.accessToken).toBeUndefined();
+  }
 };
 
 util.assertAuthSdkError = function (err, message) {


### PR DESCRIPTION
- top-level sdk instance will listen to error events from token manager:
- error handling for "login_required" error with accessToken will call method `onSessionExpired` if passed in options