### PR TITLE
feat: parseFromUrl return tokens in hash, also include state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
   - New method `closeSession` for XHR signout without redirect or reload.
   - New method `revokeAccessToken`
 
--[#316](https://github.com/okta/okta-auth-js/pull/316) - Option `issuer` is required. Option `url` has been deprecated and is no longer used.
+- [#311](https://github.com/okta/okta-auth-js/pull/311) - `parseFromUrl` now returns tokens in an object hash (instead of array). The `state` parameter (passed to authorize request) is also returned.
+
+- [#316](https://github.com/okta/okta-auth-js/pull/316) - Option `issuer` is required. Option `url` has been deprecated and is no longer used.
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -1567,8 +1567,11 @@ authClient.token.getWithoutPrompt({
   // Use a custom IdP for social authentication
   idp: '0oa62b57p7c8PaGpU0h7'
  })
-.then(function(tokenOrTokens) {
-  // manage token or tokens
+.then(function(res) {
+  var tokens = res.tokens;
+
+  // Do something with tokens, such as
+  authClient.tokenManager.add('idToken', tokens.idToken);
 })
 .catch(function(err) {
   // handle OAuthError
@@ -1586,8 +1589,11 @@ authClient.token.getWithoutPrompt({
   responseType: 'id_token', // or array of types
   sessionToken: 'testSessionToken' // optional if the user has an existing Okta session
 })
-.then(function(tokenOrTokens) {
-  // manage token or tokens
+.then(function(res) {
+  var tokens = res.tokens;
+
+  // Do something with tokens, such as
+  authClient.tokenManager.add('idToken', tokens.idToken);
 })
 .catch(function(err) {
   // handle OAuthError
@@ -1602,8 +1608,11 @@ Create token with a popup.
 
 ```javascript
 authClient.token.getWithPopup(oauthOptions)
-.then(function(tokenOrTokens) {
-  // manage token or tokens
+.then(function(res) {
+  var tokens = res.tokens;
+
+  // Do something with tokens, such as
+  authClient.tokenManager.add('idToken', tokens.idToken);
 })
 .catch(function(err) {
   // handle OAuthError
@@ -1617,7 +1626,10 @@ Create token using a redirect.
 * `oauthOptions` - See [Extended OpenID Connect options](#extended-openid-connect-options)
 
 ```javascript
-authClient.token.getWithRedirect(oauthOptions);
+authClient.token.getWithRedirect({
+  responseType: ['token', 'id_token'],
+  state: 'any-string-you-want-to-pass-to-callback' // will be URI encoded
+});
 ```
 
 #### `token.parseFromUrl(options)`
@@ -1630,8 +1642,15 @@ The ID token will be [verified and validated](https://github.com/okta/okta-auth-
 
 ```javascript
 authClient.token.parseFromUrl()
-.then(function(tokenOrTokens) {
+.then(function(res) {
+  var state = res.state; // passed to getWithRedirect(), can be any string
+
   // manage token or tokens
+  var tokens = res.tokens;
+
+  // Do something with tokens, such as
+  authClient.tokenManager.add('idToken', tokens.idToken);
+  authClient.tokenManager.add('accessToken', tokens.accesstoken);
 })
 .catch(function(err) {
   // handle OAuthError
@@ -1722,8 +1741,8 @@ After receiving an `access_token` or `id_token`, add it to the `tokenManager` to
 
 ```javascript
 authClient.token.getWithPopup()
-.then(function(idToken) {
-  authClient.tokenManager.add('idToken', idToken);
+.then(function(res) {
+  authClient.tokenManager.add('idToken', res.tokens.idToken);
 });
 ```
 

--- a/packages/okta-auth-js/lib/TokenManager.js
+++ b/packages/okta-auth-js/lib/TokenManager.js
@@ -159,15 +159,7 @@ function renew(sdk, tokenMgmtRef, storage, key) {
 
   // Store the renew promise state, to avoid renewing again
   tokenMgmtRef.renewPromise[key] = sdk.token.renew(token)
-    .then(function(freshTokens) {
-      var freshToken = freshTokens;
-      // With PKCE flow we will receive multiple tokens. Find the one we are looking for
-      if (freshTokens instanceof Array) {
-        freshToken = freshTokens.find(function(freshToken) {
-          return (freshToken.idToken && token.idToken) || (freshToken.accessToken && token.accessToken);
-        });
-      }
-
+    .then(function(freshToken) {
       var oldToken = get(storage, key);
       if (!oldToken) {
         // It is possible to enter a state where the tokens have been cleared

--- a/packages/okta-auth-js/test/spec/token.js
+++ b/packages/okta-auth-js/test/spec/token.js
@@ -293,7 +293,12 @@ describe('token.getWithoutPrompt', function() {
         'id_token': tokens.authServerIdToken,
         'state': oauthUtil.mockedState
       },
-      expectedResp: tokens.authServerIdTokenParsed
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          idToken: tokens.authServerIdTokenParsed
+        }
+      }
     });
   });
 
@@ -325,7 +330,12 @@ describe('token.getWithoutPrompt', function() {
         'id_token': tokens.authServerIdToken,
         'state': oauthUtil.mockedState
       },
-      expectedResp: tokens.authServerIdTokenParsed
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          idToken: tokens.authServerIdTokenParsed
+        }
+      }
     });
   });
 
@@ -359,7 +369,12 @@ describe('token.getWithoutPrompt', function() {
         'id_token': tokens.authServerIdToken,
         'state': oauthUtil.mockedState
       },
-      expectedResp: tokens.authServerIdTokenParsed
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          idToken: tokens.authServerIdTokenParsed
+        }
+      }
     });
   });
 
@@ -402,10 +417,15 @@ describe('token.getWithoutPrompt', function() {
         'state': 'bbbbbb'
       },
       expectedResp: {
-        idToken: tokens.modifiedIdToken,
-        claims: tokens.modifiedIdTokenClaims,
-        expiresAt: 1449699930,
-        scopes: ['openid', 'custom']
+        state: 'bbbbbb',
+        tokens: {
+          idToken: {
+            idToken: tokens.modifiedIdToken,
+            claims: tokens.modifiedIdTokenClaims,
+            expiresAt: 1449699930,
+            scopes: ['openid', 'custom']
+          }
+        }
       }
     });
   });
@@ -459,8 +479,8 @@ describe('token.getWithoutPrompt', function() {
 
       return Promise.all([firstPrompt, secondPrompt])
       .then(function(values) {
-        expect(values[0]).toEqual(tokens.standardIdTokenParsed);
-        expect(values[1]).toEqual(tokens.standardIdToken2Parsed);
+        expect(values[0].tokens.idToken).toEqual(tokens.standardIdTokenParsed);
+        expect(values[1].tokens.idToken).toEqual(tokens.standardIdToken2Parsed);
 
         // make sure both iframes were destroyed
         expect(iframes.length).toBe(0);
@@ -503,7 +523,12 @@ describe('token.getWithoutPrompt', function() {
         'expires_in': 3600,
         'state': oauthUtil.mockedState
       },
-      expectedResp: tokens.standardAccessTokenParsed
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          accessToken: tokens.standardAccessTokenParsed
+        }
+      }
     });
   });
 
@@ -539,7 +564,12 @@ describe('token.getWithoutPrompt', function() {
         'expires_in': 3600,
         'state': oauthUtil.mockedState
       },
-      expectedResp: tokens.authServerAccessTokenParsed
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          accessToken: tokens.authServerAccessTokenParsed
+        }
+      }
     });
   });
 
@@ -576,11 +606,17 @@ describe('token.getWithoutPrompt', function() {
         'expires_in': 3600,
         'state': oauthUtil.mockedState
       },
-      expectedResp: [tokens.authServerIdTokenParsed, tokens.authServerAccessTokenParsed]
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          idToken: tokens.authServerIdTokenParsed,
+          accessToken: tokens.authServerAccessTokenParsed
+        }
+      }
     });
   });
 
-  it('returns id_token and access_token (in that order) using an array of responseTypes', function() {
+  it('returns id_token and access_token using an array of responseTypes (in that order)', function() {
     return oauthUtil.setupFrame({
       oktaAuthArgs: {
         issuer: 'https://auth-js-test.okta.com',
@@ -613,11 +649,17 @@ describe('token.getWithoutPrompt', function() {
         'expires_in': 3600,
         'state': oauthUtil.mockedState
       },
-      expectedResp: [tokens.standardIdTokenParsed, tokens.standardAccessTokenParsed]
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          idToken: tokens.standardIdTokenParsed,
+          accessToken: tokens.standardAccessTokenParsed
+        }
+      }
     });
   });
 
-  it('returns access_token and id_token (in that order) using an array of responseTypes', function() {
+  it('returns access_token and id_token using an array of responseTypes (in that order)', function() {
     return oauthUtil.setupFrame({
       oktaAuthArgs: {
         issuer: 'https://auth-js-test.okta.com',
@@ -650,7 +692,13 @@ describe('token.getWithoutPrompt', function() {
         'expires_in': 3600,
         'state': oauthUtil.mockedState
       },
-      expectedResp: [tokens.standardAccessTokenParsed, tokens.standardIdTokenParsed]
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          accessToken: tokens.standardAccessTokenParsed,
+          idToken: tokens.standardIdTokenParsed
+        }
+      }
     });
   });
 
@@ -679,7 +727,12 @@ describe('token.getWithoutPrompt', function() {
           'sessionToken': 'testSessionToken'
         }
       },
-      expectedResp: [tokens.standardIdTokenParsed]
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          idToken: tokens.standardIdTokenParsed
+        }
+      }
     });
   });
 
@@ -850,7 +903,12 @@ describe('token.getWithPopup', function() {
           'id_token': tokens.authServerIdToken,
           'state': oauthUtil.mockedState
         },
-        expectedResp: tokens.authServerIdTokenParsed
+        expectedResp: {
+          state: oauthUtil.mockedState,
+          tokens: {
+            idToken: tokens.authServerIdTokenParsed
+          }
+        }
       });
   });
 
@@ -884,7 +942,12 @@ describe('token.getWithPopup', function() {
           'id_token': tokens.authServerIdToken,
           'state': oauthUtil.mockedState
         },
-        expectedResp: tokens.authServerIdTokenParsed
+        expectedResp: {
+          state: oauthUtil.mockedState,
+          tokens: {
+            idToken: tokens.authServerIdTokenParsed
+          }
+        }
       });
   });
 
@@ -943,8 +1006,8 @@ describe('token.getWithPopup', function() {
 
       return Promise.all([firstPopup, secondPopup])
       .then(function(values) {
-        expect(values[0]).toEqual(tokens.standardIdTokenParsed);
-        expect(values[1]).toEqual(tokens.standardIdToken2Parsed);
+        expect(values[0].tokens.idToken).toEqual(tokens.standardIdTokenParsed);
+        expect(values[1].tokens.idToken).toEqual(tokens.standardIdToken2Parsed);
 
         // make sure both popups were closed
         expect(getOpenPopups().length).toBe(0);
@@ -984,7 +1047,12 @@ describe('token.getWithPopup', function() {
         'expires_in': 3600,
         'state': oauthUtil.mockedState
       },
-      expectedResp: tokens.standardAccessTokenParsed
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          idToken: tokens.standardAccessTokenParsed
+        }
+      }
     });
   });
 
@@ -1020,7 +1088,12 @@ describe('token.getWithPopup', function() {
         'expires_in': 3600,
         'state': oauthUtil.mockedState
       },
-      expectedResp: tokens.authServerAccessTokenParsed
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          idToken: tokens.authServerAccessTokenParsed
+        }
+      }
     });
   });
 
@@ -1057,11 +1130,17 @@ describe('token.getWithPopup', function() {
         'expires_in': 3600,
         'state': oauthUtil.mockedState
       },
-      expectedResp: [tokens.authServerAccessTokenParsed, tokens.authServerIdTokenParsed]
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          idToken: tokens.authServerIdTokenParsed,
+          accessToken: tokens.authServerAccessTokenParsed
+        }
+      }
     });
   });
 
-  it('returns access_token and id_token (in that order) using idp', function() {
+  it('returns access_token and id_token using idp', function() {
     return oauthUtil.setupPopup({
       oktaAuthArgs: {
         issuer: 'https://auth-js-test.okta.com',
@@ -1094,44 +1173,13 @@ describe('token.getWithPopup', function() {
         'expires_in': 3600,
         'state': oauthUtil.mockedState
       },
-      expectedResp: [tokens.standardAccessTokenParsed, tokens.standardIdTokenParsed]
-    });
-  });
-
-  it('returns id_token and access_token (in that order) using idp', function() {
-    return oauthUtil.setupPopup({
-      oktaAuthArgs: {
-        issuer: 'https://auth-js-test.okta.com',
-        clientId: 'NPSfOkH5eZrTy8PMDlvx',
-        redirectUri: 'https://example.com/redirect'
-      },
-      getWithPopupArgs: {
-        responseType: ['id_token', 'token'],
-        idp: 'testIdp'
-      },
-      postMessageSrc: {
-        baseUri: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-        queryParams: {
-          'client_id': 'NPSfOkH5eZrTy8PMDlvx',
-          'redirect_uri': 'https://example.com/redirect',
-          'response_type': 'id_token token',
-          'response_mode': 'okta_post_message',
-          'display': 'popup',
-          'state': oauthUtil.mockedState,
-          'nonce': oauthUtil.mockedNonce,
-          'scope': 'openid email',
-          'idp': 'testIdp'
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          idToken: tokens.standardIdTokenParsed,
+          accessToken: tokens.standardAccessTokenParsed
         }
-      },
-      time: 1449699929,
-      postMessageResp: {
-        'id_token': tokens.standardIdToken,
-        'access_token': tokens.standardAccessToken,
-        'token_type': 'Bearer',
-        'expires_in': 3600,
-        'state': oauthUtil.mockedState
-      },
-      expectedResp: [tokens.standardIdTokenParsed, tokens.standardAccessTokenParsed]
+      }
     });
   });
 });
@@ -1573,7 +1621,7 @@ describe('token.getWithRedirect', function() {
             urls: defaultUrls,
             ignoreSignature: false
           }),
-null, {
+          null, {
             sameSite: 'strict'
           }
         ],
@@ -1874,8 +1922,8 @@ describe('token.parseFromUrl', function() {
                 '&state=' + oauthUtil.mockedState,
       oauthCookie: JSON.stringify({
         responseType: 'id_token',
-        state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        state: oauthUtil.mockedState,
+        nonce: oauthUtil.mockedNonce,
         scopes: ['openid', 'email'],
         urls: {
           issuer: 'https://auth-js-test.okta.com',
@@ -1885,10 +1933,15 @@ describe('token.parseFromUrl', function() {
         }
       }),
       expectedResp: {
-        idToken: tokens.standardIdToken,
-        claims: tokens.standardIdTokenClaims,
-        expiresAt: 1449699930,
-        scopes: ['openid', 'email']
+        state: oauthUtil.mockedState,
+        tokens: {
+          idToken: {
+            idToken: tokens.standardIdToken,
+            claims: tokens.standardIdTokenClaims,
+            expiresAt: 1449699930,
+            scopes: ['openid', 'email']
+          }
+        }
       }
     });
   });
@@ -1900,8 +1953,8 @@ describe('token.parseFromUrl', function() {
                 '&state=' + oauthUtil.mockedState,
       oauthCookie: JSON.stringify({
         responseType: 'id_token',
-        state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        state: oauthUtil.mockedState,
+        nonce: oauthUtil.mockedNonce,
         scopes: ['openid', 'email'],
         urls: {
           issuer: 'https://auth-js-test.okta.com',
@@ -1911,10 +1964,15 @@ describe('token.parseFromUrl', function() {
         }
       }),
       expectedResp: {
-        idToken: tokens.standardIdToken,
-        claims: tokens.standardIdTokenClaims,
-        expiresAt: 1449699930,
-        scopes: ['openid', 'email']
+        state: oauthUtil.mockedState,
+        tokens: {
+          idToken: {
+            idToken: tokens.standardIdToken,
+            claims: tokens.standardIdTokenClaims,
+            expiresAt: 1449699930,
+            scopes: ['openid', 'email']
+          }
+        }
       }
     });
   });
@@ -1925,8 +1983,8 @@ describe('token.parseFromUrl', function() {
                 '&state=' + oauthUtil.mockedState,
       oauthCookie: JSON.stringify({
         responseType: 'id_token',
-        state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        state: oauthUtil.mockedState,
+        nonce: oauthUtil.mockedNonce,
         scopes: ['openid', 'email'],
         urls: {
           issuer: 'https://auth-js-test.okta.com',
@@ -1936,10 +1994,15 @@ describe('token.parseFromUrl', function() {
         }
       }),
       expectedResp: {
-        idToken: tokens.standardIdToken,
-        claims: tokens.standardIdTokenClaims,
-        expiresAt: 1449699930,
-        scopes: ['openid', 'email']
+        state: oauthUtil.mockedState,
+        tokens: {
+          idToken: {
+            idToken: tokens.standardIdToken,
+            claims: tokens.standardIdTokenClaims,
+            expiresAt: 1449699930,
+            scopes: ['openid', 'email']
+          }
+        }
       }
     });
   });
@@ -1960,7 +2023,12 @@ describe('token.parseFromUrl', function() {
           userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
         }
       }),
-      expectedResp: tokens.authServerIdTokenParsed
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          idToken: tokens.authServerIdTokenParsed
+        }
+      }
     });
   });
 
@@ -1983,7 +2051,12 @@ describe('token.parseFromUrl', function() {
           userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
         }
       }),
-      expectedResp: tokens.standardAccessTokenParsed
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          accessToken: tokens.standardAccessTokenParsed
+        }
+      }
     });
   });
 
@@ -2006,7 +2079,12 @@ describe('token.parseFromUrl', function() {
           userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
         }
       }),
-      expectedResp: tokens.authServerAccessTokenParsed
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          accessToken: tokens.authServerAccessTokenParsed
+        }
+      }
     });
   });
 
@@ -2030,7 +2108,13 @@ describe('token.parseFromUrl', function() {
           userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
         }
       }),
-      expectedResp: [tokens.standardIdTokenParsed, tokens.standardAccessTokenParsed]
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          accessToken: tokens.standardAccessTokenParsed,
+          idToken: tokens.standardIdTokenParsed
+        }
+      }
     });
   });
 
@@ -2054,7 +2138,13 @@ describe('token.parseFromUrl', function() {
           userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
         }
       }),
-      expectedResp: [tokens.authServerIdTokenParsed, tokens.authServerAccessTokenParsed]
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          accessToken: tokens.authServerAccessTokenParsed,
+          idToken: tokens.authServerIdTokenParsed
+        }
+      }
     });
   });
 
@@ -2170,6 +2260,64 @@ describe('token.parseFromUrl', function() {
       errorCauses: []
     }
   );
+
+  oauthUtil.itpErrorsCorrectly('throws an error if access_token was not returned', {
+    setupMethod: oauthUtil.setupParseUrl,
+    hashMock: '#id_token=' + tokens.standardIdToken +
+              '&expires_in=3600' +
+              '&token_type=Bearer' +
+              '&state=' + oauthUtil.mockedState,
+    oauthCookie: JSON.stringify({
+      responseType: ['id_token', 'token'],
+      state: oauthUtil.mockedState,
+      nonce: oauthUtil.mockedNonce,
+      scopes: ['openid', 'email'],
+      urls: {
+        issuer: 'https://auth-js-test.okta.com',
+        tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
+        authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+        userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+      }
+    })
+  },
+  {
+    name: 'AuthSdkError',
+    message: 'Unable to parse OAuth flow response: response type "token" was requested but "access_token" was not returned.',
+    errorCode: 'INTERNAL',
+    errorSummary: 'Unable to parse OAuth flow response: response type "token" was requested but "access_token" was not returned.',
+    errorLink: 'INTERNAL',
+    errorId: 'INTERNAL',
+    errorCauses: []
+  });
+
+  oauthUtil.itpErrorsCorrectly('throws an error if id_token was not returned', {
+    setupMethod: oauthUtil.setupParseUrl,
+    hashMock: '#access_token=' + tokens.standardAccessToken +
+              '&expires_in=3600' +
+              '&token_type=Bearer' +
+              '&state=' + oauthUtil.mockedState,
+    oauthCookie: JSON.stringify({
+      responseType: ['id_token', 'token'],
+      state: oauthUtil.mockedState,
+      nonce: oauthUtil.mockedNonce,
+      scopes: ['openid', 'email'],
+      urls: {
+        issuer: 'https://auth-js-test.okta.com',
+        tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
+        authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+        userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+      }
+    })
+  },
+  {
+    name: 'AuthSdkError',
+    message: 'Unable to parse OAuth flow response: response type "id_token" was requested but "id_token" was not returned.',
+    errorCode: 'INTERNAL',
+    errorSummary: 'Unable to parse OAuth flow response: response type "id_token" was requested but "id_token" was not returned.',
+    errorLink: 'INTERNAL',
+    errorId: 'INTERNAL',
+    errorCauses: []
+  });
 });
 
 describe('token.renew', function() {
@@ -2193,7 +2341,8 @@ describe('token.renew', function() {
           'scope': 'openid email',
           'prompt': 'none'
         }
-      }
+      },
+      expectedResp: tokens.standardIdTokenParsed
     });
   });
 
@@ -2223,13 +2372,7 @@ describe('token.renew', function() {
         'id_token': tokens.authServerIdToken,
         'state': oauthUtil.mockedState
       },
-      expectedResp: {
-        idToken: tokens.authServerIdToken,
-        claims: tokens.authServerIdTokenClaims,
-        expiresAt: 1449699930,
-        scopes: ['openid', 'custom'],
-        issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
-      }
+      expectedResp: tokens.authServerIdTokenParsed
     });
   });
 
@@ -2261,13 +2404,7 @@ describe('token.renew', function() {
         'expires_in': 3600,
         'state': oauthUtil.mockedState
       },
-      expectedResp: {
-        accessToken: tokens.standardAccessToken,
-        expiresAt: 1449703529,
-        scopes: ['openid', 'email'],
-        tokenType: 'Bearer',
-        issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
-      }
+      expectedResp: tokens.standardAccessTokenParsed
     });
   });
 
@@ -2294,18 +2431,12 @@ describe('token.renew', function() {
       },
       time: 1449699929,
       postMessageResp: {
-        'access_token': tokens.standardAccessToken,
+        'access_token': tokens.authServerAccessToken,
         'token_type': 'Bearer',
         'expires_in': 3600,
         'state': oauthUtil.mockedState
       },
-      expectedResp: {
-        accessToken: tokens.standardAccessToken,
-        expiresAt: 1449703529,
-        scopes: ['openid', 'email'],
-        tokenType: 'Bearer',
-        issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
-      }
+      expectedResp: tokens.authServerAccessTokenParsed
     });
   });
 

--- a/test/app/src/tokens.js
+++ b/test/app/src/tokens.js
@@ -1,21 +1,5 @@
 import { htmlString } from './util';
 
-function tokensArrayToObject(tokens) {
-  let accessToken = tokens.filter(token => {
-    return token.accessToken;
-  });
-  accessToken = accessToken.length ? accessToken[0] : null;
-
-  let idToken = tokens.filter(token => {
-    return token.idToken;
-  });
-  idToken = idToken.length ? idToken[0] : null;
-  return {
-    accessToken,
-    idToken
-  };
-}
-
 function tokensHTML(tokens) {
   const { idToken, accessToken } = tokens;
   const claims = idToken.claims;
@@ -49,4 +33,4 @@ function tokensHTML(tokens) {
   return html;
 }
 
-export { tokensArrayToObject, tokensHTML };
+export { tokensHTML };

--- a/test/app/src/webpackEntry.js
+++ b/test/app/src/webpackEntry.js
@@ -37,7 +37,7 @@ window.bootstrapLanding = function() {
 
 // Callback, read config from storage
 window.bootstrapCallback = function() {
-  config = getConfigFromStorage();
+  config = getConfigFromStorage() || getDefaultConfig();
   clearStorage();
   mount();
   app.bootstrapCallback();

--- a/test/support/oauthUtil.js
+++ b/test/support/oauthUtil.js
@@ -80,10 +80,16 @@ var defaultPostMessage = oauthUtil.defaultPostMessage = {
 };
 
 var defaultResponse = {
-  idToken: tokens.standardIdToken,
-  claims: tokens.standardIdTokenClaims,
-  expiresAt: 1449699930,
-  scopes: ['openid', 'email']
+  state: oauthUtil.mockedState,
+  tokens: {
+    idToken: {
+      value: tokens.standardIdToken,
+      idToken: tokens.standardIdToken,
+      claims: tokens.standardIdTokenClaims,
+      expiresAt: 1449699930,
+      scopes: ['openid', 'email']
+    }
+  }
 };
 
 var getTime = oauthUtil.getTime = function getTime(time) {
@@ -100,6 +106,7 @@ function validateResponse(res, expectedResp) {
       expect(actual, expected);
       return;
     }
+    expect(actual.value).toEqual(expected.value);
     expect(actual.idToken).toEqual(expected.idToken);
     expect(actual.claims).toEqual(expected.claims);
     expect(actual.accessToken).toEqual(expected.accessToken);

--- a/test/support/tokens.js
+++ b/test/support/tokens.js
@@ -60,6 +60,7 @@ tokens.standardIdTokenClaims = {
 };
 
 tokens.standardIdTokenParsed = {
+  value: tokens.standardIdToken,
   idToken: tokens.standardIdToken,
   claims: tokens.standardIdTokenClaims,
   expiresAt: 1449699930,
@@ -105,6 +106,7 @@ tokens.standardIdToken2Claims = {
 };
 
 tokens.standardIdToken2Parsed = {
+  value: tokens.standardIdToken2,
   idToken: tokens.standardIdToken2,
   claims: tokens.standardIdToken2Claims,
   expiresAt: 1449699930,
@@ -149,6 +151,7 @@ tokens.expiredBeforeIssuedIdTokenClaims = {
 };
 
 tokens.expiredBeforeIssuedIdTokenParsed = {
+  value: tokens.expiredBeforeIssuedIdToken,
   idToken: tokens.expiredBeforeIssuedIdToken,
   claims: tokens.expiredBeforeIssuedIdTokenClaims,
   expiresAt: 1449690000,
@@ -186,6 +189,7 @@ tokens.authServerIdTokenClaims = {
 };
 
 tokens.authServerIdTokenParsed = {
+  value: tokens.authServerIdToken,
   idToken: tokens.authServerIdToken,
   claims: tokens.authServerIdTokenClaims,
   expiresAt: 1449699930,
@@ -244,6 +248,7 @@ tokens.standardAccessToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOj' +
                               'EQ9-Ua9rPOMaO0pFC6h2lfB_HfzGifXATKsN-wLdxk6cgA';
 
 tokens.standardAccessTokenParsed = {
+  value: tokens.standardAccessToken,
   accessToken: tokens.standardAccessToken,
   expiresAt: 1449703529, // assuming time = 1449699929
   scopes: ['openid', 'email'],
@@ -266,6 +271,7 @@ tokens.authServerAccessToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjE
                                 'h9gY9Z3xd92ac407ZIOHkabLvZ0-45ANM3Gm0LC0c';
 
 tokens.authServerAccessTokenParsed = {
+  value: tokens.authServerAccessToken,
   accessToken: tokens.authServerAccessToken,
   expiresAt: 1449703529, // assuming time = 1449699929
   scopes: ['openid', 'email'],


### PR DESCRIPTION
Changes behavior on `parseFromUrl`

Previously:
- tokens were returned in an array, in the same order as specified in `responseTypes`
- If `responseTypes` was not an array, the token object was returned

Now:
- An object is always returned. It will contain two properties
  - `state` which contains the value passed to `getWithRedirect` (or any of the other `getToken` calls) This allows passing information to the callback handler.
  - `tokens` which contains a hash of tokens returned. Possible key values are `idToken` and `accessToken`
- Token objects have a field `value` which contains the raw token string. For an ID token this is the same as the `idToken` field, for an access token it is the same as the `accessToken` field.