### PR TITLE
test app: support IE edge

### DIFF
--- a/test/app/package.json
+++ b/test/app/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@webpack-cli/serve": "^0.1.5",
     "source-map-loader": "^0.2.4",
+    "text-encoding": "^0.7.0",
     "webpack-cli": "^3.3.0",
     "webpack-dev-server": "^3.2.1"
   }

--- a/test/app/src/config.js
+++ b/test/app/src/config.js
@@ -1,7 +1,8 @@
 /* global window, URL, localStorage, process */
 import { CALLBACK_PATH, STORAGE_KEY } from './constants';
 const HOST = window.location.host;
-const REDIRECT_URI = `http://${HOST}${CALLBACK_PATH}`;
+const PROTO = window.location.protocol;
+const REDIRECT_URI = `${PROTO}//${HOST}${CALLBACK_PATH}`;
 
 function getDefaultConfig() {
   const ISSUER = process.env.ISSUER;

--- a/test/app/src/webpackEntry.js
+++ b/test/app/src/webpackEntry.js
@@ -1,5 +1,12 @@
 /* entry point for SPA application */
 /* global window, document */
+
+// polyfill TextEncoder for IE Edge
+import { TextEncoder } from 'text-encoding';
+if (typeof window.TextEncoder === 'undefined') {
+  window.TextEncoder = TextEncoder;
+}
+
 import TestApp from './testApp';
 import { getDefaultConfig, getConfigFromUrl, getConfigFromStorage, clearStorage } from './config';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9851,6 +9851,11 @@ test-exclude@^5.2.3:
     read-pkg-up "^4.0.0"
     require-main-filename "^2.0.0"
 
+text-encoding@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
+  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
+
 text-extensions@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"


### PR DESCRIPTION
Adds a polyfill/shim for `TextEncoder` to the test app. This unbreaks PKCE flow in IE edge.