### PR TITLE
feat: enable secure cookies by default, enforce HTTPS origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - [#311](https://github.com/okta/okta-auth-js/pull/311) - `parseFromUrl` now returns tokens in an object hash (instead of array). The `state` parameter (passed to authorize request) is also returned.
 
+- [#313](https://github.com/okta/okta-auth-js/pull/313) - New option `secureCookies`, which is `true` by default. An HTTPS origin will be enforced unless `secureCookies` is set to `false`.
+
 - [#316](https://github.com/okta/okta-auth-js/pull/316) - Option `issuer` is required. Option `url` has been deprecated and is no longer used.
 
 ### Other

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ tokenManager: {
 | `redirectUri`  | The url that is redirected to when using `token.getWithRedirect`. This must be listed in your Okta application's [Login redirect URIs](#login-redirect-uris). If no `redirectUri` is provided, defaults to the current origin (`window.location.origin`). |
 | `postLogoutRedirectUri` | Specify the url where the browser should be redirected after [signOut](#signout). This url must be listed in your Okta application's [Logout redirect URIs](#logout-redirect-uris). If not specified, your application's origin (`window.location.origin`) will be used.
 | `pkce`  | If set to true, the authorization flow will automatically use PKCE.  The authorize request will use `response_type=code`, and `grant_type=authorization_code` will be used on the token request.  All these details are handled for you, including the creation and verification of code verifiers. |
+| `secureCookies` | Defaults to `true`. Will set the "secure" option on all cookies. With this option on, an exception will be thrown if the application origin is not using the HTTPS protocol. Automatically disabled for `http://localhost`.
 | `authorizeUrl` | Specify a custom authorizeUrl to perform the OIDC flow. Defaults to the issuer plus "/v1/authorize". |
 | `userinfoUrl`  | Specify a custom userinfoUrl. Defaults to the issuer plus "/v1/userinfo". |
 | `tokenUrl`  | Specify a custom tokenUrl. Defaults to the issuer plus "/v1/token". |
@@ -469,9 +470,9 @@ authClient.closeSession()
   })
 ```
 
-### `revokeAccessToken(accessToken?)`
+### `revokeAccessToken(accessToken)`
 
-Revokes the access token for this application so it can no longer be used to authenticate API requests. By default, `revokeAccessToken` will look for a token object named `accessToken` within the `TokenManager`. If you have stored the access token object in a different location, you should retrieve it first and then pass it here. Returns a promise that resolves when the operation has completed. This method will succeed even if the access token has already been revoked or removed.
+Revokes the access token for this application so it can no longer be used to authenticate API requests. The `accessToken` parameter is optional. By default, `revokeAccessToken` will look for a token object named `accessToken` within the `TokenManager`. If you have stored the access token object in a different location, you should retrieve it first and then pass it here. Returns a promise that resolves when the operation has completed. This method will succeed even if the access token has already been revoked or removed.
 
 ### `forgotPassword(options)`
 

--- a/packages/okta-auth-js/jest.server.js
+++ b/packages/okta-auth-js/jest.server.js
@@ -11,6 +11,8 @@ module.exports = {
   ],
   'testPathIgnorePatterns': [
     './test/spec/browser.js',
+    './test/spec/browserStorage.js',
+    './test/spec/cookies.js',
     './test/spec/fingerprint.js',
     './test/spec/general.js',
     './test/spec/oauthUtil.js',

--- a/packages/okta-auth-js/lib/TokenManager.js
+++ b/packages/okta-auth-js/lib/TokenManager.js
@@ -219,7 +219,10 @@ function TokenManager(sdk, options) {
         storageProvider = sessionStorage;
         break;
       case 'cookie':
-        storageProvider = storageUtil.getCookieStorage(options);
+        storageProvider = storageUtil.getCookieStorage({
+          secure: sdk.options.secureCookies,
+          sameSite: 'strict' // Use strictest setting. We do not expect token storage to be accessed server-side.
+        });
         break;
       case 'memory':
         storageProvider = storageUtil.getInMemoryStorage();

--- a/packages/okta-auth-js/lib/browser/browserStorage.js
+++ b/packages/okta-auth-js/lib/browser/browserStorage.js
@@ -14,6 +14,7 @@
 var Cookies = require('js-cookie');
 var storageBuilder = require('../storageBuilder');
 var constants = require('../constants');
+var AuthSdkError = require('../errors/AuthSdkError');
 
 // Building this as an object allows us to mock the functions in our tests
 var storageUtil = {};
@@ -38,23 +39,23 @@ storageUtil.browserHasSessionStorage = function() {
   }
 };
 
-storageUtil.getPKCEStorage = function() {
+storageUtil.getPKCEStorage = function(options) {
   if (storageUtil.browserHasLocalStorage()) {
     return storageBuilder(storageUtil.getLocalStorage(), constants.PKCE_STORAGE_NAME);
   } else if (storageUtil.browserHasSessionStorage()) {
     return storageBuilder(storageUtil.getSessionStorage(), constants.PKCE_STORAGE_NAME);
   } else {
-    return storageBuilder(storageUtil.getCookieStorage(), constants.PKCE_STORAGE_NAME);
+    return storageBuilder(storageUtil.getCookieStorage(options), constants.PKCE_STORAGE_NAME);
   }
 };
 
-storageUtil.getHttpCache = function() {
+storageUtil.getHttpCache = function(options) {
   if (storageUtil.browserHasLocalStorage()) {
     return storageBuilder(storageUtil.getLocalStorage(), constants.CACHE_STORAGE_NAME);
   } else if (storageUtil.browserHasSessionStorage()) {
     return storageBuilder(storageUtil.getSessionStorage(), constants.CACHE_STORAGE_NAME);
   } else {
-    return storageBuilder(storageUtil.getCookieStorage(), constants.CACHE_STORAGE_NAME);
+    return storageBuilder(storageUtil.getCookieStorage(options), constants.CACHE_STORAGE_NAME);
   }
 };
 
@@ -68,9 +69,11 @@ storageUtil.getSessionStorage = function() {
 
 // Provides webStorage-like interface for cookies
 storageUtil.getCookieStorage = function(options) {
-  options = options || {};
-  var secure = options.secure; // currently opt-in
-  var sameSite = options.sameSite || 'strict'; // token storage should only be accessed by javascript
+  const secure = options.secure;
+  const sameSite = options.sameSite;
+  if (typeof secure === 'undefined' || typeof sameSite === 'undefined') {
+    throw new AuthSdkError('getCookieStorage: "secure" and "sameSite" options must be provided');
+  }
   return {
     getItem: storageUtil.storage.get,
     setItem: function(key, value) {
@@ -109,11 +112,15 @@ storageUtil.testStorage = function(storage) {
 
 storageUtil.storage = {
   set: function(name, value, expiresAt, options) {
-    options = options || {};
+    const secure = options.secure;
+    const sameSite = options.sameSite;
+    if (typeof secure === 'undefined' || typeof sameSite === 'undefined') {
+      throw new AuthSdkError('storage.set: "secure" and "sameSite" options must be provided');
+    }
     var cookieOptions = {
       path: options.path || '/',
-      secure: options.secure,
-      sameSite: options.sameSite
+      secure,
+      sameSite
     };
 
     // eslint-disable-next-line no-extra-boolean-cast

--- a/packages/okta-auth-js/lib/http.js
+++ b/packages/okta-auth-js/lib/http.js
@@ -26,7 +26,10 @@ function httpRequest(sdk, options) {
       withCredentials = options.withCredentials !== false, // default value is true
       storageUtil = sdk.options.storageUtil,
       storage = storageUtil.storage,
-      httpCache = storageUtil.getHttpCache();
+      httpCache = storageUtil.getHttpCache({
+        secure: sdk.options.secureCookies,
+        sameSite: 'strict' // http cache storage should only be accessed by javascript
+      });
 
   if (options.cacheResponse) {
     var cacheContents = httpCache.getStorage();
@@ -68,7 +71,10 @@ function httpRequest(sdk, options) {
       }
 
       if (res && res.stateToken && res.expiresAt) {
-        storage.set(constants.STATE_TOKEN_KEY_NAME, res.stateToken, res.expiresAt);
+        storage.set(constants.STATE_TOKEN_KEY_NAME, res.stateToken, res.expiresAt, {
+          secure: sdk.options.secureCookies,
+          sameSite: 'lax' // state token may be accessed by server
+        });
       }
 
       if (res && options.cacheResponse) {

--- a/packages/okta-auth-js/lib/oauthUtil.js
+++ b/packages/okta-auth-js/lib/oauthUtil.js
@@ -17,8 +17,6 @@ var util = require('./util');
 var storageUtil = require('./browser/browserStorage');
 var AuthSdkError = require('./errors/AuthSdkError');
 
-var httpCache = storageUtil.getHttpCache();
-
 function generateState() {
   return util.genRandomString(64);
 }
@@ -85,6 +83,11 @@ function getWellKnown(sdk, issuer) {
 }
 
 function getKey(sdk, issuer, kid) {
+  var httpCache = storageUtil.getHttpCache({
+    secure: sdk.options.secureCookies,
+    sameSite: 'strict' // http cache storage should only be accessed by javascript
+  });
+
   return getWellKnown(sdk, issuer)
   .then(function(wellKnown) {
     var jwksUri = wellKnown['jwks_uri'];

--- a/packages/okta-auth-js/lib/pkce.js
+++ b/packages/okta-auth-js/lib/pkce.js
@@ -41,19 +41,26 @@ function generateVerifier(prefix) {
   return encodeURIComponent(verifier).slice(0, MAX_VERIFIER_LENGTH);
 }
 
+function getStorage(sdk) {
+  return sdk.options.storageUtil.getPKCEStorage({
+    secure: sdk.options.secureCookies,
+    sameSite: 'strict' // PKCE storage should only be accessed by javascript
+  });
+}
+
 function saveMeta(sdk, meta) {
-  var storage = sdk.options.storageUtil.getPKCEStorage();
+  var storage = getStorage(sdk);
   storage.setStorage(meta);
 }
 
 function loadMeta(sdk) {
-  var storage = sdk.options.storageUtil.getPKCEStorage();
+  var storage = getStorage(sdk);
   var obj = storage.getStorage();
   return obj;
 }
 
 function clearMeta(sdk) {
-  var storage = sdk.options.storageUtil.getPKCEStorage();
+  var storage = getStorage(sdk);
   storage.clearStorage();
 }
 

--- a/packages/okta-auth-js/lib/storageBuilder.js
+++ b/packages/okta-auth-js/lib/storageBuilder.js
@@ -40,7 +40,7 @@ function storageBuilder(webstorage, storageName) {
 
   function clearStorage(key) {
     if (!key) {
-      setStorage({});
+      return setStorage({});
     }
     var storage = getStorage();
     delete storage[key];

--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -653,16 +653,19 @@ function getWithRedirect(sdk, oauthOptions, options) {
         urls: urls,
         ignoreSignature: oauthParams.ignoreSignature
       }), null, {
+        secure: sdk.options.secureCookies,
         sameSite: 'strict' // accessed by javascript in parseFromUrl()
       });
 
       // Set nonce cookie for servers to validate nonce in id_token
       cookies.set(constants.REDIRECT_NONCE_COOKIE_NAME, oauthParams.nonce, null, {
+        secure: sdk.options.secureCookies,
         sameSite: 'lax' // accessed by server from redirect
       });
 
       // Set state cookie for servers to validate state
       cookies.set(constants.REDIRECT_STATE_COOKIE_NAME, oauthParams.state, null, {
+        secure: sdk.options.secureCookies,
         sameSite: 'lax' // accessed by server from redirect
       });
 

--- a/packages/okta-auth-js/test/karma/spec/loginFlow.js
+++ b/packages/okta-auth-js/test/karma/spec/loginFlow.js
@@ -92,7 +92,10 @@ describe('Complete login flow', function() {
   }
 
   function mockWellKnown() {
-    sdk.options.storageUtil.getHttpCache().clearStorage();
+    sdk.options.storageUtil.getHttpCache({
+      secure: sdk.options.secureCookies,
+      sameSite: 'strict' // http cache storage should only be accessed by javascript
+    }).clearStorage();
 
     var wellKnown = {
       'jwks_uri': JWKS_URI,

--- a/packages/okta-auth-js/test/karma/spec/renewToken.js
+++ b/packages/okta-auth-js/test/karma/spec/renewToken.js
@@ -54,7 +54,10 @@ describe('Renew token', function() {
   }
 
   function mockWellKnown() {
-    sdk.options.storageUtil.getHttpCache().clearStorage();
+    sdk.options.storageUtil.getHttpCache({
+      secure: sdk.options.secureCookies,
+      sameSite: 'strict' // http cache storage should only be accessed by javascript
+    }).clearStorage();
 
     var wellKnown = {
       'jwks_uri': JWKS_URI,

--- a/packages/okta-auth-js/test/spec/browserStorage.js
+++ b/packages/okta-auth-js/test/spec/browserStorage.js
@@ -1,0 +1,192 @@
+jest.mock('../../lib/storageBuilder');
+
+var browserStorage  = require('../../lib/browser/browserStorage');
+var storageBuilder  = require('../../lib/storageBuilder');
+
+describe('browserStorage', () => {
+  let originalLocalStorage;
+  let originalSessionStorage;
+
+  beforeEach(() => {
+    originalLocalStorage = global.window.localStorage;
+    originalSessionStorage = global.window.sessionStorage;
+  });
+
+  afterEach(() => {
+    global.window.localStorage = originalLocalStorage;
+    global.window.sessionStorage = originalSessionStorage;
+  });
+
+  it('can return localStorage', () => {
+    expect(global.window.localStorage).toBeDefined();
+    expect(browserStorage.getLocalStorage()).toBe(global.localStorage);
+  });
+
+  it('can return sessionStorage', () => {
+    expect(global.window.sessionStorage).toBeDefined();
+    expect(browserStorage.getSessionStorage()).toBe(global.sessionStorage);
+  });
+
+  describe('browserHasLocalStorage', () => {
+    it('returns true if storage exists and passes test', () => {
+      expect(browserStorage.browserHasLocalStorage()).toBe(true);
+    });
+    it('returns false if localStorage does not exist', () => {
+      delete global.window.localStorage;
+      expect(browserStorage.browserHasLocalStorage()).toBe(false);
+    });
+    it('returns false if testStorage() returns false', () => {
+      jest.spyOn(browserStorage, 'testStorage').mockReturnValue(false);
+      expect(browserStorage.browserHasLocalStorage()).toBe(false);
+    });
+  });
+
+  describe('browserHasSessionStorage', () => {
+    it('returns true if storage exists and passes test', () => {
+      expect(browserStorage.browserHasSessionStorage()).toBe(true);
+    });
+    it('returns false if sessionStorage does not exist', () => {
+      delete global.window.sessionStorage;
+      expect(browserStorage.browserHasSessionStorage()).toBe(false);
+    });
+    it('returns false if testStorage() returns false', () => {
+      jest.spyOn(browserStorage, 'testStorage').mockReturnValue(false);
+      expect(browserStorage.browserHasSessionStorage()).toBe(false);
+    });
+  });
+
+  describe('testStorage', () => {
+    it('returns true if no exception is thrown', () => {
+      const fakeStorage = {
+        removeItem: jest.fn(),
+        setItem: jest.fn()
+      }
+      expect(browserStorage.testStorage(fakeStorage)).toBe(true);
+      expect(fakeStorage.setItem).toHaveBeenCalledWith('okta-test-storage', 'okta-test-storage');
+      expect(fakeStorage.removeItem).toHaveBeenCalledWith('okta-test-storage');
+    });
+    it('returns false if an exception is thrown on removeItem', () => {
+      const fakeStorage = {
+        removeItem: jest.fn().mockImplementation(() => {
+          throw new Error('removeItem fails');
+        }),
+        setItem: jest.fn()
+      }
+      expect(browserStorage.testStorage(fakeStorage)).toBe(false);
+    });
+    it('returns false if an exception is thrown on setItem', () => {
+      const fakeStorage = {
+        removeItem: jest.fn(),
+        setItem: jest.fn().mockImplementation(() => {
+          throw new Error('setItem fails');
+        }),
+      }
+      expect(browserStorage.testStorage(fakeStorage)).toBe(false);
+    });
+  });
+
+  describe('getPKCEStorage', () => {
+    it('Uses localStorage by default', () => {
+      browserStorage.getPKCEStorage();
+      expect(storageBuilder).toHaveBeenCalledWith(global.window.localStorage, 'okta-pkce-storage');
+    });
+    it('Uses sessionStorage if localStorage is not available', () => {
+      delete global.window.localStorage;
+      browserStorage.getPKCEStorage();
+      expect(storageBuilder).toHaveBeenCalledWith(global.window.sessionStorage, 'okta-pkce-storage');
+    });
+    it('Uses cookie storage if localStorage and sessionStorage are not available', () => {
+      delete global.window.localStorage;
+      delete global.window.sessionStorage;
+      const fakeStorage = { fakeStorage: true };
+      jest.spyOn(browserStorage, 'getCookieStorage').mockReturnValue(fakeStorage);
+      const opts = { fakeOptions: true };
+      browserStorage.getPKCEStorage(opts);
+      expect(storageBuilder).toHaveBeenCalledWith(fakeStorage, 'okta-pkce-storage');
+      expect(browserStorage.getCookieStorage).toHaveBeenCalledWith(opts);
+    });
+  });
+
+  describe('getHttpCache', () => {
+    it('Uses localStorage by default', () => {
+      browserStorage.getHttpCache();
+      expect(storageBuilder).toHaveBeenCalledWith(global.window.localStorage, 'okta-cache-storage');
+    });
+    it('Uses sessionStorage if localStorage is not available', () => {
+      delete global.window.localStorage;
+      browserStorage.getHttpCache();
+      expect(storageBuilder).toHaveBeenCalledWith(global.window.sessionStorage, 'okta-cache-storage');
+    });
+    it('Uses cookie storage if localStorage and sessionStorage are not available', () => {
+      delete global.window.localStorage;
+      delete global.window.sessionStorage;
+      const fakeStorage = { fakeStorage: true };
+      jest.spyOn(browserStorage, 'getCookieStorage').mockReturnValue(fakeStorage);
+      const opts = { fakeOptions: true };
+      browserStorage.getHttpCache(opts);
+      expect(storageBuilder).toHaveBeenCalledWith(fakeStorage, 'okta-cache-storage');
+      expect(browserStorage.getCookieStorage).toHaveBeenCalledWith(opts);
+    });
+  });
+
+  describe('getCookieStorage', () => {
+    it('requires an options object', () => {
+      const fn = function() {
+        browserStorage.getCookieStorage();
+      };
+      expect(fn).toThrowError('Cannot read property \'secure\' of undefined');
+    });
+
+    it('requires a "secure" option', () => {
+      const fn = function() {
+        browserStorage.getCookieStorage({});
+      };
+      expect(fn).toThrowError('getCookieStorage: "secure" and "sameSite" options must be provided');
+    });
+
+    it('requires a "sameSite" option', () => {
+      const fn = function() {
+        browserStorage.getCookieStorage({ secure: true });
+      };
+      expect(fn).toThrowError('getCookieStorage: "secure" and "sameSite" options must be provided');
+    });
+
+    it('Can pass false for "secure" and "sameSite"', () => {
+      const fn = function() {
+        browserStorage.getCookieStorage({ secure: false, sameSite: false });
+      };
+      expect(fn).not.toThrow();
+    });
+
+    it('getItem: will call storage.get', () => {
+      const retVal = { fakeCookie: true };
+      jest.spyOn(browserStorage.storage, 'get').mockReturnValue(retVal);
+      const storage = browserStorage.getCookieStorage({ secure: true, sameSite: 'strict' });
+      const key = 'fake-key';
+      expect(storage.getItem(key)).toBe(retVal);
+      expect(browserStorage.storage.get).toHaveBeenCalledWith(key);
+    });
+
+    it('setItem: will call storage.set, passing secure and sameSite options', () => {
+      jest.spyOn(browserStorage.storage, 'set').mockReturnValue(null);
+      const storage = browserStorage.getCookieStorage({ secure: 'fakey', sameSite: 'strictly fakey' });
+      const key = 'fake-key';
+      const val = { fakeValue: true };
+      storage.setItem(key, val);
+      expect(browserStorage.storage.set).toHaveBeenCalledWith(key, val, '2200-01-01T00:00:00.000Z', {
+        secure: 'fakey',
+        sameSite: 'strictly fakey'
+      });
+    })
+  });
+
+  describe('getInMemoryStorage', () => {
+    it('can set and retrieve a value from memory', () => {
+      const storage = browserStorage.getInMemoryStorage();
+      const key = 'fake-key';
+      const val = { fakeValue: true };
+      storage.setItem(key, val);
+      expect(storage.getItem(key)).toBe(val);
+    })
+  })
+});

--- a/packages/okta-auth-js/test/spec/cookies.js
+++ b/packages/okta-auth-js/test/spec/cookies.js
@@ -9,44 +9,58 @@ describe('cookie', function () {
   });
 
   describe('set',  function ()  {
+    it('Throws if "secure" option is not set', () => {
+      function testFunc() { Cookies.set('foo', 'bar', null, { sameSite: 'strict' }); }
+      expect(testFunc).toThrow('storage.set: "secure" and "sameSite" options must be provided')
+    });
     it('proxies JsCookie.set',  function ()  {
-      Cookies.set('foo', 'bar');
+      Cookies.set('foo', 'bar', null, { secure: true, sameSite: 'strict' });
       expect(JsCookie.set).toHaveBeenCalledWith('foo', 'bar', {
-        path: '/'
+        path: '/',
+        secure: true,
+        sameSite: 'strict'
       });
     });
 
     it('proxies JsCookie.set with an expiry time',  function ()  {
-      Cookies.set('foo', 'bar', '2200-01-01T00:00:00.000Z');
+      Cookies.set('foo', 'bar', '2200-01-01T00:00:00.000Z', { secure: true, sameSite: 'strict' });
       expect(JsCookie.set).toHaveBeenCalledWith('foo', 'bar', {
         path: '/',
-        expires: new Date('2200-01-01T00:00:00.000Z')
+        expires: new Date('2200-01-01T00:00:00.000Z'),
+        secure: true,
+        sameSite: 'strict'
       });
     });
 
     it('proxies JsCookie.set with an invalid expiry time',  function ()  {
-      Cookies.set('foo', 'bar', 'not a valid date');
+      Cookies.set('foo', 'bar', 'not a valid date', { secure: true, sameSite: 'strict' });
       expect(JsCookie.set).toHaveBeenCalledWith('foo', 'bar', {
-        path: '/'
+        path: '/',
+        secure: true,
+        sameSite: 'strict'
       });
     });
 
     it('proxies JsCookie.set with "secure" setting',  function ()  {
       Cookies.set('foo', 'bar', null, {
-        secure: true
+        secure: false,
+        sameSite: 'strict'
       });
       expect(JsCookie.set).toHaveBeenCalledWith('foo', 'bar', {
         path: '/',
-        secure: true
+        secure: false,
+        sameSite: 'strict'
       });
     });
 
     it('proxies JsCookie.set with "sameSite" setting',  function ()  {
       Cookies.set('foo', 'bar', null, {
+        secure: true,
         sameSite: 'lax'
       });
       expect(JsCookie.set).toHaveBeenCalledWith('foo', 'bar', {
         path: '/',
+        secure: true,
         sameSite: 'lax'
       });
     });

--- a/packages/okta-auth-js/test/spec/oauthUtil.js
+++ b/packages/okta-auth-js/test/spec/oauthUtil.js
@@ -253,7 +253,8 @@ describe('getWellKnown', function() {
         }),
         '2200-01-01T00:00:00.000Z',
         {
-          sameSite: 'strict'
+          sameSite: 'strict',
+          secure: false // due to localhost exemption
         }
       );
     }

--- a/packages/okta-auth-js/test/spec/storageBuilder.js
+++ b/packages/okta-auth-js/test/spec/storageBuilder.js
@@ -1,0 +1,134 @@
+var storageBuilder  = require('../../lib/storageBuilder');
+
+describe('storageBuilder', () => {
+
+  it('throws if a storagename is not provided', () => {
+    const fn = function() {
+      storageBuilder();
+    };
+    expect(fn).toThrowError('"storageName" is required');
+  });
+
+  it('Returns an interface around a storage object', () => {
+    const storage = storageBuilder({}, 'fake');
+    expect(typeof storage.getStorage).toBe('function');
+    expect(typeof storage.setStorage).toBe('function');
+    expect(typeof storage.clearStorage).toBe('function');
+    expect(typeof storage.updateStorage).toBe('function');
+  });
+
+  describe('getStorage', () => {
+    it('Calls "getItem" on the inner storage', () => {
+      const inner = {
+        getItem: jest.fn()
+      };
+      const storageName = 'fake';
+      const storage = storageBuilder(inner, storageName);
+      storage.getStorage();
+      expect(inner.getItem).toHaveBeenCalledWith(storageName);
+    });
+    it('JSON decodes the returned object', () => {
+      const obj = { fakeObject: true };
+      const inner = {
+        getItem: jest.fn().mockReturnValue(JSON.stringify(obj))
+      };
+      const storageName = 'fake';
+      const storage = storageBuilder(inner, storageName);
+      expect(storage.getStorage()).toEqual(obj);
+    });
+    it('throws if object cannot be decoded', () => {
+      const inner = {
+        getItem: jest.fn().mockReturnValue('a string that wont decode')
+      };
+      const storageName = 'fake';
+      const storage = storageBuilder(inner, storageName);
+      const fn = function() {
+        storage.getStorage();
+      }
+      expect(fn).toThrowError('Unable to parse storage string: fake')
+    });
+  });
+
+  describe('setStorage', () => {
+    it('Calls "setItem" on the inner storage', () => {
+      const inner = {
+        setItem: jest.fn()
+      };
+      const storageName = 'fake';
+      const storage = storageBuilder(inner, storageName);
+      storage.setStorage({});
+      expect(inner.setItem).toHaveBeenCalledWith(storageName, '{}');
+    });
+    it('JSON stringifies the object passed to inner storage', () => {
+      const inner = {
+        setItem: jest.fn()
+      };
+      const storageName = 'fake';
+      const storage = storageBuilder(inner, storageName);
+      const obj = { fakeObject: true, anArray: [1, 2, 3] };
+      storage.setStorage(obj);
+      expect(inner.setItem).toHaveBeenCalledWith(storageName, JSON.stringify(obj));
+    });
+    it('Throws an error if setItem throws', () => {
+      const inner = {
+        setItem: jest.fn().mockImplementation(() => {
+          throw new Error('this error will be caught');
+        })
+      };
+      const storageName = 'fake';
+      const storage = storageBuilder(inner, storageName);
+      const fn = function() {
+        storage.setStorage({});
+      }
+      expect(fn).toThrowError('Unable to set storage: fake');
+    });
+  });
+
+  describe('clearStorage', () => {
+    it('if no key is passed, it will set storage to an empty object', () => {
+      const inner = {
+        setItem: jest.fn()
+      };
+      const storageName = 'fake';
+      const storage = storageBuilder(inner, storageName);
+      storage.clearStorage();
+      expect(inner.setItem).toHaveBeenCalledWith(storageName, '{}');
+    });
+    it('will remove the property with the given key', () => {
+      const obj = {
+        key1: 'a',
+        key2: 'b'
+      };
+      const inner = {
+        setItem: jest.fn(),
+        getItem: jest.fn().mockReturnValue(JSON.stringify(obj))
+      };
+      const storageName = 'fake';
+      const storage = storageBuilder(inner, storageName);
+      storage.clearStorage('key1');
+      expect(inner.getItem).toHaveBeenCalledWith(storageName);
+      expect(inner.setItem).toHaveBeenCalledWith(storageName, '{"key2":"b"}');
+    });
+  });
+
+  describe('updateStorage', () => {
+    it('will add a property with the given key', () => {
+      const initialObj = {
+        key1: 'a'
+      };
+      const finalObj = {
+        key1: 'a',
+        key2: 'b'
+      };
+      const inner = {
+        setItem: jest.fn(),
+        getItem: jest.fn().mockReturnValue(JSON.stringify(initialObj))
+      };
+      const storageName = 'fake';
+      const storage = storageBuilder(inner, storageName);
+      storage.updateStorage('key2', 'b');
+      expect(inner.getItem).toHaveBeenCalledWith(storageName);
+      expect(inner.setItem).toHaveBeenCalledWith(storageName, JSON.stringify(finalObj));
+    });
+  });
+});

--- a/packages/okta-auth-js/test/spec/token.js
+++ b/packages/okta-auth-js/test/spec/token.js
@@ -1191,8 +1191,21 @@ describe('token.getWithRedirect', function() {
   var customUrls;
   var nonceCookie;
   var stateCookie;
+  var originalLocation;
+
+  afterEach(() => {
+    global.window.location = originalLocation;
+  });
 
   beforeEach(function() {
+    // mock window.location so we appear to be on an HTTPS origin
+    originalLocation = global.window.location;
+    delete global.window.location;
+    global.window.location = {
+      protocol: 'https:',
+      hostname: 'somesite.local'
+    };
+
     defaultUrls = {
       issuer: 'https://auth-js-test.okta.com',
       authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
@@ -1214,6 +1227,7 @@ describe('token.getWithRedirect', function() {
       oauthUtil.mockedNonce,
       null, // expiresAt
       {
+        secure: true,
         sameSite: 'lax'
       }
     ];
@@ -1223,6 +1237,7 @@ describe('token.getWithRedirect', function() {
       oauthUtil.mockedState,
       null, // expiresAt
       {
+        secure: true,
         sameSite: 'lax'
       }
     ];
@@ -1255,6 +1270,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1296,6 +1312,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1341,6 +1358,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1379,6 +1397,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1422,6 +1441,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1459,6 +1479,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1501,6 +1522,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1538,6 +1560,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1579,6 +1602,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1622,6 +1646,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1667,6 +1692,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1705,6 +1731,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1747,6 +1774,7 @@ describe('token.getWithRedirect', function() {
           ignoreSignature: false
         }),
         null, {
+          secure: true,
           sameSite: 'strict'
         }
       ],
@@ -1787,6 +1815,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1823,6 +1852,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1859,6 +1889,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],
@@ -1894,7 +1925,8 @@ describe('token.getWithRedirect', function() {
             urls: defaultUrls,
             ignoreSignature: false
           }),
-null, {
+          null, {
+            secure: true,
             sameSite: 'strict'
           }
         ],

--- a/test/app/src/config.js
+++ b/test/app/src/config.js
@@ -15,6 +15,7 @@ function getDefaultConfig() {
     issuer: ISSUER,
     clientId: CLIENT_ID,
     pkce: true,
+    secureCookies: true
   };
 }
 
@@ -28,7 +29,7 @@ function getConfigFromUrl() {
   const scopes = (url.searchParams.get('scopes') || 'openid,email').split(',');
   const responseType = (url.searchParams.get('responseType') || 'id_token,token').split(',');
   const storage = url.searchParams.get('storage') || undefined;
-  const secure = url.searchParams.get('secure') === 'on'; // currently opt-in.
+  const secureCookies = url.searchParams.get('secureCookies') !== 'off'; // On by default
   return {
     redirectUri,
     postLogoutRedirectUri,
@@ -37,9 +38,9 @@ function getConfigFromUrl() {
     pkce,
     scopes,
     responseType,
+    secureCookies,
     tokenManager: {
       storage,
-      secure,
     },
   };
 }

--- a/test/app/src/form.js
+++ b/test/app/src/form.js
@@ -16,7 +16,7 @@ const Form = `
     <option value="cookie">Cookie</option>
     <option value="memory">Memory</option>
   </select><br/>
-  <label for="secure">Secure Cookies</label><input id="secure" name="secure" type="checkbox"/><br/>
+  <label for="secure">Secure Cookies</label><input id="secureCookies" name="secureCookies" type="checkbox"/><br/>
   <hr/>
   <input id="login-submit" type="submit" value="Update Config"/>
   </form>
@@ -30,7 +30,7 @@ function updateForm(config) {
   document.getElementById('clientId').value = config.clientId;
   document.getElementById('pkce').checked = !!config.pkce;
   document.querySelector(`#storage [value="${config.storage || ''}"]`).selected = true;
-  document.getElementById('secure').checked = !!config.secure;
+  document.getElementById('secureCookies').checked = !!config.secureCookies;
 }
 
 export { Form, updateForm };

--- a/test/support/util.js
+++ b/test/support/util.js
@@ -327,7 +327,7 @@ util.mockDeleteCookie = function () {
 };
 
 util.mockGetCookie = function (text) {
-  jest.spyOn(cookies, 'get').mockReturnValue(text || '');
+  return jest.spyOn(cookies, 'get').mockReturnValue(text || '');
 };
 
 util.mockGetHistory = function (client, mockHistory) {


### PR DESCRIPTION
- secure cookies are turned on by default
- HTTP origin other than localhost will throw, unless secureCookies is set to false
- config option `tokenManager.secure` is deprecated. TokenManager will use `secureCookies` SDK setting