### PR TITLE
signOut: clear TokenManager and provide options for revoke and redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "publish": "lerna publish --skip-npm",
     "test": "yarn test:unit && yarn test:e2e",
     "test:e2e": "yarn --cwd test/e2e start",
+    "test:browser": "yarn workspace @okta/okta-auth-js test:browser",
+    "test:server": "yarn workspace @okta/okta-auth-js test:server",
     "test:unit": "yarn workspace @okta/okta-auth-js test",
     "test:report": "yarn test:unit --ci --silent || true",
     "prepare": "yarn build",

--- a/packages/okta-auth-js/lib/browser/browser.js
+++ b/packages/okta-auth-js/lib/browser/browser.js
@@ -42,8 +42,11 @@ function OktaAuthBuilder(args) {
     authorizeUrl: util.removeTrailingSlash(args.authorizeUrl),
     userinfoUrl: util.removeTrailingSlash(args.userinfoUrl),
     tokenUrl: util.removeTrailingSlash(args.tokenUrl),
+    revokeUrl: util.removeTrailingSlash(args.revokeUrl),
+    logoutUrl: util.removeTrailingSlash(args.logoutUrl),
     pkce: usePKCE,
     redirectUri: args.redirectUri,
+    postLogoutRedirectUri: args.postLogoutRedirectUri,
     httpRequestClient: args.httpRequestClient,
     storageUtil: args.storageUtil,
     transformErrorXHR: args.transformErrorXHR,
@@ -115,6 +118,7 @@ function OktaAuthBuilder(args) {
     getWithRedirect: util.bind(token.getWithRedirect, null, sdk),
     parseFromUrl: util.bind(token.parseFromUrl, null, sdk),
     decode: token.decodeToken,
+    revoke: util.bind(token.revokeToken, null, sdk),
     renew: util.bind(token.renewToken, null, sdk),
     getUserInfo: util.bind(token.getUserInfo, null, sdk),
     verify: util.bind(token.verifyToken, null, sdk)
@@ -202,8 +206,105 @@ proto.signIn = function (opts) {
   });
 };
 
-proto.signOut = function () {
-  return this.session.close();
+// Ends the current application session, clearing all local tokens
+// Optionally revokes the access token
+// Ends the user's Okta session using the API or redirect method
+proto.signOut = function (options) {
+  options = util.extend({}, options);
+
+  // postLogoutRedirectUri must be whitelisted in Okta Admin UI
+  var postLogoutRedirectUri = options.postLogoutRedirectUri || this.options.postLogoutRedirectUri;
+
+  var accessToken = options.accessToken;
+  var revokeAccessToken = options.revokeAccessToken;
+  var idToken = options.idToken;
+
+  var sdk = this;
+  var logoutUrl = oauthUtil.getOAuthUrls(sdk).logoutUrl;
+
+  function getAccessToken() {
+    return new Q()
+    .then(function() {
+      if (revokeAccessToken && typeof accessToken === 'undefined') {
+        return sdk.tokenManager.get('token');
+      }
+      return accessToken;
+    });
+  }
+
+  function getIdToken() {
+    return new Q()
+    .then(function() {
+      if (postLogoutRedirectUri && typeof idToken === 'undefined') {
+        return sdk.tokenManager.get('idToken');
+      }
+      return idToken;
+    });
+  }
+
+  function closeSession() {
+    return sdk.session.close() // DELETE /api/v1/sessions/me
+    .catch(function(e) {
+      if (e.name === 'AuthApiError') {
+        // Most likely cause is session does not exist or has already been closed
+        // Could also be a network error. Nothing we can do here.
+        return;
+      }
+      throw e;
+    });
+  }
+
+  return Q.allSettled([getAccessToken(), getIdToken()])
+    .then(function(tokens) {
+      accessToken = tokens[0].value;
+      idToken = tokens[1].value;
+
+      // Clear all local tokens
+      sdk.tokenManager.clear();
+
+      if (revokeAccessToken && accessToken) {
+        return sdk.token.revoke(accessToken)
+        .catch(function(e) {
+          if (e.name === 'AuthApiError') {
+            // Capture and ignore network errors
+            return;
+          }
+          throw e;
+        });
+      }
+    })
+    .then(function() {
+      // XHR signOut method
+      if (!postLogoutRedirectUri) {
+        return closeSession();
+      }
+
+      // No idToken? This can happen if the storage was cleared.
+      // Fallback to XHR signOut, then redirect to the post logout uri
+      if (!idToken) {
+        return closeSession()
+        .catch(function(err) {
+          // eslint-disable-next-line no-console
+          console.log('Unhandled exception while closing session', err);
+        })
+        .then(function() {
+          window.location.assign(postLogoutRedirectUri);
+        });
+      }
+
+      // logout redirect using the idToken.
+      var state = options.state;
+      var idTokenHint = idToken.idToken; // a string
+      var logoutUri = logoutUrl + '?id_token_hint=' + encodeURIComponent(idTokenHint) +
+        '&post_logout_redirect_uri=' + encodeURIComponent(postLogoutRedirectUri);
+    
+      // State allows option parameters to be passed to logout redirect uri
+      if (state) {
+        logoutUri += '&state=' + encodeURIComponent(state);
+      }
+      
+      window.location.assign(logoutUri);
+    });
 };
 
 builderUtil.addSharedPrototypes(proto);

--- a/packages/okta-auth-js/lib/util.js
+++ b/packages/okta-auth-js/lib/util.js
@@ -259,9 +259,9 @@ util.removeTrailingSlash = function(path) {
   }
   // Remove any whitespace before or after string
   var trimmed = path.replace(/^\s+|\s+$/gm,'');
-  if (trimmed.slice(-1) === '/') {
-    return trimmed.slice(0, -1);
-  }
+  // Remove trailing slash(es)
+  trimmed = trimmed.replace(/\/+$/, '');
+
   return trimmed;
 };
 

--- a/packages/okta-auth-js/test/spec/browser.js
+++ b/packages/okta-auth-js/test/spec/browser.js
@@ -1,19 +1,17 @@
 var OktaAuth = require('../../lib/browser/browserIndex');
-
+var AuthApiError = require('../../lib/errors/AuthApiError');
 
 describe('Browser', function() {
-
+  var auth;
+  beforeEach(function() {
+    auth = new OktaAuth({ url: 'http://my-okta-domain' });
+  });
 
   it('is a valid constructor', function() {
-    var auth = new OktaAuth({ url: 'http://localhost/fake' });
     expect(auth instanceof OktaAuth).toBe(true);
   });
 
   describe('options', function() {
-    var auth;
-    beforeEach(function() {
-      auth = new OktaAuth({ url: 'http://localhost/fake' });
-    });
 
     describe('PKCE', function() {
 
@@ -23,20 +21,20 @@ describe('Browser', function() {
 
       it('can be set by arg', function() {
         spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(true);
-        auth = new OktaAuth({ pkce: true, url: 'http://localhost/fake' });
+        auth = new OktaAuth({ pkce: true, url: 'http://my-okta-domain' });
         expect(auth.options.pkce).toBe(true);
       });
 
       it('accepts alias "grantType"', function() {
         spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(true);
-        auth = new OktaAuth({ grantType: "authorization_code", url: 'http://localhost/fake' });
+        auth = new OktaAuth({ grantType: "authorization_code", url: 'http://my-okta-domain' });
         expect(auth.options.pkce).toBe(true);
       });
 
       it('throws if PKCE is not supported', function() {
         spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(false);
         function fn() {
-          auth = new OktaAuth({ pkce: true, url: 'http://localhost/fake' });
+          auth = new OktaAuth({ pkce: true, url: 'http://my-okta-domain' });
         }
         expect(fn).toThrowError(
           'PKCE requires a modern browser with encryption support running in a secure context.\n' +
@@ -46,4 +44,329 @@ describe('Browser', function() {
       });
     })
   });
+
+  describe('signOut', function() {
+    beforeEach(function() {
+      global.window.location.assign = jest.fn();
+    });
+    it('Default options: clear TokenManager, close session, no redirect', function() {
+      spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+      spyOn(auth.tokenManager, 'clear');
+      return auth.signOut()
+        .then(function() {
+          expect(auth.tokenManager.clear).toHaveBeenCalled();
+          expect(auth.session.close).toHaveBeenCalled();
+          expect(window.location.assign).not.toHaveBeenCalled();
+        });
+    });
+    describe('revokeAccessToken', function() {
+      it('will call token.revoke', function() {
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'clear');
+        var accessToken = { accessToken: 'fake' };
+        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(accessToken));
+        spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
+        return auth.signOut({ revokeAccessToken: true })
+          .then(function() {
+            expect(auth.token.revoke).toHaveBeenCalledWith(accessToken);
+            expect(auth.tokenManager.clear).toHaveBeenCalled();
+            expect(auth.session.close).toHaveBeenCalled();
+          });
+      });
+      it('will throw if token.revoke rejects with unknown error', function() {
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'clear');
+        var accessToken = { accessToken: 'fake' };
+        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(accessToken));
+        var testError = new Error('test error');
+        spyOn(auth.token, 'revoke').and.callFake(function() {
+          return Promise.reject(testError);
+        });
+        return auth.signOut({ revokeAccessToken: true })
+          .catch(function(e) {
+            expect(e).toBe(testError);
+          });
+      });
+      it('will not throw if token.revoke rejects with AuthApiError', function() {
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'clear');
+        var accessToken = { accessToken: 'fake' };
+        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(accessToken));
+        var testError = new AuthApiError({});
+        spyOn(auth.token, 'revoke').and.callFake(function() {
+          return Promise.reject(testError);
+        });
+        return auth.signOut({ revokeAccessToken: true })
+        .then(function() {
+          expect(auth.token.revoke).toHaveBeenCalledWith(accessToken);
+          expect(auth.tokenManager.clear).toHaveBeenCalled();
+          expect(auth.session.close).toHaveBeenCalled();
+        });
+      });
+      it('by default, will read access token from TokenManager using key "token"', function() {
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'clear');
+        var accessToken = { accessToken: 'fake' };
+        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(accessToken));
+        spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
+        return auth.signOut({ revokeAccessToken: true })
+          .then(function() {
+            expect(auth.tokenManager.get).toHaveBeenCalledWith('token');
+            expect(auth.token.revoke).toHaveBeenCalledWith(accessToken);
+            expect(auth.tokenManager.clear).toHaveBeenCalled();
+            expect(auth.session.close).toHaveBeenCalled();
+          });
+      });
+      it('can pass an access token object', function() {
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'clear');
+        var accessToken = { accessToken: 'fake' };
+        spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'get');
+        return auth.signOut({ revokeAccessToken: true, accessToken: accessToken })
+          .then(function() {
+            expect(auth.tokenManager.get).not.toHaveBeenCalled();
+            expect(auth.token.revoke).toHaveBeenCalledWith(accessToken);
+            expect(auth.tokenManager.clear).toHaveBeenCalled();
+            expect(auth.session.close).toHaveBeenCalled();
+          });
+      });
+      it('if accessToken=false, will not revoke or read from TokenManager', function() {
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'clear');
+        spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'get');
+        return auth.signOut({ revokeAccessToken: true, accessToken: false })
+          .then(function() {
+            expect(auth.tokenManager.get).not.toHaveBeenCalled();
+            expect(auth.token.revoke).not.toHaveBeenCalled();
+            expect(auth.tokenManager.clear).toHaveBeenCalled();
+            expect(auth.session.close).toHaveBeenCalled();
+          });
+      });
+      it('if accessToken cannot be located, will not attempt revoke', function() {
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'clear');
+        spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve())
+        return auth.signOut({ revokeAccessToken: true })
+          .then(function() {
+            expect(auth.tokenManager.get).toHaveBeenCalled();
+            expect(auth.token.revoke).not.toHaveBeenCalled();
+            expect(auth.tokenManager.clear).toHaveBeenCalled();
+            expect(auth.session.close).toHaveBeenCalled();
+          });
+      });
+      it('can be combined with "postLogoutRedirectUri"', function() {
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'clear');
+        var accessToken = { accessToken: 'fake' };
+        var idToken = { idToken: 'fake' };
+
+        spyOn(auth.tokenManager, 'get');
+        spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
+        return auth.signOut({ revokeAccessToken: true, accessToken: accessToken, postLogoutRedirectUri: 'http://someother', idToken: idToken })
+          .then(function() {
+            expect(auth.tokenManager.get).not.toHaveBeenCalled();
+            expect(auth.token.revoke).toHaveBeenCalledWith(accessToken);
+            expect(auth.tokenManager.clear).toHaveBeenCalled();
+            expect(auth.session.close).not.toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith('http://my-okta-domain/oauth2/v1/logout?id_token_hint=fake&post_logout_redirect_uri=http%3A%2F%2Fsomeother');
+          });
+      });
+
+      it('can be combined with "postLogoutRedirectUri" (no id token)', function() {
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'clear');
+        var accessToken = { accessToken: 'fake' };
+        var idToken = false;
+
+        spyOn(auth.tokenManager, 'get');
+        spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
+        return auth.signOut({ revokeAccessToken: true, accessToken: accessToken, postLogoutRedirectUri: 'http://someother', idToken: idToken })
+          .then(function() {
+            expect(auth.tokenManager.get).not.toHaveBeenCalled();
+            expect(auth.token.revoke).toHaveBeenCalledWith(accessToken);
+            expect(auth.tokenManager.clear).toHaveBeenCalled();
+            expect(auth.session.close).toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith('http://someother');
+          });
+      });
+    });
+    describe('closeSession', function() {
+      it('will throw unknown errors', function() {
+        var testError = new Error('test error');
+        spyOn(auth.session, 'close').and.callFake(function() {
+          return Promise.reject(testError);
+        });
+        return auth.signOut()
+        .catch(function(e) {
+          expect(e).toBe(testError);
+        });
+      });
+      it('catches and absorbs "AuthApiError" errors', function() {
+        var testError = new AuthApiError({});
+        spyOn(auth.session, 'close').and.callFake(function() {
+          return Promise.reject(testError);
+        });
+        return auth.signOut()
+        .then(function() {
+          expect(auth.session.close).toHaveBeenCalled();
+        });
+      });
+    })
+    describe('postLogoutRedirectUri', function() {
+      it('can be set by config', function() {
+        auth = new OktaAuth({
+          url: 'http://my-okta-domain',
+          postLogoutRedirectUri: 'http://someother' 
+        });
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        return auth.signOut()
+          .then(function() {
+            expect(window.location.assign).toHaveBeenCalledWith('http://someother');
+          });
+      });
+    
+      it('supports custom authorization server', function() {
+        auth = new OktaAuth({
+          url: 'http://my-okta-domain',
+          issuer: 'http://my-okta-domain/oauth2/custom-as',
+        });
+        var idToken = { idToken: 'fake' };
+        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(idToken));
+        return auth.signOut({ postLogoutRedirectUri: 'http://someother' })
+          .then(function() {
+            expect(window.location.assign).toHaveBeenCalledWith('http://my-okta-domain/oauth2/custom-as/v1/logout?id_token_hint=fake&post_logout_redirect_uri=http%3A%2F%2Fsomeother');
+          });
+      });
+  
+      it('will catch exceptions from session.close and perform redirect', function() {
+        auth = new OktaAuth({
+          url: 'http://my-okta-domain',
+          postLogoutRedirectUri: 'http://someother' 
+        });
+        var testError = new Error('test error');
+        spyOn(auth.session, 'close').and.callFake(function() {
+          return Promise.reject(testError);
+        });
+        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(null));
+        return auth.signOut()
+          .then(function() {
+            expect(auth.session.close).toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith('http://someother');
+          });
+      });
+
+      it('by default, will try to get idToken from TokenManager', function() {
+        var idToken = { idToken: 'fake' };
+  
+        spyOn(auth.tokenManager, 'clear').and.callFake(function() {
+          // Catch condition where clear() is called before the idToken is read
+          idToken = false;
+        });
+  
+        spyOn(auth.tokenManager, 'get').and.callFake(function() {
+          return idToken;
+        })
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        return auth.signOut({ postLogoutRedirectUri: 'http://someother' })
+          .then(function() {
+            expect(auth.tokenManager.get).toHaveBeenCalledWith('idToken');
+            expect(auth.session.close).not.toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith('http://my-okta-domain/oauth2/v1/logout?id_token_hint=fake&post_logout_redirect_uri=http%3A%2F%2Fsomeother');
+          });
+      });
+  
+      it('if idToken is passed, will skip token manager read and do location redirect', function() {
+        var idToken = { idToken: 'fake' };
+        var customToken = { idToken: 'fake-custom' };
+        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(idToken));
+        return auth.signOut({ idToken: customToken, postLogoutRedirectUri: 'http://someother' })
+          .then(function() {
+            expect(auth.tokenManager.get).not.toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith('http://my-okta-domain/oauth2/v1/logout?id_token_hint=fake-custom&post_logout_redirect_uri=http%3A%2F%2Fsomeother');
+          });
+      });
+  
+      it('if idToken=false will skip token manager read and use session.close before redirecting', function() {
+        var idToken = { idToken: 'fake' };
+        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(idToken));
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        return auth.signOut({ idToken: false, postLogoutRedirectUri: 'http://someother' })
+          .then(function() {
+            expect(auth.tokenManager.get).not.toHaveBeenCalled();
+            expect(auth.session.close).toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith('http://someother');
+          });
+      });
+  
+  
+      it('redirect: (no idToken) - will close session and redirect to uri', function() {
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'clear');
+        return auth.signOut({ postLogoutRedirectUri: 'http://someother' })
+          .then(function() {
+            expect(auth.tokenManager.clear).toHaveBeenCalled();
+            expect(auth.session.close).toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith('http://someother');
+          });
+      });
+  
+      it('idToken: without a redirect option, it will not use logout redirect', function() {
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'clear');
+        return auth.signOut({ idToken: { idToken: 'fake' } })
+          .then(function() {
+            expect(auth.tokenManager.clear).toHaveBeenCalled();
+            expect(auth.session.close).toHaveBeenCalled();
+            expect(window.location.assign).not.toHaveBeenCalled();
+          });
+      });
+  
+      it('idToken + postLogoutRedirectUri: will use logout redirect with "post_logout_redirect_uri"', function() {
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'clear');
+        return auth.signOut({ idToken: { idToken: 'fake' }, postLogoutRedirectUri: 'http://someother' })
+          .then(function() {
+            expect(auth.tokenManager.clear).toHaveBeenCalled();
+            expect(auth.session.close).not.toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith('http://my-okta-domain/oauth2/v1/logout?id_token_hint=fake&post_logout_redirect_uri=http%3A%2F%2Fsomeother');
+          });
+      });
+  
+      it('idToken + postLogoutRedirectUri + state: logout redirect url includes "state" and "post_logout_redirect_uri"', function() {
+        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'clear');
+        return auth.signOut({ idToken: { idToken: 'fake' }, postLogoutRedirectUri: 'http://someother', state: 'foo=bar&yo=me' })
+          .then(function() {
+            expect(auth.tokenManager.clear).toHaveBeenCalled();
+            expect(auth.session.close).not.toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith('http://my-okta-domain/oauth2/v1/logout?id_token_hint=fake&post_logout_redirect_uri=http%3A%2F%2Fsomeother&state=foo%3Dbar%26yo%3Dme');
+          });
+      });
+    });
+
+    describe('XHR logout', function() {
+      it('will not catch exceptions from session.close', function() {
+        auth = new OktaAuth({
+          url: 'http://my-okta-domain',
+        });
+        var testError = new Error('test error');
+        spyOn(auth.session, 'close').and.callFake(function() {
+          return Promise.reject(testError);
+        });
+        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(null));
+        return auth.signOut()
+          .catch(function(e) {
+            expect(e).toBe(testError);
+          })
+          .then(function() {
+            expect(auth.session.close).toHaveBeenCalled();
+          });
+      });
+    });
+  });
+
 });

--- a/packages/okta-auth-js/test/spec/oauthUtil.js
+++ b/packages/okta-auth-js/test/spec/oauthUtil.js
@@ -351,6 +351,8 @@ describe('getOAuthUrls', function() {
     setupOAuthUrls({
       expectedResult: {
         issuer: 'https://auth-js-test.okta.com',
+        logoutUrl: 'https://auth-js-test.okta.com/oauth2/v1/logout',
+        revokeUrl: 'https://auth-js-test.okta.com/oauth2/v1/revoke',
         tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
         authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
         userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
@@ -362,12 +364,15 @@ describe('getOAuthUrls', function() {
       oktaAuthArgs: {
         url: 'https://auth-js-test.okta.com',
         issuer: 'https://auth-js-test.okta.com/',
+        logoutUrl: 'https://auth-js-test.okta.com/oauth2/v1/logout/',
         tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token/',
         authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize/',
         userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo/'
       },
       expectedResult: {
         issuer: 'https://auth-js-test.okta.com',
+        logoutUrl: 'https://auth-js-test.okta.com/oauth2/v1/logout',
+        revokeUrl: 'https://auth-js-test.okta.com/oauth2/v1/revoke',
         tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
         authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
         userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
@@ -379,21 +384,27 @@ describe('getOAuthUrls', function() {
       oktaAuthArgs: {
         url: 'https://auth-js-test.okta.com',
         issuer: 'https://bad.okta.com',
+        logoutUrl: 'https://bad.okta.com/oauth2/v1/logout',
+        revokeUrl: 'https://bad.okta.com/oauth2/v1/revoke',
         tokenUrl: 'https://bad.okta.com/oauth2/v1/token',
         authorizeUrl: 'https://bad.okta.com/oauth2/v1/authorize',
         userinfoUrl: 'https://bad.okta.com/oauth2/v1/userinfo'
       },
       options: {
         issuer: 'https://auth-js-test.okta.com',
-        tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
-        authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-        userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+        logoutUrl: 'https://overrid-js-test.okta.com/oauth2/v1/logout',
+        revokeUrl: 'https://override-js-test.okta.com/oauth2/v1/revoke',
+        tokenUrl: 'https://override-js-test.okta.com/oauth2/v1/token',
+        authorizeUrl: 'https://override-js-test.okta.com/oauth2/v1/authorize',
+        userinfoUrl: 'https://override-js-test.okta.com/oauth2/v1/userinfo'
       },
       expectedResult: {
         issuer: 'https://auth-js-test.okta.com',
-        tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
-        authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-        userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+        logoutUrl: 'https://overrid-js-test.okta.com/oauth2/v1/logout',
+        revokeUrl: 'https://override-js-test.okta.com/oauth2/v1/revoke',
+        tokenUrl: 'https://override-js-test.okta.com/oauth2/v1/token',
+        authorizeUrl: 'https://override-js-test.okta.com/oauth2/v1/authorize',
+        userinfoUrl: 'https://override-js-test.okta.com/oauth2/v1/userinfo'
       }
     });
   });
@@ -401,12 +412,16 @@ describe('getOAuthUrls', function() {
     setupOAuthUrls({
       options: {
         issuer: 'https://auth-js-test.okta.com/',
+        logoutUrl: 'https://auth-js-test.okta.com/oauth2/v1/logout/',
+        revokeUrl: 'https://auth-js-test.okta.com/oauth2/v1/revoke/',
         tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token/',
         authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize/',
         userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo/'
       },
       expectedResult: {
         issuer: 'https://auth-js-test.okta.com',
+        logoutUrl: 'https://auth-js-test.okta.com/oauth2/v1/logout',
+        revokeUrl: 'https://auth-js-test.okta.com/oauth2/v1/revoke',
         tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
         authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
         userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
@@ -420,6 +435,8 @@ describe('getOAuthUrls', function() {
       },
       expectedResult: {
         issuer: 'https://auth-js-test.okta.com',
+        logoutUrl: 'https://auth-js-test.okta.com/oauth2/v1/logout',
+        revokeUrl: 'https://auth-js-test.okta.com/oauth2/v1/revoke',
         tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
         authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
         userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
@@ -433,6 +450,8 @@ describe('getOAuthUrls', function() {
       },
       expectedResult: {
         issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
+        logoutUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/logout',
+        revokeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/revoke',
         tokenUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/token',
         authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
         userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
@@ -446,6 +465,8 @@ describe('getOAuthUrls', function() {
       },
       expectedResult: {
         issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
+        logoutUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/logout',
+        revokeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/revoke',
         tokenUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/token',
         authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
         userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
@@ -463,6 +484,8 @@ describe('getOAuthUrls', function() {
       },
       expectedResult: {
         issuer: 'https://auth-js-test.okta.com', // We don't validate the issuer of access tokens, so this is ignored
+        logoutUrl: 'https://auth-js-test.okta.com/oauth2/v1/logout',
+        revokeUrl: 'https://auth-js-test.okta.com/oauth2/v1/revoke',
         tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token', // we are not using this url for responseType 'token'
         authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
         userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'

--- a/packages/okta-auth-js/test/spec/session.js
+++ b/packages/okta-auth-js/test/spec/session.js
@@ -1,0 +1,245 @@
+var session = require('../../lib/session');
+var http = require('../../lib/http');
+var Q = require('q');
+
+describe('session', function() {
+  var sdk;
+  var sessionObj;
+
+  beforeEach(function() {
+    sessionObj = {};
+    sdk = {
+      session: {
+        get: jest.fn().mockImplementation(function() {
+          var deferred = Q.defer();
+          deferred.resolve(sessionObj);
+          return deferred.promise;
+        })
+      }
+    };
+  });
+  describe('sessionExists', function() {
+    it('calls sdk.session.get', function() {
+      return session.sessionExists(sdk)
+        .then(function() {
+          expect(sdk.session.get).toHaveBeenCalled();
+        });
+    });
+
+    it('resolves to false by default', function() {
+      return session.sessionExists(sdk)
+        .then(function(res) {
+          expect(res).toBe(false);
+        });
+    });
+
+    it('resolves to false if session.get throws', function() {
+      sdk.session.get.mockImplementation(function() {
+        var deferred = Q.defer();
+        deferred.reject(new Error('test error'));
+        return deferred.promise;
+      });
+      return session.sessionExists(sdk)
+        .then(function(res) {
+          expect(res).toBe(false);
+        });
+    });
+
+    it('resolves to true if status = "ACTIVE"', function() {
+      sessionObj = {
+        status: 'ACTIVE'
+      };
+      return session.sessionExists(sdk)
+        .then(function(res) {
+          expect(res).toBe(true);
+        });
+    });
+  });
+
+  describe('getSession', function() {
+    it('Hits endpoint: /api/v1/sessions/me', function() {
+      jest.spyOn(http, 'get').mockReturnValue(Q());
+      return session.getSession(sdk)
+        .then(function() {
+          expect(http.get).toHaveBeenCalledWith(sdk, '/api/v1/sessions/me');
+        });
+    });
+
+    it('XHR error: returns an INACTIVE session object', function() {
+      jest.spyOn(http, 'get').mockImplementation(function() {
+        var deferred = Q.defer();
+        deferred.reject(new Error('test error'));
+        return deferred.promise;
+      });
+      return session.getSession(sdk)
+        .then(function(res) {
+          expect(res).toEqual({
+            status: 'INACTIVE'
+          });
+        });
+    });
+
+    it('Adds a "refresh" method on the session object', function() {
+      jest.spyOn(http, 'get').mockReturnValue(Q());
+      return session.getSession(sdk)
+        .then(function(res) {
+          expect(typeof res.refresh).toBe('function');
+        });
+    });
+
+    it('Adds a "user" method on the session object', function() {
+      jest.spyOn(http, 'get').mockReturnValue(Q());
+      return session.getSession(sdk)
+        .then(function(res) {
+          expect(typeof res.user).toBe('function');
+        });
+    });
+
+    it('Omits the "_links" section from the object', function() {
+      var sessionObj = {
+        foo: 'bar',
+        _links: {
+          foo: 'bar'
+        }
+      };
+      jest.spyOn(http, 'get').mockImplementation(function() {
+        var deferred = Q.defer();
+        deferred.resolve(sessionObj);
+        return deferred.promise;
+      });
+      return session.getSession(sdk)
+        .then(function(res) {
+          expect(res).toEqual({
+            foo: 'bar',
+            refresh: expect.any(Function),
+            user: expect.any(Function)
+          });
+        });
+    });
+
+    it('refresh: posts to the refresh link', function() {
+      var href = 'fake-link';
+      var sessionObj = {
+        _links: {
+          refresh: {
+            href: href
+          }
+        }
+      };
+      jest.spyOn(http, 'post').mockReturnValue(null);
+      jest.spyOn(http, 'get').mockImplementation(function() {
+        var deferred = Q.defer();
+        deferred.resolve(sessionObj);
+        return deferred.promise;
+      });
+      return session.getSession(sdk)
+        .then(function(res) {
+          res.refresh();
+          expect(http.post).toHaveBeenCalledWith(sdk, href)
+        });
+    });
+
+    it('user: gets the user link', function() {
+      var href = 'fake-link';
+      var sessionObj = {
+        _links: {
+          user: {
+            href: href
+          }
+        }
+      };
+      jest.spyOn(http, 'get').mockImplementation(function() {
+        var deferred = Q.defer();
+        deferred.resolve(sessionObj);
+        return deferred.promise;
+      });
+      return session.getSession(sdk)
+        .then(function(res) {
+          http.get.mockReset();
+          jest.spyOn(http, 'get').mockReturnValue(null);
+          res.user();
+          expect(http.get).toHaveBeenCalledWith(sdk, href)
+        });
+    });
+  });
+
+  describe('closeSession', function() {
+    it('makes a DELETE request to /api/v1/sessions/me', function() {
+      jest.spyOn(http, 'httpRequest').mockReturnValue(Promise.resolve());
+      var baseUrl = 'http://fakey';
+      sdk.options = {
+        url: baseUrl
+      };
+      return session.closeSession(sdk)
+        .then(function() {
+          expect(http.httpRequest).toHaveBeenCalledWith(sdk, {
+            url: baseUrl + '/api/v1/sessions/me',
+            method: 'DELETE'
+          });
+        });
+    });
+
+    it('will throw if http request rejects', function() {
+      var testError = new Error('test error');
+      jest.spyOn(http, 'httpRequest').mockReturnValue(Promise.reject(testError));
+      sdk.options = {
+        url: 'http://fakey'
+      };
+      return session.closeSession(sdk) // should throw
+        .catch(function(e) {
+          expect(e).toBe(testError);
+        });
+    });
+  });
+
+  describe('refreshSession', function() {
+    it('makes a POST to /api/v1/sessions/me/lifecycle/refresh', function() {
+      jest.spyOn(http, 'post').mockReturnValue(Promise.resolve());
+      return session.refreshSession(sdk)
+        .then(function() {
+          expect(http.post).toHaveBeenCalledWith(sdk,'/api/v1/sessions/me/lifecycle/refresh');
+        });
+    });
+    it('can throw', function() {
+      var testError = new Error('test error');
+      jest.spyOn(http, 'post').mockReturnValue(Promise.reject(testError));
+      return session.refreshSession(sdk)
+        .catch(function(e) {
+          expect(e).toBe(testError);
+        });
+    });
+  });
+
+  describe('setCookieAndRedirect', function() {
+    var baseUrl;
+    var currentUrl;
+    beforeEach(function() {
+      currentUrl = 'http://i-am-here';
+      delete window.location;
+      window.location = {
+        href: currentUrl
+      };
+      baseUrl = 'http://fakey';
+      sdk.options = {
+        url: baseUrl
+      }
+    });
+    it('redirects to /login/sessionCookieRedirect', function() {
+      session.setCookieAndRedirect(sdk);
+      expect(window.location).toBe(baseUrl + '/login/sessionCookieRedirect?checkAccountSetupComplete=true&redirectUrl=' + encodeURIComponent(currentUrl));
+    });
+    it('can pass a sessionToken', function() {
+      var sessionToken = 'blah-blah';
+      session.setCookieAndRedirect(sdk, sessionToken);
+      expect(window.location).toBe(baseUrl + '/login/sessionCookieRedirect?checkAccountSetupComplete=true&token=' +
+        encodeURIComponent(sessionToken) + '&redirectUrl=' + encodeURIComponent(currentUrl));
+    });
+    it('can pass a redirectUrl', function() {
+      var sessionToken = 'blah-blah';
+      var redirectUrl = 'http://go-here-now';
+      session.setCookieAndRedirect(sdk, sessionToken, redirectUrl);
+      expect(window.location).toBe(baseUrl + '/login/sessionCookieRedirect?checkAccountSetupComplete=true&token=' +
+        encodeURIComponent(sessionToken) + '&redirectUrl=' + encodeURIComponent(redirectUrl));
+    });
+  });
+});

--- a/test/e2e/pageobjects/OktaHome.js
+++ b/test/e2e/pageobjects/OktaHome.js
@@ -11,6 +11,10 @@ class OktaLogin {
     await this.signOutBtn.then(el => el.click());
     await browser.waitUntil(async () => browser.getUrl().then(cur => (cur !== url)), 5000, 'wait for url change');
   }
+
+  async waitForLoad() {
+    await browser.waitUntil(async () => this.userMenu.then(el => el.isDisplayed()), 5000, 'wait for user menu');
+  }
 }
 
 export default new OktaLogin();

--- a/test/e2e/pageobjects/TestApp.js
+++ b/test/e2e/pageobjects/TestApp.js
@@ -9,11 +9,16 @@ class TestApp {
 
   // Authenticated landing
   get logoutBtn() { return $('#logout'); }
+  get logoutRedirectBtn() { return $('#logout-redirect'); }
+  get logoutLocalBtn() { return $('#logout-local'); }
   get renewTokenBtn() { return $('#renew-token'); }
+  get revokeTokenBtn() { return $('#revoke-token'); }
   get getTokenBtn() { return $('#get-token'); }
+  get clearTokensBtn() { return $('#clear-tokens'); }
   get getUserInfoBtn() { return $('#get-userinfo'); }
   get userInfo() { return $('#user-info'); }
   get tokenError() { return $('#token-error'); }
+  get tokenMsg() { return $('#token-msg'); }
 
   // Unauthenticated landing
   get loginRedirectBtn() { return $('#login-redirect'); }
@@ -76,6 +81,14 @@ class TestApp {
     return this.getTokenBtn.then(el => el.click());
   }
 
+  async clearTokens() {
+    return this.clearTokensBtn.then(el => el.click());
+  }
+
+  async revokeToken() {
+    return this.revokeTokenBtn.then(el => el.click());
+  }
+
   async getUserInfo() {
     await browser.waitUntil(async () => this.getUserInfoBtn.then(el => el.isDisplayed()));
     await this.getUserInfoBtn.then(el => el.click());
@@ -92,12 +105,22 @@ class TestApp {
     await this.waitForLoginBtn();
   }
 
+  async logoutLocal() {
+    await this.logoutLocalBtn.then(el => el.click());
+    await this.waitForLoginBtn();
+  }
+
+  async logoutRedirect() {
+    await this.logoutRedirectBtn.then(el => el.click());
+    await this.waitForLoginBtn();
+  }
+
   async waitForLoginBtn() {
     return browser.waitUntil(async () => this.loginRedirectBtn.then(el => el.isDisplayed()), 5000, 'wait for login button');
   }
 
   async waitForLogoutBtn() {
-    return browser.waitUntil(async () => this.logoutBtn.then(el => el.isDisplayed()), 5000, 'wait for logout button');
+    return browser.waitUntil(async () => this.logoutBtn.then(el => el.isDisplayed()), 15000, 'wait for logout button');
   }
 
   async waitForCallback() {
@@ -147,6 +170,13 @@ class TestApp {
       assert(txt.indexOf('email') > 0);
     });
   }
+
+  async assertIdToken() {
+    await this.idToken.then(el => el.getText()).then(txt => {
+      assert(txt.indexOf('claims') > 0);
+    });
+  }
+
 }
 
 export default new TestApp();

--- a/test/e2e/specs/logout.js
+++ b/test/e2e/specs/logout.js
@@ -1,0 +1,50 @@
+import TestApp from '../pageobjects/TestApp';
+import OktaHome from '../pageobjects/OktaHome'
+import { openPKCE } from '../util/appUtils';
+import { loginPopup } from '../util/loginUtils';
+import { openOktaHome, switchToMainWindow } from '../util/browserUtils';
+import OktaLogin from '../pageobjects/OktaLogin';
+
+describe('E2E logout', () => {
+    beforeEach(async () => {
+      await openPKCE();
+      await loginPopup();
+    });
+
+    it('can logout locally, keeping remote user session open', async () => {
+      await TestApp.logoutLocal();
+
+      // We should still be logged into Okta
+      await openOktaHome();
+      await OktaHome.waitForLoad();
+
+      // Now sign the user out
+      await OktaHome.signOut();
+      await browser.closeWindow();
+      await switchToMainWindow();
+
+    });
+
+    it('can logout from okta, ending remote user session', async() => {
+      await TestApp.logout();
+
+      // We should not be logged into Okta
+      await openOktaHome();
+      await OktaLogin.waitForLoad();
+
+      // cleanup
+      await browser.closeWindow();
+      await switchToMainWindow();
+    });
+
+    it('can logout from okta and redirect back to the application', async () => {
+      await TestApp.assertIdToken();
+      await TestApp.logoutRedirect();
+    });
+
+    it('no idToken: can logout from okta and redirect back to the application', async () => {
+      await TestApp.clearTokens();
+      await TestApp.logoutRedirect();
+    });
+
+});

--- a/test/e2e/util/browserUtils.js
+++ b/test/e2e/util/browserUtils.js
@@ -2,10 +2,10 @@
 const URL = require('url');
 const ISSUER = process.env.ISSUER;
 const issuer = URL.parse(ISSUER);
-const BASE_URL = issuer.protocol + issuer.host;
+const BASE_URL = issuer.protocol + '//' + issuer.host;
 
 async function openOktaHome() {
-  return browser.newWindow(BASE_URL, 'Okta signin page');
+  return browser.newWindow(BASE_URL, 'Okta-hosted page');
 }
 
 async function switchToPopupWindow() {

--- a/test/support/oauthUtil.js
+++ b/test/support/oauthUtil.js
@@ -232,8 +232,8 @@ oauthUtil.setup = function(opts) {
       if (opts.willFail) {
         throw err;
       } else {
-        expect('not to be hit').toBe(true);
         console.error(err); // eslint-disable-line
+        expect('not to be hit').toBe(true);
       }
     });
 };


### PR DESCRIPTION
- Current behavior is preserved with default options
- Passing a `postLogoutRedirectUri` will use post logout redirect flow
- Automatically reads idToken from TokenManager
- Can manually specify idToken for advanced/custom scenarios
- If `postLogoutRedirectUri` is specified, redirect logic will happen even if idToken is not available

- Clears TokenManager on signOut. All OIDC sdks have been doing this step before calling signOut. The server-side redirect method requires an idToken, so the TokenManager should not be cleared before calling signOut(). The call to `tokenManager.clear()` can be removed from the SDKs once they are using this version.