### PR TITLE
feat: signOut uses redirect method. new method closeSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - [#309](https://github.com/okta/okta-auth-js/pull/309) - Removed `Q` library, now using standard Promise. IE11 will require a polyfill for the `Promise` object. Use of `Promise.prototype.finally` requires Node > 10.3 for server-side use.
 
+- [#310](https://github.com/okta/okta-auth-js/pull/310)
+  - `postLogoutRedirectUri` will default to `window.location.origin`
+  - `signOut` will revoke access token and perform redirect by default. Fallback to XHR (`closeSession`) if no idToken.
+  - New method `closeSession` for XHR signout without redirect or reload.
+  - New method `revokeAccessToken`
+
 ### Other
 
 ## 2.11.2

--- a/README.md
+++ b/README.md
@@ -48,6 +48,29 @@ Installing the Authentication SDK is simple. You can include it in your project 
 You'll also need:
 
 * An Okta account, called an _organization_ (sign up for a free [developer organization](https://developer.okta.com/signup) if you need one)
+* An Okta application, which can be created using the Okta Admin UI
+
+### Creating your Okta application
+
+When creating a new Okta application, you can specify the application type. This SDK is designed to work with `SPA` (Single-page Applications) or `Web` applications. A `SPA` application will perform all logic and authorization flows client-side. A `Web` application will perform authorization flows on the server.
+
+### Configuring your Okta application
+
+From the Okta Admin UI, click `Applications`, then select your application. You can view and edit your Okta application's configuration under the application's `General` tab.
+
+#### Client ID
+
+A string which uniquely identifies your Okta application.
+
+#### Login redirect URIs
+
+To sign users in, your application redirects the browser to an Okta-hosted sign-in page. Okta then redirects back to your application with information about the user. You can learn more about how this works on [Okta-hosted flows](https://developer.okta.com/docs/concepts/okta-hosted-flows/).
+
+You need to whitelist the login redirect URL in your Okta application settings.
+
+#### Logout redirect URIs
+
+After you sign users out of your app and out of Okta, you have to redirect users to a specific location in your application. You need to whitelist the post sign-out URL in your Okta application settings.
 
 ### Using the npm module
 
@@ -194,8 +217,8 @@ tokenManager: {
 | -------------- | ------------ |
 | `issuer`       | Specify a custom issuer to perform the OIDC flow. Defaults to the base url parameter if not provided. |
 | `clientId`     | Client Id pre-registered with Okta for the OIDC authentication flow. |
-| `redirectUri`  | The url that is redirected to when using `token.getWithRedirect`. This must be pre-registered as part of client registration. If no `redirectUri` is provided, defaults to the current origin. |
-| `postLogoutRedirectUri` | Specify the url where the browser should be redirected after [signOut](#signout). This url must be added to the list of `Logout redirect URIs` on the application's `General Settings` tab.
+| `redirectUri`  | The url that is redirected to when using `token.getWithRedirect`. This must be listed in your Okta application's [Login redirect URIs](#login-redirect-uris). If no `redirectUri` is provided, defaults to the current origin (`window.location.origin`). |
+| `postLogoutRedirectUri` | Specify the url where the browser should be redirected after [signOut](#signout). This url must be listed in your Okta application's [Logout redirect URIs](#logout-redirect-uris). If not specified, your application's origin (`window.location.origin`) will be used.
 | `pkce`  | If set to true, the authorization flow will automatically use PKCE.  The authorize request will use `response_type=code`, and `grant_type=authorization_code` will be used on the token request.  All these details are handled for you, including the creation and verification of code verifiers. |
 | `authorizeUrl` | Specify a custom authorizeUrl to perform the OIDC flow. Defaults to the issuer plus "/v1/authorize". |
 | `userinfoUrl`  | Specify a custom userinfoUrl. Defaults to the issuer plus "/v1/userinfo". |
@@ -331,6 +354,8 @@ var config = {
 
 * [signIn](#signinoptions)
 * [signOut](#signout)
+* [closeSession](#closesession)
+* [revokeAccessToken](#revokeaccesstokenaccesstoken)
 * [forgotPassword](#forgotpasswordoptions)
 * [unlockAccount](#unlockaccountoptions)
 * [verifyRecoveryToken](#verifyrecoverytokenoptions)
@@ -402,51 +427,30 @@ authClient.signIn({
 
 ### `signOut()`
 
-Signs the user out of their current [Okta session](https://developer.okta.com/docs/api/resources/sessions) and clears all tokens stored locally in the `TokenManager`. The Okta session can be closed using either an `XHR` method or a `redirect` method. By default, the `XHR` method is used. Here are some points to consider when deciding which method is most appropriate for your application:
+Signs the user out of their current [Okta session](https://developer.okta.com/docs/api/resources/sessions) and clears all tokens stored locally in the `TokenManager`. By default, the access token is revoked so it can no longer be used. Some points to consider:
 
-XHR:
-
-* Executes in the background. The user will see not any change to `window.location`.
-* Will fail if 3rd-party cookies are blocked by the browser.
-* If the session is already closed, the method will fail and reject the returned Promise. This error can be caught by the app and handled seamlessly.
-* It is recommended (but not required) for the app to call `window.location.reload()` after the `XHR` method completes to ensure your app is properly re-initialized in an unauthenticated state.
-* For more information, see [Close Current Session](https://developer.okta.com/docs/reference/api/sessions/#close-current-session) in the Session API documentation.
-
-Redirect:
-
-* Will change the `window.location` to an Okta-hosted page before redirecting to a URI of your choice.
-* No issue with 3rd-party cookies.
-* Requires a `postLogoutRedirectUri` to be specified. This URI must be whitelisted in the Okta application's settings. If the `postLogoutRedirectUri` is unknown or invalid the redirect will end on a 400 error page from Okta. This error will be visible to the user and cannot be handled by the app.
-* Requires a valid ID token. If an ID token is not available, `signOut` will fallback to using the `XHR` method and then redirect to the `postLogoutRedirectUri`.
+* Will redirect to an Okta-hosted page before returning to your app.
+* If a `postLogoutRedirectUri` has not been specified or configured, `window.location.origin` will be used as the return URI. This URI must be listed in the Okta application's [Login redirect URIs](#login-redirect-uris). If the URI is unknown or invalid the redirect will end on a 400 error page from Okta. This error will be visible to the user and cannot be handled by the app.
+* Requires a valid ID token. If an ID token is not available, `signOut` will fallback to using the XHR-based [closeSession](#closesession) method. This method may fail to sign the user out if 3rd-party cookies have been blocked by the browser.
 * For more information, see [Logout](https://developer.okta.com/docs/reference/api/oidc/#logout) in the OIDC API documentation.
 
 `signOut` takes the following options:
 
-* `postLogoutRedirectUri` - Setting a value will enable the logout redirect method. **The URI must be whitelisted** as a `Logout Redirect Uri` in your application's general settings. It is common to use your application's origin URI as the `postLogoutRedirectUri` so that users are sent to the application "home page" after signout.
+* `postLogoutRedirectUri` - Setting a value will override the `postLogoutRedirectUri` configured on the SDK.
 * `state` - An optional value, used along with `postLogoutRedirectUri`. If set, this value will be returned as a query parameter during the redirect to the `postLogoutRedirectUri`
-* `idToken` - Specifies the ID token object. This is only relevant when a `postLogoutRedirectUri` has been specified. By default, `signOut` will look for a token object named `idToken` within the `TokenManager`. If you have stored the id token object in a different location, you should retrieve it first and then pass it here.
-* `revokeAccessToken` - If `true`, the access token will be revoked before the session is closed.
-* `accessToken` - Specifies the access token object. This is only relevant when the `revokeAccessToken` option is `true`. By default, `signOut` will look for a token object named `token` within the `TokenManager`. If you have stored the access token object in a different location, you should retrieve it first and then pass it here.
+* `idToken` - Specifies the ID token object. By default, `signOut` will look for a token object named `idToken` within the `TokenManager`. If you have stored the id token object in a different location, you should retrieve it first and then pass it here.
+* `revokeAccessToken` - If `false`, the access token will not be revoked. Use this option with care: not revoking the access token may pose a security risk if the token has been leaked outside the application.
+* `accessToken` - Specifies the access token object. By default, `signOut` will look for a token object named `accessToken` within the `TokenManager`. If you have stored the access token object in a different location, you should retrieve it first and then pass it here. This options is ignored if the `revokeAccessToken` option is `false`.
 
 ```javascript
-// Sign out using the XHR method
+// Sign out using the default options
 authClient.signOut()
-.then(function() {
-  console.log('successfully logged out');
-})
-.catch(function(err) {
-  console.error(err);
-})
-.then(function() {
-  // Reload app in unauthenticated state
-  window.location.reload();
-});
 ```
 
 ```javascript
-// Sign out using the redirect method, specifying the current window origin as the post logout URI
+// Override the post logout URI for this call
 authClient.signOut({
-  postLogoutRedirectUri: window.location.origin
+  postLogoutRedirectUri: `${window.location.origin}/logout/callback`
 });
 ```
 
@@ -454,16 +458,7 @@ authClient.signOut({
 // In this case, the ID token is stored under the 'myIdToken' key
 var idToken = await authClient.tokenManager.get('myIdToken');
 authClient.signOut({
-  idToken: idToken,
-  postLogoutRedirectUri: window.location.origin
-});
-```
-
-```javascript
-// Revoke the access token and sign out using the redirect method
-authClient.signOut({
-  revokeAccessToken: true,
-  postLogoutRedirectUri: window.location.origin
+  idToken: idToken
 });
 ```
 
@@ -471,11 +466,36 @@ authClient.signOut({
 // In this case, the access token is stored under the 'myAccessToken' key
 var accessToken = await authClient.tokenManager.get('myAccessToken');
 authClient.signOut({
-  accessToken: accessToken,
-  revokeAccessToken: true,
-  postLogoutRedirectUri: window.location.origin
+  accessToken: accessToken
 });
 ```
+
+### `closeSession()`
+
+Signs the user out of their current [Okta session](https://developer.okta.com/docs/api/resources/sessions) and clears all tokens stored locally in the `TokenManager`. This method is an XHR-based alternative to [signOut](#signout), which will redirect to Okta before returning to your application. Here are some points to consider when using this method:
+
+* Executes in the background. The user will see not any change to `window.location`.
+* Will fail to sign the user out if 3rd-party cookies are blocked by the browser.
+* Does not revoke the access token. It is strongly recommended to call [revokeAccessToken](#revokeaccesstokenaccesstoken) before calling this method
+* It is recommended (but not required) for the app to call `window.location.reload()` after the `XHR` method completes to ensure your app is properly re-initialized in an unauthenticated state.
+* For more information, see [Close Current Session](https://developer.okta.com/docs/reference/api/sessions/#close-current-session) in the Session API documentation.
+
+```javascript
+await authClient.revokeAccessToken(); // strongly recommended
+authClient.closeSession()
+  .then(() => {
+    window.location.reload(); // optional
+  })
+  .catch(e => {
+    if (e.xhr && e.xhr.status === 429) {
+      // Too many requests
+    }
+  })
+```
+
+### `revokeAccessToken(accessToken?)`
+
+Revokes the access token for this application so it can no longer be used to authenticate API requests. By default, `revokeAccessToken` will look for a token object named `accessToken` within the `TokenManager`. If you have stored the access token object in a different location, you should retrieve it first and then pass it here. Returns a promise that resolves when the operation has completed. This method will succeed even if the access token has already been revoked or removed.
 
 ### `forgotPassword(options)`
 

--- a/packages/okta-auth-js/.babelrc
+++ b/packages/okta-auth-js/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-env"]
-}

--- a/packages/okta-auth-js/package.json
+++ b/packages/okta-auth-js/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@babel/cli": "^7.8.0",
     "@babel/core": "^7.8.0",
+    "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.8.2",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",

--- a/packages/okta-auth-js/test/spec/browser.js
+++ b/packages/okta-auth-js/test/spec/browser.js
@@ -7,8 +7,10 @@ var AuthApiError = require('../../lib/errors/AuthApiError');
 
 describe('Browser', function() {
   var auth;
+  var issuer;
   beforeEach(function() {
-    auth = new OktaAuth({ url: 'http://my-okta-domain' });
+    issuer =  'http://my-okta-domain';
+    auth = new OktaAuth({ url: issuer });
   });
 
   it('is a valid constructor', function() {
@@ -95,328 +97,328 @@ describe('Browser', function() {
     })
   });
 
-  describe('signOut', function() {
-    beforeEach(function() {
-      global.window.location.assign = jest.fn();
-    });
-    it('Default options: clear TokenManager, close session, no redirect', function() {
-      spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-      spyOn(auth.tokenManager, 'clear');
-      return auth.signOut()
+  describe('revokeAccessToken', function() {
+    it('will read from TokenManager and call token.revoke', function() {
+      var accessToken = { accessToken: 'fake' };
+      spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(accessToken));
+      spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
+      return auth.revokeAccessToken()
         .then(function() {
-          expect(auth.tokenManager.clear).toHaveBeenCalled();
-          expect(auth.session.close).toHaveBeenCalled();
-          expect(window.location.assign).not.toHaveBeenCalled();
-        });
-    });
-    describe('revokeAccessToken', function() {
-      it('will call token.revoke', function() {
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'clear');
-        var accessToken = { accessToken: 'fake' };
-        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(accessToken));
-        spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
-        return auth.signOut({ revokeAccessToken: true })
-          .then(function() {
-            expect(auth.token.revoke).toHaveBeenCalledWith(accessToken);
-            expect(auth.tokenManager.clear).toHaveBeenCalled();
-            expect(auth.session.close).toHaveBeenCalled();
-          });
-      });
-      it('will throw if token.revoke rejects with unknown error', function() {
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'clear');
-        var accessToken = { accessToken: 'fake' };
-        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(accessToken));
-        var testError = new Error('test error');
-        spyOn(auth.token, 'revoke').and.callFake(function() {
-          return Promise.reject(testError);
-        });
-        return auth.signOut({ revokeAccessToken: true })
-          .catch(function(e) {
-            expect(e).toBe(testError);
-          });
-      });
-      it('will not throw if token.revoke rejects with AuthApiError', function() {
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'clear');
-        var accessToken = { accessToken: 'fake' };
-        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(accessToken));
-        var testError = new AuthApiError({});
-        spyOn(auth.token, 'revoke').and.callFake(function() {
-          return Promise.reject(testError);
-        });
-        return auth.signOut({ revokeAccessToken: true })
-        .then(function() {
+          expect(auth.tokenManager.get).toHaveBeenCalledWith('accessToken');
           expect(auth.token.revoke).toHaveBeenCalledWith(accessToken);
-          expect(auth.tokenManager.clear).toHaveBeenCalled();
-          expect(auth.session.close).toHaveBeenCalled();
         });
-      });
-      it('by default, will read access token from TokenManager using key "token"', function() {
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'clear');
-        var accessToken = { accessToken: 'fake' };
-        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(accessToken));
-        spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
-        return auth.signOut({ revokeAccessToken: true })
-          .then(function() {
-            expect(auth.tokenManager.get).toHaveBeenCalledWith('token');
-            expect(auth.token.revoke).toHaveBeenCalledWith(accessToken);
-            expect(auth.tokenManager.clear).toHaveBeenCalled();
-            expect(auth.session.close).toHaveBeenCalled();
-          });
-      });
-      it('can pass an access token object', function() {
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'clear');
-        var accessToken = { accessToken: 'fake' };
-        spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'get');
-        return auth.signOut({ revokeAccessToken: true, accessToken: accessToken })
-          .then(function() {
-            expect(auth.tokenManager.get).not.toHaveBeenCalled();
-            expect(auth.token.revoke).toHaveBeenCalledWith(accessToken);
-            expect(auth.tokenManager.clear).toHaveBeenCalled();
-            expect(auth.session.close).toHaveBeenCalled();
-          });
-      });
-      it('if accessToken=false, will not revoke or read from TokenManager', function() {
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'clear');
-        spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'get');
-        return auth.signOut({ revokeAccessToken: true, accessToken: false })
-          .then(function() {
-            expect(auth.tokenManager.get).not.toHaveBeenCalled();
-            expect(auth.token.revoke).not.toHaveBeenCalled();
-            expect(auth.tokenManager.clear).toHaveBeenCalled();
-            expect(auth.session.close).toHaveBeenCalled();
-          });
-      });
-      it('if accessToken cannot be located, will not attempt revoke', function() {
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'clear');
-        spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve())
-        return auth.signOut({ revokeAccessToken: true })
-          .then(function() {
-            expect(auth.tokenManager.get).toHaveBeenCalled();
-            expect(auth.token.revoke).not.toHaveBeenCalled();
-            expect(auth.tokenManager.clear).toHaveBeenCalled();
-            expect(auth.session.close).toHaveBeenCalled();
-          });
-      });
-      it('can be combined with "postLogoutRedirectUri"', function() {
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'clear');
-        var accessToken = { accessToken: 'fake' };
-        var idToken = { idToken: 'fake' };
-
-        spyOn(auth.tokenManager, 'get');
-        spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
-        return auth.signOut({ revokeAccessToken: true, accessToken: accessToken, postLogoutRedirectUri: 'http://someother', idToken: idToken })
-          .then(function() {
-            expect(auth.tokenManager.get).not.toHaveBeenCalled();
-            expect(auth.token.revoke).toHaveBeenCalledWith(accessToken);
-            expect(auth.tokenManager.clear).toHaveBeenCalled();
-            expect(auth.session.close).not.toHaveBeenCalled();
-            expect(window.location.assign).toHaveBeenCalledWith('http://my-okta-domain/oauth2/v1/logout?id_token_hint=fake&post_logout_redirect_uri=http%3A%2F%2Fsomeother');
-          });
-      });
-
-      it('can be combined with "postLogoutRedirectUri" (no id token)', function() {
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'clear');
-        var accessToken = { accessToken: 'fake' };
-        var idToken = false;
-
-        spyOn(auth.tokenManager, 'get');
-        spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
-        return auth.signOut({ revokeAccessToken: true, accessToken: accessToken, postLogoutRedirectUri: 'http://someother', idToken: idToken })
-          .then(function() {
-            expect(auth.tokenManager.get).not.toHaveBeenCalled();
-            expect(auth.token.revoke).toHaveBeenCalledWith(accessToken);
-            expect(auth.tokenManager.clear).toHaveBeenCalled();
-            expect(auth.session.close).toHaveBeenCalled();
-            expect(window.location.assign).toHaveBeenCalledWith('http://someother');
-          });
-      });
     });
-    describe('closeSession', function() {
-      it('will throw unknown errors', function() {
-        var testError = new Error('test error');
-        spyOn(auth.session, 'close').and.callFake(function() {
-          return Promise.reject(testError);
-        });
-        return auth.signOut()
+    it('will throw if token.revoke rejects with unknown error', function() {
+      var accessToken = { accessToken: 'fake' };
+      spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(accessToken));
+      var testError = new Error('test error');
+      spyOn(auth.token, 'revoke').and.callFake(function() {
+        return Promise.reject(testError);
+      });
+      return auth.revokeAccessToken()
         .catch(function(e) {
           expect(e).toBe(testError);
         });
-      });
-      it('catches and absorbs "AuthApiError" errors', function() {
-        var testError = new AuthApiError({});
-        spyOn(auth.session, 'close').and.callFake(function() {
-          return Promise.reject(testError);
-        });
-        return auth.signOut()
+    });
+    it('can pass an access token object to bypass TokenManager', function() {
+      var accessToken = { accessToken: 'fake' };
+      spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
+      spyOn(auth.tokenManager, 'get');
+      return auth.revokeAccessToken(accessToken)
         .then(function() {
+          expect(auth.tokenManager.get).not.toHaveBeenCalled();
+          expect(auth.token.revoke).toHaveBeenCalledWith(accessToken);
+        });
+    });
+    it('if accessToken cannot be located, will resolve without error', function() {
+      spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
+      spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve())
+      return auth.revokeAccessToken()
+        .then(() => {
+          expect(auth.tokenManager.get).toHaveBeenCalled();
+          expect(auth.token.revoke).not.toHaveBeenCalled();
+        });
+    });
+  });
+
+  describe('closeSession', function() {
+    it('Default options: clears TokenManager, closes session', function() {
+      spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+      spyOn(auth.tokenManager, 'clear');
+      return auth.closeSession()
+        .then(function() {
+          expect(auth.tokenManager.clear).toHaveBeenCalled();
           expect(auth.session.close).toHaveBeenCalled();
         });
+    });
+    it('catches and absorbs "AuthApiError" errors with errorCode E0000007 (RESOURCE_NOT_FOUND_EXCEPTION)', function() {
+      var testError = new AuthApiError({ errorCode: 'E0000007' });
+      spyOn(auth.session, 'close').and.callFake(function() {
+        return Promise.reject(testError);
       });
-    })
-    describe('postLogoutRedirectUri', function() {
-      it('can be set by config', function() {
-        auth = new OktaAuth({
-          url: 'http://my-okta-domain',
-          postLogoutRedirectUri: 'http://someother' 
+      return auth.closeSession()
+      .then(function() {
+        expect(auth.session.close).toHaveBeenCalled();
+      });
+    });
+    it('will throw unknown errors', function() {
+      var testError = new Error('test error');
+      spyOn(auth.session, 'close').and.callFake(function() {
+        return Promise.reject(testError);
+      });
+      return auth.closeSession()
+      .catch(function(e) {
+        expect(e).toBe(testError);
+      });
+    });
+  });
+
+  describe('signOut', function() {
+    let origin;
+    let encodedOrigin;
+    beforeEach(function() {
+      delete global.window.location;
+      origin = 'http://localhost:3000';
+      encodedOrigin = encodeURIComponent(origin);
+      global.window.location = {
+        origin,
+        assign: jest.fn(),
+        reload: jest.fn()
+      };
+    });
+    describe('with idToken and accessToken', () => {
+      let idToken;
+      let accessToken;
+
+      function initSpies() {
+        spyOn(auth.tokenManager, 'get').and.callFake(key => {
+          if (key === 'idToken') {
+            return idToken;
+          } else if (key === 'token') {
+            return accessToken;
+          } else {
+            throw new Error(`Unknown token key: ${key}`);
+          }
         });
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+        spyOn(auth.tokenManager, 'clear');
+        spyOn(auth, 'revokeAccessToken').and.returnValue(Promise.resolve());
+        spyOn(auth, 'closeSession').and.returnValue(Promise.resolve());
+      }
+
+      beforeEach(() => {
+        accessToken = { accessToken: 'fake' };
+        idToken = { idToken: 'fake' };
+        initSpies();
+      });
+
+      it('Default options: will revokeAccessToken and use window.location.href for postLogoutRedirectUri', function() {
         return auth.signOut()
           .then(function() {
-            expect(window.location.assign).toHaveBeenCalledWith('http://someother');
-          });
-      });
-    
-      it('supports custom authorization server', function() {
-        auth = new OktaAuth({
-          url: 'http://my-okta-domain',
-          issuer: 'http://my-okta-domain/oauth2/custom-as',
-        });
-        var idToken = { idToken: 'fake' };
-        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(idToken));
-        return auth.signOut({ postLogoutRedirectUri: 'http://someother' })
-          .then(function() {
-            expect(window.location.assign).toHaveBeenCalledWith('http://my-okta-domain/oauth2/custom-as/v1/logout?id_token_hint=fake&post_logout_redirect_uri=http%3A%2F%2Fsomeother');
-          });
-      });
-  
-      it('will catch exceptions from session.close and perform redirect', function() {
-        auth = new OktaAuth({
-          url: 'http://my-okta-domain',
-          postLogoutRedirectUri: 'http://someother' 
-        });
-        var testError = new Error('test error');
-        spyOn(auth.session, 'close').and.callFake(function() {
-          return Promise.reject(testError);
-        });
-        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(null));
-        return auth.signOut()
-          .then(function() {
-            expect(auth.session.close).toHaveBeenCalled();
-            expect(window.location.assign).toHaveBeenCalledWith('http://someother');
+            expect(auth.tokenManager.get).toHaveBeenNthCalledWith(1, 'idToken');
+            expect(auth.tokenManager.get).toHaveBeenNthCalledWith(2, 'token');
+            expect(auth.revokeAccessToken).toHaveBeenCalledWith(accessToken);
+            expect(auth.tokenManager.clear).toHaveBeenCalled();
+            expect(auth.closeSession).not.toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith(`${issuer}/oauth2/v1/logout?id_token_hint=${idToken.idToken}&post_logout_redirect_uri=${encodedOrigin}`);
           });
       });
 
-      it('by default, will try to get idToken from TokenManager', function() {
-        var idToken = { idToken: 'fake' };
-  
-        spyOn(auth.tokenManager, 'clear').and.callFake(function() {
-          // Catch condition where clear() is called before the idToken is read
-          idToken = false;
+      it('supports custom authorization server', function() {
+        issuer = 'http://my-okta-domain/oauth2/custom-as';
+        auth = new OktaAuth({
+          url: 'http://my-okta-domain',
+          issuer
         });
-  
-        spyOn(auth.tokenManager, 'get').and.callFake(function() {
-          return idToken;
-        })
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-        return auth.signOut({ postLogoutRedirectUri: 'http://someother' })
+        initSpies();
+        return auth.signOut()
           .then(function() {
-            expect(auth.tokenManager.get).toHaveBeenCalledWith('idToken');
-            expect(auth.session.close).not.toHaveBeenCalled();
-            expect(window.location.assign).toHaveBeenCalledWith('http://my-okta-domain/oauth2/v1/logout?id_token_hint=fake&post_logout_redirect_uri=http%3A%2F%2Fsomeother');
+            expect(window.location.assign).toHaveBeenCalledWith(`${issuer}/v1/logout?id_token_hint=${idToken.idToken}&post_logout_redirect_uri=${encodedOrigin}`);
           });
       });
-  
-      it('if idToken is passed, will skip token manager read and do location redirect', function() {
-        var idToken = { idToken: 'fake' };
+
+      it('if idToken is passed, will skip token manager read', function() {
         var customToken = { idToken: 'fake-custom' };
-        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(idToken));
-        return auth.signOut({ idToken: customToken, postLogoutRedirectUri: 'http://someother' })
+        return auth.signOut({ idToken: customToken })
           .then(function() {
-            expect(auth.tokenManager.get).not.toHaveBeenCalled();
-            expect(window.location.assign).toHaveBeenCalledWith('http://my-okta-domain/oauth2/v1/logout?id_token_hint=fake-custom&post_logout_redirect_uri=http%3A%2F%2Fsomeother');
+            expect(auth.tokenManager.get).toHaveBeenCalledTimes(1);
+            expect(auth.tokenManager.get).toHaveBeenNthCalledWith(1, 'token');
+            expect(window.location.assign).toHaveBeenCalledWith(`${issuer}/oauth2/v1/logout?id_token_hint=${customToken.idToken}&post_logout_redirect_uri=${encodedOrigin}`);
           });
       });
   
-      it('if idToken=false will skip token manager read and use session.close before redirecting', function() {
-        var idToken = { idToken: 'fake' };
-        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(idToken));
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-        return auth.signOut({ idToken: false, postLogoutRedirectUri: 'http://someother' })
+      it('if idToken=false will skip token manager read and call closeSession', function() {
+        return auth.signOut({ idToken: false })
           .then(function() {
-            expect(auth.tokenManager.get).not.toHaveBeenCalled();
-            expect(auth.session.close).toHaveBeenCalled();
-            expect(window.location.assign).toHaveBeenCalledWith('http://someother');
+            expect(auth.tokenManager.get).toHaveBeenCalledTimes(1);
+            expect(auth.tokenManager.get).toHaveBeenNthCalledWith(1, 'token');
+            expect(auth.closeSession).toHaveBeenCalled();
+            expect(window.location.reload).toHaveBeenCalled();
           });
       });
   
-  
-      it('redirect: (no idToken) - will close session and redirect to uri', function() {
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve());
+      describe('postLogoutRedirectUri', function() {
+        it('can be set by config', function() {
+          const postLogoutRedirectUri = 'http://someother';
+          const encodedUri = encodeURIComponent(postLogoutRedirectUri);
+          auth = new OktaAuth({
+            url: issuer,
+            postLogoutRedirectUri
+          });
+          initSpies();
+          return auth.signOut()
+            .then(function() {
+              expect(window.location.assign).toHaveBeenCalledWith(`${issuer}/oauth2/v1/logout?id_token_hint=${idToken.idToken}&post_logout_redirect_uri=${encodedUri}`);
+            });
+        });
+        it('can be passed as an option', function() {
+          const postLogoutRedirectUri = 'http://someother';
+          const encodedUri = encodeURIComponent(postLogoutRedirectUri);
+          return auth.signOut({ postLogoutRedirectUri })
+            .then(function() {
+              expect(window.location.assign).toHaveBeenCalledWith(`${issuer}/oauth2/v1/logout?id_token_hint=${idToken.idToken}&post_logout_redirect_uri=${encodedUri}`);
+            });
+        });
+      });
+
+      it('Can pass a "state" option', function() {
+        const state = 'foo=bar&yo=me';
+        const encodedState = encodeURIComponent(state);
+        return auth.signOut({ state })
+          .then(function() {
+            expect(window.location.assign).toHaveBeenCalledWith(`${issuer}/oauth2/v1/logout?id_token_hint=${idToken.idToken}&post_logout_redirect_uri=${encodedOrigin}&state=${encodedState}`);
+          });
+      });
+
+      it('Can pass a "revokeAccessToken=false" to skip accessToken logic', function() {
+        return auth.signOut({ revokeAccessToken: false })
+          .then(function() {
+            expect(auth.tokenManager.get).toHaveBeenCalledTimes(1);
+            expect(auth.tokenManager.get).toHaveBeenNthCalledWith(1, 'idToken');
+            expect(auth.revokeAccessToken).not.toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith(`${issuer}/oauth2/v1/logout?id_token_hint=${idToken.idToken}&post_logout_redirect_uri=${encodedOrigin}`);
+          });
+      });
+
+      it('Can pass a "accessToken=false" to skip accessToken logic', function() {
+        return auth.signOut({ accessToken: false })
+          .then(function() {
+            expect(auth.tokenManager.get).toHaveBeenCalledTimes(1);
+            expect(auth.tokenManager.get).toHaveBeenNthCalledWith(1, 'idToken');
+            expect(auth.revokeAccessToken).not.toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith(`${issuer}/oauth2/v1/logout?id_token_hint=${idToken.idToken}&post_logout_redirect_uri=${encodedOrigin}`);
+          });
+      });
+    });
+
+    describe('without idToken', () => {
+      let accessToken;
+
+      beforeEach(() => {
+        accessToken = { accessToken: 'fake' };
+        spyOn(auth.tokenManager, 'get').and.callFake(key => {
+          if (key === 'idToken') {
+            return;
+          } else if (key === 'token') {
+            return accessToken;
+          } else {
+            throw new Error(`Unknown token key: ${key}`);
+          }
+        });        
         spyOn(auth.tokenManager, 'clear');
-        return auth.signOut({ postLogoutRedirectUri: 'http://someother' })
+        spyOn(auth, 'revokeAccessToken').and.returnValue(Promise.resolve());
+      });
+
+      it('Default options: will revokeAccessToken and fallback to closeSession and window.location.reload()', function() {
+        spyOn(auth, 'closeSession').and.returnValue(Promise.resolve());
+        return auth.signOut()
           .then(function() {
+            expect(auth.tokenManager.get).toHaveBeenNthCalledWith(1, 'idToken');
+            expect(auth.tokenManager.get).toHaveBeenNthCalledWith(2, 'token');
+            expect(auth.revokeAccessToken).toHaveBeenCalledWith(accessToken);
             expect(auth.tokenManager.clear).toHaveBeenCalled();
-            expect(auth.session.close).toHaveBeenCalled();
-            expect(window.location.assign).toHaveBeenCalledWith('http://someother');
+            expect(auth.closeSession).toHaveBeenCalled();
+            expect(window.location.reload).toHaveBeenCalled();
           });
       });
-  
-      it('idToken: without a redirect option, it will not use logout redirect', function() {
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'clear');
-        return auth.signOut({ idToken: { idToken: 'fake' } })
+
+      it('Default options: will throw exceptions from closeSession and not call window.location.reload', function() {
+        const testError = new Error('test error');
+        spyOn(auth, 'closeSession').and.callFake(function() {
+          return Promise.reject(testError);
+        });
+        return auth.signOut()
           .then(function() {
-            expect(auth.tokenManager.clear).toHaveBeenCalled();
-            expect(auth.session.close).toHaveBeenCalled();
+            expect(false).toBe(true);
+          })
+          .catch(function(e) {
+            expect(e).toBe(testError);
+            expect(auth.closeSession).toHaveBeenCalled();
+            expect(window.location.reload).not.toHaveBeenCalled();
+          });
+      });
+
+      it('with postLogoutRedirectUri: will call window.location.assign', function() {
+        const postLogoutRedirectUri = 'http://someother';
+        spyOn(auth, 'closeSession').and.returnValue(Promise.resolve());
+        return auth.signOut({ postLogoutRedirectUri })
+          .then(function() {
+            expect(window.location.assign).toHaveBeenCalledWith(postLogoutRedirectUri);
+          });
+      });
+
+      it('with postLogoutRedirectUri: will throw exceptions from closeSession and not call window.location.assign', function() {
+        const postLogoutRedirectUri = 'http://someother';
+        const testError = new Error('test error');
+        spyOn(auth, 'closeSession').and.callFake(function() {
+          return Promise.reject(testError);
+        });
+        return auth.signOut({ postLogoutRedirectUri })
+          .then(function() {
+            expect(false).toBe(true);
+          })
+          .catch(function(e) {
+            expect(e).toBe(testError);
+            expect(auth.closeSession).toHaveBeenCalled();
             expect(window.location.assign).not.toHaveBeenCalled();
           });
       });
-  
-      it('idToken + postLogoutRedirectUri: will use logout redirect with "post_logout_redirect_uri"', function() {
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
+    });
+
+    describe('without accessToken', () => {
+      let idToken;
+      beforeEach(() => {
+        idToken = { idToken: 'fake' };
+        spyOn(auth.tokenManager, 'get').and.callFake(key => {
+          if (key === 'idToken') {
+            return idToken;
+          } else if (key === 'token') {
+            return;
+          } else {
+            throw new Error(`Unknown token key: ${key}`);
+          }
+        });
         spyOn(auth.tokenManager, 'clear');
-        return auth.signOut({ idToken: { idToken: 'fake' }, postLogoutRedirectUri: 'http://someother' })
-          .then(function() {
-            expect(auth.tokenManager.clear).toHaveBeenCalled();
-            expect(auth.session.close).not.toHaveBeenCalled();
-            expect(window.location.assign).toHaveBeenCalledWith('http://my-okta-domain/oauth2/v1/logout?id_token_hint=fake&post_logout_redirect_uri=http%3A%2F%2Fsomeother');
-          });
+        spyOn(auth, 'revokeAccessToken').and.returnValue(Promise.resolve());
       });
-  
-      it('idToken + postLogoutRedirectUri + state: logout redirect url includes "state" and "post_logout_redirect_uri"', function() {
-        spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
-        spyOn(auth.tokenManager, 'clear');
-        return auth.signOut({ idToken: { idToken: 'fake' }, postLogoutRedirectUri: 'http://someother', state: 'foo=bar&yo=me' })
-          .then(function() {
-            expect(auth.tokenManager.clear).toHaveBeenCalled();
-            expect(auth.session.close).not.toHaveBeenCalled();
-            expect(window.location.assign).toHaveBeenCalledWith('http://my-okta-domain/oauth2/v1/logout?id_token_hint=fake&post_logout_redirect_uri=http%3A%2F%2Fsomeother&state=foo%3Dbar%26yo%3Dme');
-          });
+
+      it('Default options: will not revoke accessToken', () => {
+        return auth.signOut()
+        .then(function() {
+          expect(auth.revokeAccessToken).not.toHaveBeenCalled();
+          expect(window.location.assign).toHaveBeenCalledWith(`${issuer}/oauth2/v1/logout?id_token_hint=${idToken.idToken}&post_logout_redirect_uri=${encodedOrigin}`);
+        });
+      });
+
+      it('Can pass an accessToken', () => {
+        const accessToken = { accessToken: 'custom-fake' };
+        return auth.signOut({ accessToken })
+        .then(function() {
+          expect(auth.revokeAccessToken).toHaveBeenCalledWith(accessToken);
+          expect(window.location.assign).toHaveBeenCalledWith(`${issuer}/oauth2/v1/logout?id_token_hint=${idToken.idToken}&post_logout_redirect_uri=${encodedOrigin}`);
+        });
       });
     });
 
-    describe('XHR logout', function() {
-      it('will not catch exceptions from session.close', function() {
-        auth = new OktaAuth({
-          url: 'http://my-okta-domain',
-        });
-        var testError = new Error('test error');
-        spyOn(auth.session, 'close').and.callFake(function() {
-          return Promise.reject(testError);
-        });
-        spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(null));
-        return auth.signOut()
-          .catch(function(e) {
-            expect(e).toBe(testError);
-          })
-          .then(function() {
-            expect(auth.session.close).toHaveBeenCalled();
-          });
-      });
-    });
   });
 
 });

--- a/packages/okta-auth-js/webpack.common.config.js
+++ b/packages/okta-auth-js/webpack.common.config.js
@@ -8,7 +8,16 @@ module.exports = {
       { test: /\.json$/, loader: 'json' }
     ],
     rules: [
-      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' }
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        query: {
+          presets: ['@babel/env'],
+          plugins: ['@babel/plugin-transform-runtime'],
+          sourceType: 'unambiguous'
+        }
+      }
     ]
   },
   plugins: [

--- a/test/app/src/config.js
+++ b/test/app/src/config.js
@@ -2,6 +2,7 @@
 import { CALLBACK_PATH, STORAGE_KEY } from './constants';
 const HOST = window.location.host;
 const REDIRECT_URI = `http://${HOST}${CALLBACK_PATH}`;
+const POST_LOGOUT_REDIRECT_URI = `http://${HOST}`;
 
 function getDefaultConfig() {
   const ISSUER = process.env.ISSUER;
@@ -9,6 +10,7 @@ function getDefaultConfig() {
   
   return {
     redirectUri: REDIRECT_URI,
+    postLogoutRedirectUri: POST_LOGOUT_REDIRECT_URI,
     issuer: ISSUER,
     clientId: CLIENT_ID,
     pkce: true,
@@ -18,6 +20,8 @@ function getDefaultConfig() {
 function getConfigFromUrl() {
   const url = new URL(window.location.href);
   const issuer = url.searchParams.get('issuer');
+  const redirectUri = url.searchParams.get('redirectUri') || REDIRECT_URI;
+  const postLogoutRedirectUri = url.searchParams.get('postLogoutRedirectUri') || POST_LOGOUT_REDIRECT_URI;
   const clientId = url.searchParams.get('clientId');
   const pkce = url.searchParams.get('pkce') && url.searchParams.get('pkce') !== 'false';
   const scopes = (url.searchParams.get('scopes') || 'openid,email').split(',');
@@ -25,7 +29,8 @@ function getConfigFromUrl() {
   const storage = url.searchParams.get('storage') || undefined;
   const secure = url.searchParams.get('secure') === 'on'; // currently opt-in.
   return {
-    redirectUri: REDIRECT_URI,
+    redirectUri,
+    postLogoutRedirectUri,
     issuer,
     clientId,
     pkce,
@@ -39,7 +44,13 @@ function getConfigFromUrl() {
 }
 
 function saveConfigToStorage(config) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+  const configCopy = {};
+  Object.keys(config).forEach(key => {
+    if (typeof config[key] !== 'function') {
+      configCopy[key] = config[key];
+    }
+  });
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(configCopy));
 }
 
 function getConfigFromStorage() {

--- a/test/app/src/form.js
+++ b/test/app/src/form.js
@@ -5,6 +5,8 @@ const Form = `
   <form target="/oidc" method="GET">
   <label for="issuer">Issuer</label><input id="issuer" name="issuer" type="text" /><br/>
   <label for="clientId">Client ID</label><input id="clientId" name="clientId" type="text" /><br/>
+  <label for="redirectUri">Redirect URI</label><input id="redirectUri" name="redirectUri" type="text" /><br/>
+  <label for="postLogoutRedirectUri">Post Logout Redirect URI</label><input id="postLogoutRedirectUri" name="postLogoutRedirectUri" type="text" /><br/>
   <label for="pkce">PKCE</label><input id="pkce" name="pkce" type="checkbox"/><br/>
   <label for="storage">Storage</label>
   <select id="storage" name="storage">
@@ -23,6 +25,8 @@ const Form = `
 function updateForm(config) {
   config = flattenConfig(config);
   document.getElementById('issuer').value = config.issuer;
+  document.getElementById('redirectUri').value = config.redirectUri;
+  document.getElementById('postLogoutRedirectUri').value = config.postLogoutRedirectUri;
   document.getElementById('clientId').value = config.clientId;
   document.getElementById('pkce').checked = !!config.pkce;
   document.querySelector(`#storage [value="${config.storage || ''}"]`).selected = true;

--- a/test/e2e/pageobjects/TestApp.js
+++ b/test/e2e/pageobjects/TestApp.js
@@ -8,9 +8,9 @@ class TestApp {
   get landingSelector() { return $('body.oidc-app.landing'); }
 
   // Authenticated landing
-  get logoutBtn() { return $('#logout'); }
   get logoutRedirectBtn() { return $('#logout-redirect'); }
-  get logoutLocalBtn() { return $('#logout-local'); }
+  get logoutXHRBtn() { return $('#logout-xhr'); }
+  get logoutAppBtn() { return $('#logout-app'); }
   get renewTokenBtn() { return $('#renew-token'); }
   get revokeTokenBtn() { return $('#revoke-token'); }
   get getTokenBtn() { return $('#get-token'); }
@@ -102,18 +102,18 @@ class TestApp {
     await browser.waitUntil(async () => this.landingSelector.then(el => el.isDisplayed()));
   }
 
-  async logout() {
-    await this.logoutBtn.then(el => el.click());
-    await this.waitForLoginBtn();
-  }
-
-  async logoutLocal() {
-    await this.logoutLocalBtn.then(el => el.click());
-    await this.waitForLoginBtn();
-  }
-
   async logoutRedirect() {
     await this.logoutRedirectBtn.then(el => el.click());
+    await this.waitForLoginBtn();
+  }
+
+  async logoutXHR() {
+    await this.logoutXHRBtn.then(el => el.click());
+    await this.waitForLoginBtn();
+  }
+
+  async logoutApp() {
+    await this.logoutAppBtn.then(el => el.click());
     await this.waitForLoginBtn();
   }
 
@@ -122,7 +122,7 @@ class TestApp {
   }
 
   async waitForLogoutBtn() {
-    return browser.waitUntil(async () => this.logoutBtn.then(el => el.isDisplayed()), 15000, 'wait for logout button');
+    return browser.waitUntil(async () => this.logoutRedirectBtn.then(el => el.isDisplayed()), 15000, 'wait for logout button');
   }
 
   async waitForCallback() {

--- a/test/e2e/specs/login.js
+++ b/test/e2e/specs/login.js
@@ -14,21 +14,21 @@ describe('E2E login', () => {
         await loginRedirect(flow);
         await TestApp.getUserInfo();
         await TestApp.assertUserInfo();
-        await TestApp.logout();
+        await TestApp.logoutRedirect();
       });
 
       it('can login using a popup window', async() => {
         await loginPopup(flow);
         await TestApp.getUserInfo();
         await TestApp.assertUserInfo();
-        await TestApp.logout();
+        await TestApp.logoutRedirect();
       });
 
       it('can login directly, calling signin() with username and password', async () => {
         await loginDirect(flow);
         await TestApp.getUserInfo();
         await TestApp.assertUserInfo();
-        await TestApp.logout();
+        await TestApp.logoutRedirect();
       });
     });
   });

--- a/test/e2e/specs/logout.js
+++ b/test/e2e/specs/logout.js
@@ -11,41 +11,63 @@ describe('E2E logout', () => {
       await loginPopup();
     });
 
-    it('can logout locally, keeping remote user session open', async () => {
-      await TestApp.logoutLocal();
-
-      // We should still be logged into Okta
-      await openOktaHome();
-      await OktaHome.waitForLoad();
-
-      // Now sign the user out
-      await OktaHome.closeInitialPopUp();
-      await OktaHome.signOut();
-      await browser.closeWindow();
-      await switchToMainWindow();
-
+    describe('logoutApp', () => {
+      it('can clear app session, keeping remote SSO session open', async () => {
+        await TestApp.logoutApp();
+  
+        // We should still be logged into Okta
+        await openOktaHome();
+        await OktaHome.waitForLoad();
+  
+        // Now sign the user out
+        await OktaHome.closeInitialPopUp();
+        await OktaHome.signOut();
+        await browser.closeWindow();
+        await switchToMainWindow();
+      });
+  
     });
 
-    it('can logout from okta, ending remote user session', async() => {
-      await TestApp.logout();
+    describe('logoutRedirect', () => {
+      it('can logout from okta, ending remote user session', async() => {
+        await TestApp.assertIdToken();
+        await TestApp.logoutRedirect();
+  
+        // We should not be logged into Okta
+        await openOktaHome();
+        await OktaLogin.waitForLoad();
+  
+        // cleanup
+        await browser.closeWindow();
+        await switchToMainWindow();
+      });
+  
+      it('no idToken: can logout from okta (using XHR fallback) and end back to the application', async () => {
+        await TestApp.clearTokens();
+        await TestApp.logoutRedirect();
 
-      // We should not be logged into Okta
-      await openOktaHome();
-      await OktaLogin.waitForLoad();
-
-      // cleanup
-      await browser.closeWindow();
-      await switchToMainWindow();
+        // We should not be logged into Okta
+        await openOktaHome();
+        await OktaLogin.waitForLoad();
+  
+        // cleanup
+        await browser.closeWindow();
+        await switchToMainWindow();
+      });
     });
 
-    it('can logout from okta and redirect back to the application', async () => {
-      await TestApp.assertIdToken();
-      await TestApp.logoutRedirect();
-    });
-
-    it('no idToken: can logout from okta and redirect back to the application', async () => {
-      await TestApp.clearTokens();
-      await TestApp.logoutRedirect();
+    describe('logoutXHR', () => {
+      it('can logout from okta using XHR, ending remote user session', async() => {
+        await TestApp.logoutXHR();
+  
+        // We should not be logged into Okta
+        await openOktaHome();
+        await OktaLogin.waitForLoad();
+  
+        // cleanup
+        await browser.closeWindow();
+        await switchToMainWindow();
+      });
     });
 
 });

--- a/test/e2e/specs/tokens.js
+++ b/test/e2e/specs/tokens.js
@@ -31,7 +31,7 @@ describe('token revoke', () => {
     const xhrError = await TestApp.xhrError.then(el => el.getText());
     assert(xhrError === 'Network request failed');
 
-    await TestApp.logout();
+    await TestApp.logoutRedirect();
   });
 });
 
@@ -52,7 +52,7 @@ describe('E2E token flows', () => {
           return txt !== prevToken;
         }, 10000);
         await TestApp.assertLoggedIn();
-        await TestApp.logout();
+        await TestApp.logoutRedirect();
       });
 
       it('can refresh all tokens', async () => {
@@ -71,7 +71,7 @@ describe('E2E token flows', () => {
           );
         }, 10000);
         await TestApp.assertLoggedIn();
-        await TestApp.logout();
+        await TestApp.logoutRedirect();
       });
 
       it('Can receive an error on token renew if user has signed out from Okta page', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -625,6 +625,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
+"@babel/plugin-transform-runtime@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.8.3.tgz#c0153bc0a5375ebc1f1591cb7eea223adea9f169"
+  integrity sha512-/vqUt5Yh+cgPZXXjmaG9NT8aVfThKk7G4OqkVhrXqwsC5soMn/qTCxs36rZ2QFhpfTJcjw4SNDIZ4RUb8OL4jQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz#28545216e023a832d4d3a1185ed492bcfeac08c8"
@@ -3928,7 +3938,7 @@ error@^7.0.2:
   dependencies:
     string-template "~0.2.1"
 
-es-abstract@^1.17.0-next.0, es-abstract@^1.17.0-next.1:
+es-abstract@^1.17.0-next.1:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.1.tgz#1331afa4cba2628b63e988104b9846c2d631b380"
   integrity sha512-WmWNHWmm/LDwK8jaeZic/g6sU1ZckM+vvOyCV1qFRhJJ6hzve6DRgthNQB7Lra1ocrw68HexLKYgtdxIPcb3Fg==
@@ -8971,7 +8981,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.2.tgz#dbf31d0fa98b1f29aa5169783b9c290cb865fea2"
   integrity sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==


### PR DESCRIPTION
- new method `closeSession` for XHR signout
- new method `revokeAccessToken`
- `signout` will use redirect method by default, fallback to XHR if no idToken
- `postLogoutRedirectUri` will default to `window.location.origin`