### PR TITLE
Set 'SameSite' on cookies

### DIFF
--- a/packages/okta-auth-js/lib/browser/browserStorage.js
+++ b/packages/okta-auth-js/lib/browser/browserStorage.js
@@ -69,11 +69,16 @@ storageUtil.getSessionStorage = function() {
 // Provides webStorage-like interface for cookies
 storageUtil.getCookieStorage = function(options) {
   options = options || {};
+  var secure = options.secure; // currently opt-in
+  var sameSite = options.sameSite || 'strict'; // token storage should only be accessed by javascript
   return {
     getItem: storageUtil.storage.get,
     setItem: function(key, value) {
       // Cookie shouldn't expire
-      storageUtil.storage.set(key, value, '2200-01-01T00:00:00.000Z', options.secure);
+      storageUtil.storage.set(key, value, '2200-01-01T00:00:00.000Z', {
+        secure: secure, 
+        sameSite: sameSite
+      });
     }
   };
 };
@@ -103,10 +108,12 @@ storageUtil.testStorage = function(storage) {
 };
 
 storageUtil.storage = {
-  set: function(name, value, expiresAt, secure) {
+  set: function(name, value, expiresAt, options) {
+    options = options || {};
     var cookieOptions = {
-      path: '/',
-      secure: secure
+      path: options.path || '/',
+      secure: options.secure,
+      sameSite: options.sameSite
     };
 
     // eslint-disable-next-line no-extra-boolean-cast

--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -643,13 +643,19 @@ function getWithRedirect(sdk, oauthOptions, options) {
         clientId: oauthParams.clientId,
         urls: urls,
         ignoreSignature: oauthParams.ignoreSignature
-      }));
+      }), null, {
+        sameSite: 'strict' // accessed by javascript in parseFromUrl()
+      });
 
       // Set nonce cookie for servers to validate nonce in id_token
-      cookies.set(constants.REDIRECT_NONCE_COOKIE_NAME, oauthParams.nonce);
+      cookies.set(constants.REDIRECT_NONCE_COOKIE_NAME, oauthParams.nonce, null, {
+        sameSite: 'lax' // accessed by server from redirect
+      });
 
       // Set state cookie for servers to validate state
-      cookies.set(constants.REDIRECT_STATE_COOKIE_NAME, oauthParams.state);
+      cookies.set(constants.REDIRECT_STATE_COOKIE_NAME, oauthParams.state, null, {
+        sameSite: 'lax' // accessed by server from redirect
+      });
 
       sdk.token.getWithRedirect._setLocation(requestUrl);
     });

--- a/packages/okta-auth-js/test/spec/cookies.js
+++ b/packages/okta-auth-js/test/spec/cookies.js
@@ -30,6 +30,26 @@ describe('cookie', function () {
         path: '/'
       });
     });
+
+    it('proxies JsCookie.set with "secure" setting',  function ()  {
+      Cookies.set('foo', 'bar', null, {
+        secure: true
+      });
+      expect(JsCookie.set).toHaveBeenCalledWith('foo', 'bar', {
+        path: '/',
+        secure: true
+      });
+    });
+
+    it('proxies JsCookie.set with "sameSite" setting',  function ()  {
+      Cookies.set('foo', 'bar', null, {
+        sameSite: 'lax'
+      });
+      expect(JsCookie.set).toHaveBeenCalledWith('foo', 'bar', {
+        path: '/',
+        sameSite: 'lax'
+      });
+    });
   });
 
   describe('get',  function ()  {

--- a/packages/okta-auth-js/test/spec/oauthUtil.js
+++ b/packages/okta-auth-js/test/spec/oauthUtil.js
@@ -161,7 +161,9 @@ describe('getWellKnown', function() {
           }
         }),
         '2200-01-01T00:00:00.000Z',
-        undefined // secure
+        {
+          sameSite: 'strict'
+        }
       );
     }
   });

--- a/packages/okta-auth-js/test/spec/token.js
+++ b/packages/okta-auth-js/test/spec/token.js
@@ -1171,6 +1171,9 @@ describe('token.getWithRedirect', function() {
   var codeChallenge = 'fake';
   var defaultUrls;
   var customUrls;
+  var nonceCookie;
+  var stateCookie;
+
   beforeEach(function() {
     defaultUrls = {
       issuer: 'https://auth-js-test.okta.com',
@@ -1188,6 +1191,23 @@ describe('token.getWithRedirect', function() {
       revokeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/revoke',
       logoutUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/logout',
     }
+    nonceCookie = [
+      'okta-oauth-nonce',
+      oauthUtil.mockedNonce,
+      null, // expiresAt
+      {
+        sameSite: 'lax'
+      }
+    ];
+
+    stateCookie =  [
+      'okta-oauth-state',
+      oauthUtil.mockedState,
+      null, // expiresAt
+      {
+        sameSite: 'lax'
+      }
+    ];
   });
   function mockPKCE() {
     spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(true);
@@ -1209,31 +1229,28 @@ describe('token.getWithRedirect', function() {
           'okta-oauth-redirect-params',
           JSON.stringify({
             responseType: 'id_token',
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: defaultUrls,
             ignoreSignature: false
-          })
+          }),
+          null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
                             'response_type=id_token&' +
                             'sessionToken=testToken&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
@@ -1259,25 +1276,22 @@ describe('token.getWithRedirect', function() {
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: customUrls,
             ignoreSignature: false
-          })
+          }),
+          null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
                             'response_type=id_token&' +
                             'sessionToken=testToken&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
@@ -1307,25 +1321,22 @@ describe('token.getWithRedirect', function() {
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: customUrls,
             ignoreSignature: false
-          })
+          }),
+          null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
                             'response_type=token&' +
                             'sessionToken=testToken&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=email'
     });
   });
@@ -1342,31 +1353,28 @@ describe('token.getWithRedirect', function() {
           'okta-oauth-redirect-params',
           JSON.stringify({
             responseType: 'token',
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
             scopes: ['email'],
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: defaultUrls,
             ignoreSignature: false
-          })
+          }),
+          null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
                             'response_type=token&' +
                             'sessionToken=testToken&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=email'
     });
   });
@@ -1394,25 +1402,22 @@ describe('token.getWithRedirect', function() {
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: customUrls,
             ignoreSignature: false
-          })
+          }),
+          null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
                             'response_type=token&' +
                             'sessionToken=testToken&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=email'
     });
   });
@@ -1428,31 +1433,28 @@ describe('token.getWithRedirect', function() {
           'okta-oauth-redirect-params',
           JSON.stringify({
             responseType: ['token', 'id_token'],
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: defaultUrls,
             ignoreSignature: false
-          })
+          }),
+          null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'idp=testIdp&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
                             'response_type=token%20id_token&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
@@ -1479,25 +1481,22 @@ describe('token.getWithRedirect', function() {
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: customUrls,
             ignoreSignature: false
-          })
+          }),
+          null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'idp=testIdp&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
                             'response_type=token%20id_token&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
@@ -1513,31 +1512,28 @@ describe('token.getWithRedirect', function() {
           'okta-oauth-redirect-params',
           JSON.stringify({
             responseType: 'code',
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: defaultUrls,
             ignoreSignature: false
-          })
+          }),
+          null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=query&' +
                             'response_type=code&' +
                             'sessionToken=testToken&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
@@ -1557,33 +1553,30 @@ describe('token.getWithRedirect', function() {
           'okta-oauth-redirect-params',
           JSON.stringify({
             responseType: 'code',
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: defaultUrls,
             ignoreSignature: false
-          })
+          }),
+          null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'code_challenge=' + codeChallenge + '&' +
                             'code_challenge_method=' + codeChallengeMethod + '&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
                             'response_type=code&' +
                             'sessionToken=testToken&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
@@ -1603,33 +1596,30 @@ describe('token.getWithRedirect', function() {
           'okta-oauth-redirect-params',
           JSON.stringify({
             responseType: 'code',
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: defaultUrls,
             ignoreSignature: false
-          })
+          }),
+null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'code_challenge=' + codeChallenge + '&' +
                             'code_challenge_method=' + codeChallengeMethod + '&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
                             'response_type=code&' +
                             'sessionToken=testToken&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
@@ -1657,25 +1647,22 @@ describe('token.getWithRedirect', function() {
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: customUrls,
             ignoreSignature: false
-          })
+          }),
+          null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=query&' +
                             'response_type=code&' +
                             'sessionToken=testToken&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
@@ -1692,31 +1679,28 @@ describe('token.getWithRedirect', function() {
           'okta-oauth-redirect-params',
           JSON.stringify({
             responseType: ['code'],
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: defaultUrls,
             ignoreSignature: false
-          })
+          }),
+          null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=query&' +
                             'response_type=code&' +
                             'sessionToken=testToken&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
@@ -1737,33 +1721,30 @@ describe('token.getWithRedirect', function() {
         'okta-oauth-redirect-params',
         JSON.stringify({
           responseType: 'code',
-          state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          state: oauthUtil.mockedState,
+          nonce: oauthUtil.mockedNonce,
           scopes: ['openid', 'email'],
           clientId: 'NPSfOkH5eZrTy8PMDlvx',
           urls: defaultUrls,
           ignoreSignature: false
-        })
+        }),
+        null, {
+          sameSite: 'strict'
+        }
       ],
-      [
-        'okta-oauth-nonce',
-        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-      ],
-      [
-        'okta-oauth-state',
-        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-      ]
+      nonceCookie,
+      stateCookie
     ],
     expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                           'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                           'code_challenge=' + codeChallenge + '&' +
                           'code_challenge_method=' + codeChallengeMethod + '&' +
-                          'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                          'nonce=' + oauthUtil.mockedNonce + '&' +
                           'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                           'response_mode=fragment&' +
                           'response_type=code&' +
                           'sessionToken=testToken&' +
-                          'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                          'state=' + oauthUtil.mockedState + '&' +
                           'scope=openid%20email'
   });
 });
@@ -1780,31 +1761,28 @@ describe('token.getWithRedirect', function() {
           'okta-oauth-redirect-params',
           JSON.stringify({
             responseType: 'code',
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: defaultUrls,
             ignoreSignature: false
-          })
+          }),
+          null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=form_post&' +
                             'response_type=code&' +
                             'sessionToken=testToken&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
@@ -1819,31 +1797,28 @@ describe('token.getWithRedirect', function() {
           'okta-oauth-redirect-params',
           JSON.stringify({
             responseType: 'id_token',
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: defaultUrls,
             ignoreSignature: false
-          })
+          }),
+          null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'login_hint=JoeUser&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
                             'response_type=id_token&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
@@ -1858,31 +1833,28 @@ describe('token.getWithRedirect', function() {
           'okta-oauth-redirect-params',
           JSON.stringify({
             responseType: 'id_token',
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: defaultUrls,
             ignoreSignature: false
-          })
+          }),
+          null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'idp_scope=scope1%20scope2&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
                             'response_type=id_token&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
@@ -1897,31 +1869,28 @@ describe('token.getWithRedirect', function() {
           'okta-oauth-redirect-params',
           JSON.stringify({
             responseType: 'id_token',
-            state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
             clientId: 'NPSfOkH5eZrTy8PMDlvx',
             urls: defaultUrls,
             ignoreSignature: false
-          })
+          }),
+null, {
+            sameSite: 'strict'
+          }
         ],
-        [
-          'okta-oauth-nonce',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ],
-        [
-          'okta-oauth-state',
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        ]
+        nonceCookie,
+        stateCookie
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'idp_scope=scope1%20scope2&' +
-                            'nonce=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
                             'response_type=id_token&' +
-                            'state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&' +
+                            'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });

--- a/packages/okta-auth-js/test/spec/tokenManager.js
+++ b/packages/okta-auth-js/test/spec/tokenManager.js
@@ -197,8 +197,9 @@ describe('TokenManager', function() {
       expect(setCookieMock).toHaveBeenCalledWith(
         'okta-token-storage',
         JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
-        '2200-01-01T00:00:00.000Z',
-        undefined // secure
+        '2200-01-01T00:00:00.000Z', {
+          sameSite: 'strict'
+        }
       );
     });
     it('defaults to cookie-based storage if sessionStorage cannot be written to', function() {
@@ -219,8 +220,9 @@ describe('TokenManager', function() {
       expect(setCookieMock).toHaveBeenCalledWith(
         'okta-token-storage',
         JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
-        '2200-01-01T00:00:00.000Z',
-        undefined // secure
+        '2200-01-01T00:00:00.000Z', {
+          sameSite: 'strict'
+        }
       );
     });
   });
@@ -1239,8 +1241,9 @@ describe('TokenManager', function() {
         expect(setCookieMock).toHaveBeenCalledWith(
           'okta-token-storage',
           JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
-          '2200-01-01T00:00:00.000Z',
-          undefined // secure
+          '2200-01-01T00:00:00.000Z', {
+            sameSite: 'strict'
+          }
         );
       });
 
@@ -1251,8 +1254,10 @@ describe('TokenManager', function() {
         expect(setCookieMock).toHaveBeenCalledWith(
           'okta-token-storage',
           JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
-          '2200-01-01T00:00:00.000Z',
-          true // secure
+          '2200-01-01T00:00:00.000Z', {
+            secure: true,
+            sameSite: 'strict'
+          }
         );
       });
 
@@ -1289,8 +1294,9 @@ describe('TokenManager', function() {
         expect(setCookieMock).toHaveBeenCalledWith(
           'okta-token-storage',
           JSON.stringify({anotherKey: tokens.standardIdTokenParsed}),
-          '2200-01-01T00:00:00.000Z',
-          undefined // secure
+          '2200-01-01T00:00:00.000Z', {
+            sameSite: 'strict'
+          }
         );
       });
     });
@@ -1305,8 +1311,9 @@ describe('TokenManager', function() {
         expect(setCookieMock).toHaveBeenCalledWith(
           'okta-token-storage',
           '{}',
-          '2200-01-01T00:00:00.000Z',
-          undefined // secure
+          '2200-01-01T00:00:00.000Z', {
+            sameSite: 'strict'
+          }
         );
       });
     });

--- a/test/app/public/oidc-app.css
+++ b/test/app/public/oidc-app.css
@@ -11,11 +11,19 @@
   overflow-wrap: break-word;
 }
 
-input {
-  font-size: larger;
+input[type=text] {
   width: 600px;
 }
 
+label,
+input,
+select {
+  font-size: larger;
+}
+
+label {
+  margin-right: 10px;
+}
 a {
   padding: 4px;
   margin: 4px;

--- a/test/app/src/config.js
+++ b/test/app/src/config.js
@@ -22,6 +22,8 @@ function getConfigFromUrl() {
   const pkce = url.searchParams.get('pkce') && url.searchParams.get('pkce') !== 'false';
   const scopes = (url.searchParams.get('scopes') || 'openid,email').split(',');
   const responseType = (url.searchParams.get('responseType') || 'id_token,token').split(',');
+  const storage = url.searchParams.get('storage') || undefined;
+  const secure = url.searchParams.get('secure') === 'on'; // currently opt-in.
   return {
     redirectUri: REDIRECT_URI,
     issuer,
@@ -29,6 +31,10 @@ function getConfigFromUrl() {
     pkce,
     scopes,
     responseType,
+    tokenManager: {
+      storage,
+      secure,
+    },
   };
 }
 
@@ -45,4 +51,15 @@ function clearStorage() {
   localStorage.removeItem(STORAGE_KEY);
 }
 
-export { getDefaultConfig, getConfigFromUrl, saveConfigToStorage, getConfigFromStorage, clearStorage };
+function flattenConfig(config) {
+  let flat = {};
+  Object.assign(flat, config.tokenManager);
+  Object.keys(config).forEach(key => {
+    if (key !== 'tokenManager') {
+      flat[key] = config[key];
+    }
+  });
+  return flat;
+}
+
+export { getDefaultConfig, getConfigFromUrl, saveConfigToStorage, getConfigFromStorage, clearStorage, flattenConfig };

--- a/test/app/src/form.js
+++ b/test/app/src/form.js
@@ -1,17 +1,32 @@
 /* global document */
+import { flattenConfig } from './config';
+
 const Form = `
   <form target="/oidc" method="GET">
-  <label for="issuer">Issuer</label><input id="issuer" name="issuer" /><br/>
-  <label for="clientId">Client ID</label><input id="clientId" name="clientId" /><br/>
+  <label for="issuer">Issuer</label><input id="issuer" name="issuer" type="text" /><br/>
+  <label for="clientId">Client ID</label><input id="clientId" name="clientId" type="text" /><br/>
   <label for="pkce">PKCE</label><input id="pkce" name="pkce" type="checkbox"/><br/>
+  <label for="storage">Storage</label>
+  <select id="storage" name="storage">
+    <option value="" selected>Auto</option>
+    <option value="localStorage">Local Storage</option>
+    <option value="sessionStorage">Session Storage</option>
+    <option value="cookie">Cookie</option>
+    <option value="memory">Memory</option>
+  </select><br/>
+  <label for="secure">Secure Cookies</label><input id="secure" name="secure" type="checkbox"/><br/>
+  <hr/>
   <input id="login-submit" type="submit" value="Update Config"/>
   </form>
 `;
 
 function updateForm(config) {
+  config = flattenConfig(config);
   document.getElementById('issuer').value = config.issuer;
   document.getElementById('clientId').value = config.clientId;
   document.getElementById('pkce').checked = !!config.pkce;
+  document.querySelector(`#storage [value="${config.storage || ''}"]`).selected = true;
+  document.getElementById('secure').checked = !!config.secure;
 }
 
 export { Form, updateForm };

--- a/test/app/src/testApp.js
+++ b/test/app/src/testApp.js
@@ -13,7 +13,7 @@
 /* global document, window, Promise, console */
 /* eslint-disable no-console */
 import OktaAuth from '@okta/okta-auth-js';
-import { saveConfigToStorage } from './config';
+import { saveConfigToStorage, flattenConfig } from './config';
 import { MOUNT_PATH } from './constants';
 import { htmlString, toQueryParams } from './util';
 import { Form, updateForm } from './form';
@@ -89,7 +89,7 @@ export default TestApp;
 Object.assign(TestApp.prototype, {
   // Mount into the DOM
   mount: function(window, rootElem) {
-    this.originalUrl = MOUNT_PATH + toQueryParams(this.config);
+    this.originalUrl = MOUNT_PATH + toQueryParams(flattenConfig(this.config));
     this.rootElem = rootElem;
     this.rootElem.innerHTML = Layout;
     updateForm(this.config);
@@ -100,7 +100,7 @@ Object.assign(TestApp.prototype, {
   getSDKInstance() {
     return Promise.resolve()
       .then(() => {
-        this.oktaAuth = this.oktaAuth || new OktaAuth(this.config); // can throw
+        this.oktaAuth = this.oktaAuth || new OktaAuth(Object.assign({}, this.config)); // can throw
         this.oktaAuth.tokenManager.on('error', this._onTokenError.bind(this));
       });
   },

--- a/test/app/src/webpackEntry.js
+++ b/test/app/src/webpackEntry.js
@@ -1,5 +1,6 @@
 /* entry point for SPA application */
 /* global window, document */
+import Cookies from 'js-cookie';
 import TestApp from './testApp';
 import { getDefaultConfig, getConfigFromUrl, getConfigFromStorage, clearStorage } from './config';
 
@@ -10,7 +11,11 @@ const rootElem = document.getElementById('root');
 function mount() {
   // Create the app as a function of config
   app = new TestApp(config);
-  window._testApp = app; // Expose for console fiddling
+
+  // Expose for console fiddling
+  window._testApp = app;
+  window._cookies = Cookies;
+
   app.mount(window, rootElem);
   return app;
 }


### PR DESCRIPTION
- will set a 'SameSite' value on all cookies set by this SDK. Currently, these are: `okta-oauth-nonce`, `okta-oauth-state` `okta-oauth-redirect-params`, and `okta-oauth-token` (only if using tokenManager.storage = "cookie")

`okta-oauth-nonce` and `okta-oauth-state` are intended to be accessed server-side. These cookies will be set with "SameSite: Lax"

All other cookies set by the SDK are meant to be accessed client-side using Javascript. The "SameSite" setting is set to "Strict" for these. (`okta-oauth-redirect-params`, and `okta-oauth-token`)

- Updates the E2E test harness application to include settings related to cookies. This is to facilitate manual testing.