### PR TITLE
release: 2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.10.1
+
+### Other
+
+- Fixes incorrect npm publish of previous version
+
 ## 2.10.0
 
 ### Features

--- a/packages/okta-auth-js/.npmignore
+++ b/packages/okta-auth-js/.npmignore
@@ -5,4 +5,5 @@ build2
 .travis.yml
 ci-scripts
 webpack*config.js
+karma*conf.js
 scripts

--- a/packages/okta-auth-js/package.json
+++ b/packages/okta-auth-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "lib/server/serverIndex.js",


### PR DESCRIPTION
Moving .npmignore to packages/okta-auth-js (where publish occurs)