### PR TITLE
Refactor publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "clean-dist": "rimraf dist && lerna exec rimraf build2 && lerna exec rimraf dist",
     "clean-node-modules": "lerna exec rimraf node_modules && rimraf node_modules",
     "lint": "yarn workspaces run lint",
-    "publish": "lerna publish --skip-npm",
     "test": "yarn test:unit && yarn test:e2e",
     "test:e2e": "yarn --cwd test/e2e start",
     "test:browser": "yarn workspace @okta/okta-auth-js test:browser",

--- a/scripts/.eslintrc.json
+++ b/scripts/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "extends": ["eslint:recommended"],
+  "env": {
+    "browser": false,
+    "node": true
+  },
+  "globals": {
+    "console": "readonly"
+  },
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaVersion": 2017
+  },
+  "rules": {
+    "semi": 2,
+    "eol-last": 2,
+    "no-console": 0
+  }
+}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,50 +1,12 @@
 #!/bin/bash -xe
 
+echo "attempting npm publish"
+
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
-
-REGISTRY="${ARTIFACTORY_URL}/api/npm/npm-okta"
-
-export TEST_SUITE_TYPE="build"
-
-# Install required dependencies
-export PATH="${PATH}:$(yarn global bin)"
-yarn global add @okta/ci-update-package
-yarn global add @okta/ci-pkginfo
-
-if [ -n "${action_branch}" ];
-then
-  echo "Publishing from bacon task using branch ${action_branch}"
-  TARGET_BRANCH=${action_branch}
-else
-  echo "Publishing from bacon testSuite using branch ${BRANCH}"
-  TARGET_BRANCH=${BRANCH}
-fi
 
 # Copy README, CHANGELOG, and CONTRIBUTING to the package directory so they will be published with the the package on npm
 cp ./*.md ./packages/okta-auth-js/
 
-pushd ./packages/okta-auth-js
+node $OKTA_HOME/$REPO/scripts/publish_artifact.js
 
-if ! ci-update-package --branch ${TARGET_BRANCH}; then
-  echo "ci-update-package failed! Exiting..."
-  exit ${FAILED_SETUP}
-fi
-
-### looks like ci-update-package is not compatible with `yarn publish`
-### which expects new-version is passed via command line parameter.
-### keep using npm for now
-if ! npm publish --registry ${REGISTRY}; then
-  echo "npm publish failed! Exiting..."
-  exit ${PUBLISH_ARTIFACTORY_FAILURE}
-fi
-
-
-DATALOAD=$(ci-pkginfo -t dataload)
-if ! artifactory_curl -X PUT -u ${ARTIFACTORY_CREDS} ${DATALOAD} -v -f; then
-  echo "artifactory_curl failed! Exiting..."
-  exit ${PUBLISH_ARTIFACTORY_FAILURE}
-fi
-
-popd
-
-exit ${SUCCESS}
+exit $SUCCESS

--- a/scripts/publish_artifact.js
+++ b/scripts/publish_artifact.js
@@ -1,0 +1,77 @@
+'use strict';
+
+if (!process.env.ARTIFACTORY_URL) {
+  throw new Error('ARTIFACTORY_URL environment variable must be set');
+}
+
+if (!process.env.BRANCH) {
+  throw new Error('BRANCH environment variable must be set');
+}
+
+if (!process.env.SHA) {
+  throw new Error('SHA environment variable must be set');
+}
+
+const path = require('path');
+const execSync = require('child_process').execSync;
+const branch = process.env.BRANCH;
+const sha = process.env.SHA;
+const isTopicBranch = branch !== 'master';
+
+let versionSuffix = '';
+if (isTopicBranch) {
+  versionSuffix = '-beta.' + sha.substring(sha.length - 8);
+  console.log(`Using version suffix "${versionSuffix}"`);
+}
+
+const registry=`${process.env.ARTIFACTORY_URL}/api/npm/npm-okta`;
+const workspacesInfo = JSON.parse(execSync(`yarn workspaces info --json`).toString());
+const workspaces = JSON.parse(workspacesInfo.data);
+
+let hasPublishedAPackage = false;
+Object.keys(workspaces).forEach(name => {
+  const moduleDir = path.resolve(__dirname, '..', workspaces[name].location);
+  const pkg = require(`${moduleDir}/package`);
+
+  // Skip private packages
+  if (pkg.private) {
+    console.log(`Skipping private package ${name}`);
+    return;
+  }
+
+  let pkgVersion = pkg.version + versionSuffix;
+  if (versionSuffix) {
+    // Update package.json with the beta version
+    execSync(`npm version ${pkgVersion} --no-git-tag-version`,  {
+      cwd: moduleDir
+    });
+  }
+
+  const moduleWithVersion = `${pkg.name}@${pkgVersion}`;
+
+  console.log(`Checking if ${moduleWithVersion} exists`);
+
+  let isInPublicNpm = false;
+  try {
+    isInPublicNpm = !!execSync(`npm view ${moduleWithVersion} --registry ${registry}`).toString();
+  } catch (err) {
+    // We expect packages that do not exist to throw a 404 error
+    console.log(`${pkg.name} does not have any published versions`);
+  }
+
+  if (isInPublicNpm) {
+    console.log(`${moduleWithVersion} exists`);
+  } else {
+    console.log(`Publishing ${moduleWithVersion}`);
+    execSync(`npm publish --registry ${registry}`, {
+      cwd: moduleDir
+    });
+    hasPublishedAPackage = true;
+  }
+});
+
+if (hasPublishedAPackage && !isTopicBranch) {
+  execSync('git tag -f last-published && git push -f origin last-published');
+}
+
+console.log(`Finished syncing latest packages to npm registry: ${registry}`);

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -27,4 +27,4 @@ fi
 yarn workspace @okta/okta-auth-js prepare
 
 # Revert the origional change
-# sed -i "s#${OKTA_REGISTRY}#${YARN_REGISTRY}#" yarn.lock
+sed -i "s#${OKTA_REGISTRY}#${YARN_REGISTRY}#" yarn.lock

--- a/test/app/package.json
+++ b/test/app/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@okta/test.app",
   "version": "1.0.0",
   "description": "",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@okta/test.e2e",
   "version": "1.0.0",
   "main": "index.js",

--- a/test/support/package.json
+++ b/test/support/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@okta/test.support",
   "version": "1.0.0",
   "license": "Apache-2.0",


### PR DESCRIPTION
- removes dependency on ci-update-package
- will publish with -beta.SHA suffix if not running on master branch