### PR TITLE
change: deprecate options.url, enforce options.issuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   - New method `closeSession` for XHR signout without redirect or reload.
   - New method `revokeAccessToken`
 
+-[#316](https://github.com/okta/okta-auth-js/pull/316) - Option `issuer` is required. Option `url` has been deprecated and is no longer used.
+
 ### Other
 
 ## 2.12.0

--- a/README.md
+++ b/README.md
@@ -120,7 +120,21 @@ You can also browse the full [API reference documentation](#api-reference).
 
 ## Configuration reference
 
-If you are using this SDK to implement an OIDC flow, the only required configuration option is `issuer`:
+Whether you are using this SDK to implement an OIDC flow or for communicating with the [Authentication API](https://developer.okta.com/docs/api/resources/authn), the only required configuration option is `issuer`, which is the URL to an Okta [Authorization Server](https://developer.okta.com/docs/guides/customize-authz-server/overview/)
+
+### About the Issuer
+
+You may use the URL for your Okta organization as the issuer. This will apply a default authorization policy and issue tokens scoped at the organization level.
+
+```javascript
+var config = {
+  issuer: 'https://{yourOktaDomain}'
+};
+
+var authClient = new OktaAuth(config);
+```
+
+Okta allows you to create multiple custom OAuth 2.0 authorization servers that you can use to protect your own resource servers. Within each authorization server you can define your own OAuth 2.0 scopes, claims, and access policies. Many organizations have a "default" authorization server.
 
 ```javascript
 var config = {
@@ -130,12 +144,12 @@ var config = {
 var authClient = new OktaAuth(config);
 ```
 
-If you’re using this SDK only for communicating with the [Authentication API](https://developer.okta.com/docs/api/resources/authn), you instead need to set the `url` for your Okta Domain:
+You may also create and customize additional authorization servers.
 
 ```javascript
+
 var config = {
-  // The URL for your Okta organization
-  url: 'https://{yourOktaDomain}'
+  issuer: 'https://{yourOktaDomain}/oauth2/custom-auth-server-id'
 };
 
 var authClient = new OktaAuth(config);

--- a/packages/okta-auth-js/lib/browser/browser.js
+++ b/packages/okta-auth-js/lib/browser/browser.js
@@ -30,11 +30,10 @@ var util              = require('../util');
 function OktaAuthBuilder(args) {
   var sdk = this;
 
-  var url = builderUtil.getValidUrl(args);
+  builderUtil.assertValidConfig(args);
   // OKTA-242989: support for grantType will be removed in 3.0 
   var usePKCE = args.pkce || args.grantType === 'authorization_code';
   this.options = {
-    url: util.removeTrailingSlash(url),
     clientId: args.clientId,
     issuer: util.removeTrailingSlash(args.issuer),
     authorizeUrl: util.removeTrailingSlash(args.authorizeUrl),
@@ -335,7 +334,7 @@ proto.fingerprint = function(options) {
     iframe.style.display = 'none';
 
     listener = function listener(e) {
-      if (!e || !e.data || e.origin !== sdk.options.url) {
+      if (!e || !e.data || e.origin !== sdk.getIssuerOrigin()) {
         return;
       }
 
@@ -357,7 +356,7 @@ proto.fingerprint = function(options) {
     };
     oauthUtil.addListener(window, 'message', listener);
 
-    iframe.src = sdk.options.url + '/auth/services/devicefingerprint';
+    iframe.src = sdk.getIssuerOrigin() + '/auth/services/devicefingerprint';
     document.body.appendChild(iframe);
 
     timeout = setTimeout(function() {

--- a/packages/okta-auth-js/lib/builderUtil.js
+++ b/packages/okta-auth-js/lib/builderUtil.js
@@ -14,33 +14,37 @@ var AuthSdkError = require('./errors/AuthSdkError');
 var tx = require('./tx');
 var util = require('./util');
 
-function getValidUrl(args) {
+// TODO: use @okta/configuration-validation (move module to this monorepo?)
+function assertValidConfig(args) {
   if (!args) {
     throw new AuthSdkError('No arguments passed to constructor. ' +
       'Required usage: new OktaAuth(args)');
   }
 
-  var url = args.url;
-  if (!url) {
-    var isUrlRegex = new RegExp('^http?s?://.+');
-    if (args.issuer && isUrlRegex.test(args.issuer)) {
-      // Infer the URL from the issuer URL, omitting the /oauth2/{authServerId}
-      url = args.issuer.split('/oauth2/')[0];
-    } else {
-      throw new AuthSdkError('No url passed to constructor. ' +
-      'Required usage: new OktaAuth({url: "https://{yourOktaDomain}.com"})');
-    }
+  var issuer = args.issuer;
+  if (!issuer) {
+    throw new AuthSdkError('No issuer passed to constructor. ' + 
+      'Required usage: new OktaAuth({issuer: "https://{yourOktaDomain}.com/oauth2/{authServerId}"})');
   }
 
-  if (url.indexOf('-admin.') !== -1) {
-    throw new AuthSdkError('URL passed to constructor contains "-admin" in subdomain. ' +
-      'Required usage: new OktaAuth({url: "https://{yourOktaDomain}.com})');
+  var isUrlRegex = new RegExp('^http?s?://.+');
+  if (!isUrlRegex.test(args.issuer)) {
+    throw new AuthSdkError('Issuer must be a valid URL. ' + 
+      'Required usage: new OktaAuth({issuer: "https://{yourOktaDomain}.com/oauth2/{authServerId}"})');
   }
 
-  return url;
+  if (issuer.indexOf('-admin.') !== -1) {
+    throw new AuthSdkError('Issuer URL passed to constructor contains "-admin" in subdomain. ' +
+      'Required usage: new OktaAuth({issuer: "https://{yourOktaDomain}.com})');
+  }
 }
 
 function addSharedPrototypes(proto) {
+  proto.getIssuerOrigin = function() {
+    // Infer the URL from the issuer URL, omitting the /oauth2/{authServerId}
+    return this.options.issuer.split('/oauth2/')[0];
+  };
+
   // { username, (relayState) }
   proto.forgotPassword = function (opts) {
     return tx.postToTransaction(this, '/api/v1/authn/recovery/password', opts);
@@ -90,5 +94,5 @@ function buildOktaAuth(OktaAuthBuilder) {
 module.exports = {
   addSharedPrototypes: addSharedPrototypes,
   buildOktaAuth: buildOktaAuth,
-  getValidUrl: getValidUrl
+  assertValidConfig: assertValidConfig
 };

--- a/packages/okta-auth-js/lib/http.js
+++ b/packages/okta-auth-js/lib/http.js
@@ -111,7 +111,7 @@ function httpRequest(sdk, options) {
 }
 
 function get(sdk, url, options) {
-  url = util.isAbsoluteUrl(url) ? url : sdk.options.url + url;
+  url = util.isAbsoluteUrl(url) ? url : sdk.getIssuerOrigin() + url;
   var getOptions = {
     url: url,
     method: 'GET'
@@ -121,7 +121,7 @@ function get(sdk, url, options) {
 }
 
 function post(sdk, url, args, options) {
-  url = util.isAbsoluteUrl(url) ? url : sdk.options.url + url;
+  url = util.isAbsoluteUrl(url) ? url : sdk.getIssuerOrigin() + url;
   var postOptions = {
     url: url,
     method: 'POST',

--- a/packages/okta-auth-js/lib/oauthUtil.js
+++ b/packages/okta-auth-js/lib/oauthUtil.js
@@ -78,7 +78,7 @@ function loadPopup(src, options) {
 }
 
 function getWellKnown(sdk, issuer) {
-  var authServerUri = (issuer || sdk.options.issuer || sdk.options.url);
+  var authServerUri = (issuer || sdk.options.issuer);
   return http.get(sdk, authServerUri + '/.well-known/openid-configuration', {
     cacheResponse: true
   });
@@ -172,53 +172,7 @@ function getOAuthUrls(sdk, oauthParams, options) {
   var logoutUrl = util.removeTrailingSlash(options.logoutUrl) || sdk.options.logoutUrl;
   var revokeUrl = util.removeTrailingSlash(options.revokeUrl) || sdk.options.revokeUrl;
 
-  // If an issuer exists but it's not a url, assume it's an authServerId
-  if (issuer && !(/^https?:/.test(issuer))) {
-    // Make it a url
-    issuer = sdk.options.url + '/oauth2/' + issuer;
-  }
-
-  // If an authorizeUrl is supplied without an issuer, and an id_token is requested
-  if (!issuer && authorizeUrl &&
-      oauthParams.responseType.indexOf('id_token') !== -1) {
-    // The issuer is ambiguous, so we won't be able to validate the id_token jwt
-    throw new AuthSdkError('Cannot request idToken with an authorizeUrl without an issuer');
-  }
-
-  // If a token is requested without an issuer
-  if (!issuer && oauthParams && oauthParams.responseType.indexOf('token') !== -1) {
-    // If an authorizeUrl is supplied without a userinfoUrl
-    if (authorizeUrl && !userinfoUrl) {
-      // The userinfoUrl is ambiguous, so we won't be able to call getUserInfo
-      throw new AuthSdkError('Cannot request accessToken with an authorizeUrl without an issuer or userinfoUrl');
-    }
-
-    // If a userinfoUrl is supplied without a authorizeUrl
-    if (userinfoUrl && !authorizeUrl) {
-      // The authorizeUrl is ambiguous, so we won't be able to call the authorize endpoint
-      throw new AuthSdkError('Cannot request token with an userinfoUrl without an issuer or authorizeUrl');
-    }
-  }
-
-  // Default the issuer to our baseUrl
-  issuer = issuer || sdk.options.url;
-
-  // Trim trailing slashes
-  issuer = util.removeTrailingSlash(issuer);
-
-  var baseUrl = issuer;
-  // A custom auth server issuer looks like:
-  // https://example.okta.com/oauth2/aus8aus76q8iphupD0h7
-  // 
-  // Most orgs have a "default" custom authorization server:
-  // https://example.okta.com/oauth2/default
-  var customAuthServerRegex = new RegExp('^https?://.*?/oauth2/.+');
-  if (!customAuthServerRegex.test(baseUrl)) {
-    // Append '/oauth2' if necessary
-    if (!baseUrl.endsWith('/oauth2')) {
-      baseUrl += '/oauth2';
-    }
-  }
+  var baseUrl = issuer.indexOf('/oauth2') > 0 ? issuer : issuer + '/oauth2';
 
   authorizeUrl = authorizeUrl || baseUrl + '/v1/authorize';
   userinfoUrl = userinfoUrl || baseUrl + '/v1/userinfo';

--- a/packages/okta-auth-js/lib/server/server.js
+++ b/packages/okta-auth-js/lib/server/server.js
@@ -21,9 +21,9 @@ var util              = require('../util');
 function OktaAuthBuilder(args) {
   var sdk = this;
 
-  var url = builderUtil.getValidUrl(args);
+  builderUtil.assertValidConfig(args);
   this.options = {
-    url: util.removeTrailingSlash(url),
+    issuer: util.removeTrailingSlash(args.issuer),
     httpRequestClient: args.httpRequestClient,
     storageUtil: args.storageUtil,
     headers: args.headers

--- a/packages/okta-auth-js/lib/session.js
+++ b/packages/okta-auth-js/lib/session.js
@@ -50,7 +50,7 @@ function getSession(sdk) {
 
 function closeSession(sdk) {
   return http.httpRequest(sdk, {
-    url: sdk.options.url + '/api/v1/sessions/me',
+    url: sdk.getIssuerOrigin() + '/api/v1/sessions/me',
     method: 'DELETE'
   });
 }
@@ -61,7 +61,7 @@ function refreshSession(sdk) {
 
 function setCookieAndRedirect(sdk, sessionToken, redirectUrl) {
   redirectUrl = redirectUrl || window.location.href;
-  window.location = sdk.options.url + '/login/sessionCookieRedirect' +
+  window.location = sdk.getIssuerOrigin() + '/login/sessionCookieRedirect' +
     util.toQueryParams({
       checkAccountSetupComplete: true,
       token: sessionToken,

--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -79,7 +79,7 @@ function verifyToken(sdk, token, validationParams) {
 
     var validationOptions = {
       clientId: sdk.options.clientId,
-      issuer: sdk.options.issuer || sdk.options.url,
+      issuer: sdk.options.issuer,
       ignoreSignature: sdk.options.ignoreSignature
     };
 
@@ -122,7 +122,7 @@ function addPostMessageListener(sdk, timeout, state) {
       // This may happen if apps with different issuers are running on the same host url
       // If they share the same storage key, they may read and write tokens in the same location.
       // Common when developing against http://localhost
-      if (e.origin !== sdk.options.url) {
+      if (e.origin !== sdk.getIssuerOrigin()) {
         return reject(new AuthSdkError('The request does not match client configuration'));
       }
 

--- a/packages/okta-auth-js/lib/tx.js
+++ b/packages/okta-auth-js/lib/tx.js
@@ -36,7 +36,7 @@ function getStateToken(res) {
 
 function transactionStatus(sdk, args) {
   args = addStateToken(sdk, args);
-  return http.post(sdk, sdk.options.url + '/api/v1/authn', args);
+  return http.post(sdk, sdk.getIssuerOrigin() + '/api/v1/authn', args);
 }
 
 function resumeTransaction(sdk, args) {
@@ -75,7 +75,7 @@ function introspect (sdk, args) {
 
 function transactionStep(sdk, args) {
   args = addStateToken(sdk, args);
-  return http.post(sdk, sdk.options.url + '/idp/idx/introspect', args);
+  return http.post(sdk, sdk.getIssuerOrigin() + '/idp/idx/introspect', args);
 }
 
 function transactionExists(sdk) {

--- a/packages/okta-auth-js/test/spec/browser.js
+++ b/packages/okta-auth-js/test/spec/browser.js
@@ -10,7 +10,7 @@ describe('Browser', function() {
   var issuer;
   beforeEach(function() {
     issuer =  'http://my-okta-domain';
-    auth = new OktaAuth({ url: issuer });
+    auth = new OktaAuth({ issuer });
   });
 
   it('is a valid constructor', function() {
@@ -21,7 +21,7 @@ describe('Browser', function() {
     it('Listens to error events from TokenManager', function() {
       jest.spyOn(Emitter.prototype, 'on');
       jest.spyOn(OktaAuth.prototype, '_onTokenManagerError');
-      var auth = new OktaAuth({ url: 'http://localhost/fake' });
+      var auth = new OktaAuth({ issuer: 'http://localhost/fake' });
       expect(Emitter.prototype.on).toHaveBeenCalledWith('error', auth._onTokenManagerError, auth);
       var emitter = Emitter.prototype.on.mock.instances[0];
       var error = { errorCode: 'anything'};
@@ -32,7 +32,7 @@ describe('Browser', function() {
     it('error with errorCode "login_required" and accessToken: true will call option "onSessionExpired" function', function() {
       var onSessionExpired = jest.fn();
       jest.spyOn(Emitter.prototype, 'on');
-      new OktaAuth({ url: 'http://localhost/fake', onSessionExpired: onSessionExpired });
+      new OktaAuth({ issuer: 'http://localhost/fake', onSessionExpired: onSessionExpired });
       var emitter = Emitter.prototype.on.mock.instances[0];
       expect(onSessionExpired).not.toHaveBeenCalled();
       var error = { errorCode: 'login_required', accessToken: true };
@@ -43,7 +43,7 @@ describe('Browser', function() {
     it('error with errorCode "login_required" (not accessToken) does not call option "onSessionExpired" function', function() {
       var onSessionExpired = jest.fn();
       jest.spyOn(Emitter.prototype, 'on');
-      new OktaAuth({ url: 'http://localhost/fake', onSessionExpired: onSessionExpired });
+      new OktaAuth({ issuer: 'http://localhost/fake', onSessionExpired: onSessionExpired });
       var emitter = Emitter.prototype.on.mock.instances[0];
       expect(onSessionExpired).not.toHaveBeenCalled();
       var error = { errorCode: 'login_required' };
@@ -54,7 +54,7 @@ describe('Browser', function() {
     it('error with unknown errorCode does not call option "onSessionExpired" function', function() {
       var onSessionExpired = jest.fn();
       jest.spyOn(Emitter.prototype, 'on');
-      new OktaAuth({ url: 'http://localhost/fake', onSessionExpired: onSessionExpired });
+      new OktaAuth({ issuer: 'http://localhost/fake', onSessionExpired: onSessionExpired });
       var emitter = Emitter.prototype.on.mock.instances[0];
       expect(onSessionExpired).not.toHaveBeenCalled();
       var error = { errorCode: 'unknown', accessToken: true };
@@ -73,20 +73,20 @@ describe('Browser', function() {
 
       it('can be set by arg', function() {
         spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(true);
-        auth = new OktaAuth({ pkce: true, url: 'http://my-okta-domain' });
+        auth = new OktaAuth({ pkce: true, issuer: 'http://my-okta-domain' });
         expect(auth.options.pkce).toBe(true);
       });
 
       it('accepts alias "grantType"', function() {
         spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(true);
-        auth = new OktaAuth({ grantType: "authorization_code", url: 'http://my-okta-domain' });
+        auth = new OktaAuth({ grantType: "authorization_code", issuer: 'http://my-okta-domain' });
         expect(auth.options.pkce).toBe(true);
       });
 
       it('throws if PKCE is not supported', function() {
         spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(false);
         function fn() {
-          auth = new OktaAuth({ pkce: true, url: 'http://my-okta-domain' });
+          auth = new OktaAuth({ pkce: true, issuer: 'http://my-okta-domain' });
         }
         expect(fn).toThrowError(
           'PKCE requires a modern browser with encryption support running in a secure context.\n' +
@@ -226,7 +226,6 @@ describe('Browser', function() {
       it('supports custom authorization server', function() {
         issuer = 'http://my-okta-domain/oauth2/custom-as';
         auth = new OktaAuth({
-          url: 'http://my-okta-domain',
           issuer
         });
         initSpies();
@@ -261,7 +260,7 @@ describe('Browser', function() {
           const postLogoutRedirectUri = 'http://someother';
           const encodedUri = encodeURIComponent(postLogoutRedirectUri);
           auth = new OktaAuth({
-            url: issuer,
+            issuer,
             postLogoutRedirectUri
           });
           initSpies();

--- a/packages/okta-auth-js/test/spec/errors.js
+++ b/packages/okta-auth-js/test/spec/errors.js
@@ -83,7 +83,7 @@ describe('General Errors', function () {
     expect(err.errorSummary).toEqual('No arguments passed to constructor. Required usage: new OktaAuth(args)');
   });
 
-  it('throw an error if no url and no issuer are passed to the constructor', function () {
+  it('throw an error if no issuer is passed to the constructor', function () {
     var err;
     try {
       new OktaAuth({}); // eslint-disable-line no-new
@@ -91,11 +91,11 @@ describe('General Errors', function () {
       err = e;
     }
     expect(err.name).toEqual('AuthSdkError');
-    expect(err.errorSummary).toEqual('No url passed to constructor. ' +
-      'Required usage: new OktaAuth({url: "https://{yourOktaDomain}.com"})');
+    expect(err.errorSummary).toEqual('No issuer passed to constructor. ' +
+      'Required usage: new OktaAuth({issuer: "https://{yourOktaDomain}.com/oauth2/{authServerId}"})');
   });
 
-  it('throw an error if issuer is not a url and url is omitted when passed to the constructor', function () {
+  it('throw an error if issuer is not a url', function () {
     var err;
     try {
       new OktaAuth({issuer: 'default'}); // eslint-disable-line no-new
@@ -103,19 +103,19 @@ describe('General Errors', function () {
       err = e;
     }
     expect(err.name).toEqual('AuthSdkError');
-    expect(err.errorSummary).toEqual('No url passed to constructor. ' +
-      'Required usage: new OktaAuth({url: "https://{yourOktaDomain}.com"})');
+    expect(err.errorSummary).toEqual('Issuer must be a valid URL. ' +
+      'Required usage: new OktaAuth({issuer: "https://{yourOktaDomain}.com/oauth2/{authServerId}"})');
   });
 
   it('throw an error if url contains "-admin" when passed to the constructor', function () {
     var err;
     try {
-      new OktaAuth({url: 'https://dev-12345-admin.oktapreview.com'}); // eslint-disable-line no-new
+      new OktaAuth({issuer: 'https://dev-12345-admin.oktapreview.com'}); // eslint-disable-line no-new
     } catch (e) {
       err = e;
     }
     expect(err.name).toEqual('AuthSdkError');
-    expect(err.errorSummary).toEqual('URL passed to constructor contains "-admin" in subdomain. ' +
-      'Required usage: new OktaAuth({url: "https://{yourOktaDomain}.com})');
+    expect(err.errorSummary).toEqual('Issuer URL passed to constructor contains "-admin" in subdomain. ' +
+      'Required usage: new OktaAuth({issuer: "https://{yourOktaDomain}.com})');
   });
 });

--- a/packages/okta-auth-js/test/spec/features.js
+++ b/packages/okta-auth-js/test/spec/features.js
@@ -110,7 +110,7 @@ describe('features', function() {
       spyOn(OktaAuth.features, 'isHTTPS').and.returnValue(true);
       try {
         new OktaAuth({
-          url: 'https://dev-12345.oktapreview.com',
+          issuer: 'https://dev-12345.oktapreview.com',
           pkce: true,
         });
       } catch (e) {
@@ -127,7 +127,7 @@ describe('features', function() {
       spyOn(OktaAuth.features, 'isHTTPS').and.returnValue(false);
       try {
         new OktaAuth({
-          url: 'https://dev-12345.oktapreview.com',
+          issuer: 'https://dev-12345.oktapreview.com',
           pkce: true,
         });
       } catch (e) {
@@ -147,7 +147,7 @@ describe('features', function() {
       window.TextEncoder = undefined;
       try {
         new OktaAuth({
-          url: 'https://dev-12345.oktapreview.com',
+          issuer: 'https://dev-12345.oktapreview.com',
           pkce: true,
         });
       } catch (e) {
@@ -167,7 +167,7 @@ describe('features', function() {
       window.TextEncoder = undefined;
       try {
         new OktaAuth({
-          url: 'https://dev-12345.oktapreview.com',
+          issuer: 'https://dev-12345.oktapreview.com',
           pkce: true,
         });
       } catch (e) {

--- a/packages/okta-auth-js/test/spec/fingerprint.js
+++ b/packages/okta-auth-js/test/spec/fingerprint.js
@@ -70,7 +70,7 @@ describe('fingerprint', function() {
     });
 
     var authClient = options.authClient || new OktaAuth({
-      url: 'http://example.okta.com'
+      issuer: 'http://example.okta.com'
     });
     if (typeof options.userAgent !== 'undefined') {
       util.mockUserAgent(authClient, options.userAgent);
@@ -153,7 +153,7 @@ describe('fingerprint', function() {
   util.itMakesCorrectRequestResponse({
     title: 'attaches fingerprint to signIn requests if sendFingerprint is true',
     setup: {
-      uri: 'http://example.okta.com',
+      issuer: 'http://example.okta.com',
       calls: [
         {
           request: {
@@ -183,7 +183,7 @@ describe('fingerprint', function() {
   util.itMakesCorrectRequestResponse({
     title: 'does not attach fingerprint to signIn requests if sendFingerprint is false',
     setup: {
-      uri: 'http://example.okta.com',
+      issuer: 'http://example.okta.com',
       calls: [
         {
           request: {

--- a/packages/okta-auth-js/test/spec/oauthUtil.js
+++ b/packages/okta-auth-js/test/spec/oauthUtil.js
@@ -268,7 +268,7 @@ describe('getKey', function() {
     },
     execute: function(test) {
       oauthUtilHelpers.loadWellKnownAndKeysCache();
-      return oauthUtil.getKey(test.oa, test.oa.options.url, 'U5R8cHbGw445Qbq8zVO1PcCpXL8yG6IcovVa3laCoxM');
+      return oauthUtil.getKey(test.oa, null, 'U5R8cHbGw445Qbq8zVO1PcCpXL8yG6IcovVa3laCoxM');
     },
     expectations: function(test, key) {
       expect(key).toEqual(tokens.standardKey);
@@ -290,7 +290,7 @@ describe('getKey', function() {
     },
     execute: function(test) {
       oauthUtilHelpers.loadWellKnownCache();
-      return oauthUtil.getKey(test.oa, test.oa.options.url, 'U5R8cHbGw445Qbq8zVO1PcCpXL8yG6IcovVa3laCoxM');
+      return oauthUtil.getKey(test.oa, null, 'U5R8cHbGw445Qbq8zVO1PcCpXL8yG6IcovVa3laCoxM');
     },
     expectations: function(test, key) {
       expect(key).toEqual(tokens.standardKey);
@@ -344,7 +344,7 @@ describe('getKey', function() {
         }
       }));
 
-      return oauthUtil.getKey(test.oa, test.oa.options.url, 'U5R8cHbGw445Qbq8zVO1PcCpXL8yG6IcovVa3laCoxM');
+      return oauthUtil.getKey(test.oa, null, 'U5R8cHbGw445Qbq8zVO1PcCpXL8yG6IcovVa3laCoxM');
     },
     expectations: function(test, key) {
       expect(key).toEqual(tokens.standardKey);
@@ -389,7 +389,7 @@ describe('getKey', function() {
         }
       }));
 
-      return oauthUtil.getKey(test.oa, test.oa.options.url, 'invalidKid');
+      return oauthUtil.getKey(test.oa, null, 'invalidKid');
     },
     expectations: function(test, err) {
       util.assertAuthSdkError(err, 'The key id, invalidKid, was not found in the server\'s keys');
@@ -411,7 +411,7 @@ describe('getKey', function() {
 describe('getOAuthUrls', function() {
   function setupOAuthUrls(options) {
     var sdk = new OktaAuth(options.oktaAuthArgs || {
-      url: 'https://auth-js-test.okta.com'
+      issuer: 'https://auth-js-test.okta.com'
     });
 
     var oauthParams = options.oauthParams || {
@@ -455,7 +455,6 @@ describe('getOAuthUrls', function() {
   it('sanitizes forward slashes', function() {
     setupOAuthUrls({
       oktaAuthArgs: {
-        url: 'https://auth-js-test.okta.com',
         issuer: 'https://auth-js-test.okta.com/',
         logoutUrl: 'https://auth-js-test.okta.com/oauth2/v1/logout/',
         tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token/',
@@ -475,7 +474,6 @@ describe('getOAuthUrls', function() {
   it('overrides defaults with options', function() {
     setupOAuthUrls({
       oktaAuthArgs: {
-        url: 'https://auth-js-test.okta.com',
         issuer: 'https://bad.okta.com',
         logoutUrl: 'https://bad.okta.com/oauth2/v1/logout',
         revokeUrl: 'https://bad.okta.com/oauth2/v1/revoke',
@@ -551,21 +549,6 @@ describe('getOAuthUrls', function() {
       }
     });
   });
-  it('uses authServer issuer as authServerId to generate authorizeUrl and userinfoUrl', function() {
-    setupOAuthUrls({
-      options: {
-        issuer: 'aus8aus76q8iphupD0h7'
-      },
-      expectedResult: {
-        issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
-        logoutUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/logout',
-        revokeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/revoke',
-        tokenUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/token',
-        authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
-        userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
-      }
-    });
-  });
   it('allows token requested with only authorizeUrl and userinfoUrl', function() {
     setupOAuthUrls({
       oauthParams: {
@@ -582,48 +565,6 @@ describe('getOAuthUrls', function() {
         tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token', // we are not using this url for responseType 'token'
         authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
         userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
-      }
-    });
-  });
-  it('fails if id_token requested without issuer, with authorizeUrl', function() {
-    setupOAuthUrls({
-      oauthParams: {
-        responseType: 'id_token'
-      },
-      options: {
-        authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize'
-      },
-      expectedError: {
-        name: 'AuthSdkError',
-        message: 'Cannot request idToken with an authorizeUrl without an issuer'
-      }
-    });
-  });
-  it('fails if token requested without issuer, without userinfoUrl, with authorizeUrl', function() {
-    setupOAuthUrls({
-      oauthParams: {
-        responseType: 'token'
-      },
-      options: {
-        authorizeUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize'
-      },
-      expectedError: {
-        name: 'AuthSdkError',
-        message: 'Cannot request accessToken with an authorizeUrl without an issuer or userinfoUrl'
-      }
-    });
-  });
-  it('fails if token requested without issuer, without authorizeUrl, with userinfoUrl', function() {
-    setupOAuthUrls({
-      oauthParams: {
-        responseType: 'id_token'
-      },
-      options: {
-        userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
-      },
-      expectedError: {
-        name: 'AuthSdkError',
-        message: 'Cannot request token with an userinfoUrl without an issuer or authorizeUrl'
       }
     });
   });
@@ -695,7 +636,7 @@ describe('validateClaims', function () {
 
   beforeEach(function() {
     sdk = new OktaAuth({
-      url: 'https://auth-js-test.okta.com',
+      issuer: 'https://auth-js-test.okta.com',
       clientId: 'foo',
       ignoreSignature: false
     });

--- a/packages/okta-auth-js/test/spec/pkce.js
+++ b/packages/okta-auth-js/test/spec/pkce.js
@@ -103,7 +103,7 @@ describe('pkce', function() {
     util.itMakesCorrectRequestResponse({
       title: 'requests a token',
       setup: {
-        uri: ISSUER,
+        issuer: ISSUER,
         bypassCrypto: true,
         calls: [
           {
@@ -152,7 +152,7 @@ describe('pkce', function() {
 
       beforeEach(function() {
         authClient = new OktaAuth({
-          url: 'https://auth-js-test.okta.com'
+          issuer: 'https://auth-js-test.okta.com'
         });
 
         oauthOptions = {

--- a/packages/okta-auth-js/test/spec/session.js
+++ b/packages/okta-auth-js/test/spec/session.js
@@ -5,10 +5,17 @@ var http = require('../../lib/http');
 describe('session', function() {
   var sdk;
   var sessionObj;
+  var baseUrl;
 
   beforeEach(function() {
     sessionObj = {};
+    baseUrl = 'http://fakey';
+    
     sdk = {
+      getIssuerOrigin: jest.fn().mockReturnValue(baseUrl),
+      options: {
+        issuer: baseUrl
+      },
       session: {
         get: jest.fn().mockImplementation(function() {
           return Promise.resolve(sessionObj);
@@ -154,10 +161,6 @@ describe('session', function() {
   describe('closeSession', function() {
     it('makes a DELETE request to /api/v1/sessions/me', function() {
       jest.spyOn(http, 'httpRequest').mockReturnValue(Promise.resolve());
-      var baseUrl = 'http://fakey';
-      sdk.options = {
-        url: baseUrl
-      };
       return session.closeSession(sdk)
         .then(function() {
           expect(http.httpRequest).toHaveBeenCalledWith(sdk, {
@@ -170,9 +173,6 @@ describe('session', function() {
     it('will throw if http request rejects', function() {
       var testError = new Error('test error');
       jest.spyOn(http, 'httpRequest').mockReturnValue(Promise.reject(testError));
-      sdk.options = {
-        url: 'http://fakey'
-      };
       return session.closeSession(sdk) // should throw
         .catch(function(e) {
           expect(e).toBe(testError);
@@ -199,7 +199,6 @@ describe('session', function() {
   });
 
   describe('setCookieAndRedirect', function() {
-    var baseUrl;
     var currentUrl;
     beforeEach(function() {
       currentUrl = 'http://i-am-here';
@@ -207,10 +206,6 @@ describe('session', function() {
       window.location = {
         href: currentUrl
       };
-      baseUrl = 'http://fakey';
-      sdk.options = {
-        url: baseUrl
-      }
     });
     it('redirects to /login/sessionCookieRedirect', function() {
       session.setCookieAndRedirect(sdk);

--- a/packages/okta-auth-js/test/spec/token.js
+++ b/packages/okta-auth-js/test/spec/token.js
@@ -300,10 +300,9 @@ describe('token.getWithoutPrompt', function() {
   it('returns id_token using sessionToken with issuer as id', function() {
     return oauthUtil.setupFrame({
       oktaAuthArgs: {
-        url: 'https://auth-js-test.okta.com',
+        issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
         clientId: 'NPSfOkH5eZrTy8PMDlvx',
         redirectUri: 'https://example.com/redirect',
-        issuer: 'aus8aus76q8iphupD0h7'
       },
       getWithoutPromptArgs: {
         sessionToken: 'testSessionToken'
@@ -341,40 +340,6 @@ describe('token.getWithoutPrompt', function() {
         sessionToken: 'testSessionToken'
       }, {
         issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7'
-      }],
-      postMessageSrc: {
-        baseUri: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
-        queryParams: {
-          'client_id': 'NPSfOkH5eZrTy8PMDlvx',
-          'redirect_uri': 'https://example.com/redirect',
-          'response_type': 'id_token',
-          'response_mode': 'okta_post_message',
-          'state': oauthUtil.mockedState,
-          'nonce': oauthUtil.mockedNonce,
-          'scope': 'openid email',
-          'prompt': 'none',
-          'sessionToken': 'testSessionToken'
-        }
-      },
-      postMessageResp: {
-        'id_token': tokens.authServerIdToken,
-        'state': oauthUtil.mockedState
-      },
-      expectedResp: tokens.authServerIdTokenParsed
-    });
-  });
-
-  it('allows passing issuer as an id through getWithoutPrompt, which takes precedence', function() {
-    return oauthUtil.setupFrame({
-      oktaAuthArgs: {
-        issuer: 'https://auth-js-test.okta.com/oauth2/ORIGINAL_AUTH_SERVER_ID',
-        clientId: 'NPSfOkH5eZrTy8PMDlvx',
-        redirectUri: 'https://example.com/redirect'
-      },
-      getWithoutPromptArgs: [{
-        sessionToken: 'testSessionToken'
-      }, {
-        issuer: 'aus8aus76q8iphupD0h7'
       }],
       postMessageSrc: {
         baseUri: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',

--- a/test/support/oauthUtil.js
+++ b/test/support/oauthUtil.js
@@ -160,7 +160,7 @@ oauthUtil.setup = function(opts) {
     authClient = opts.authClient;
   } else {
     authClient = new OktaAuth({
-      url: 'https://auth-js-test.okta.com'
+      issuer: 'https://auth-js-test.okta.com'
     });
   }
 
@@ -350,7 +350,7 @@ oauthUtil.setupPopup = function(opts) {
 
 oauthUtil.setupRedirect = function(opts) {
   var client = new OktaAuth(Object.assign({
-    url: 'https://auth-js-test.okta.com',
+    issuer: 'https://auth-js-test.okta.com',
     clientId: 'NPSfOkH5eZrTy8PMDlvx',
     redirectUri: 'https://example.com/redirect'
   }, opts.oktaAuthArgs));
@@ -378,7 +378,7 @@ oauthUtil.setupRedirect = function(opts) {
 
 oauthUtil.setupParseUrl = function(opts) {
   var client = new OktaAuth({
-    url: 'https://auth-js-test.okta.com',
+    issuer: 'https://auth-js-test.okta.com',
     clientId: 'NPSfOkH5eZrTy8PMDlvx',
     redirectUri: 'https://example.com/redirect'
   });
@@ -449,7 +449,7 @@ oauthUtil.setupParseUrl = function(opts) {
 oauthUtil.setupSimultaneousPostMessage = function() {
   // Create client
   var client =  new OktaAuth({
-    url: 'https://auth-js-test.okta.com',
+    issuer: 'https://auth-js-test.okta.com',
     clientId: 'NPSfOkH5eZrTy8PMDlvx',
     redirectUri: 'https://example.com/redirect'
   });

--- a/test/support/util.js
+++ b/test/support/util.js
@@ -132,10 +132,10 @@ function mockAjax(pairs) {
 }
 
 function setup(options) {
-  if (!options.uri) {
-    options.uri = 'https://auth-js-test.okta.com';
+  if (!options.issuer) {
+    options.issuer = 'https://auth-js-test.okta.com';
   }
-
+  var baseUri = options.issuer.indexOf('/oauth2') > 0 ? options.issuer.split('/oauth2')[0] : options.issuer;
   var ajaxMock, resReply, oa, trans;
 
   return Promise.resolve()
@@ -151,7 +151,7 @@ function setup(options) {
         // Get all the pairs and load the mock
         var xhrGenPromises = [];
         _.each(options.calls, function(call) {
-          var xhrGenPromise = generateXHRPair(call.request, call.response, options.uri, call.responseVars);
+          var xhrGenPromise = generateXHRPair(call.request, call.response, baseUri, call.responseVars);
           xhrGenPromises.push(xhrGenPromise);
         });
 
@@ -162,7 +162,7 @@ function setup(options) {
           });
 
       } else if (options.response) {
-        return generateXHRPair(options.request, options.response, options.uri, options.responseVars)
+        return generateXHRPair(options.request, options.response, baseUri, options.responseVars)
           .then(function(pair) {
             // Load the single response as a pair
             ajaxMock = mockAjax(pair);
@@ -179,7 +179,6 @@ function setup(options) {
 
       // 2. Setup OktaAuth
       oa = new OktaAuth({
-        url: options.uri,
         issuer: options.issuer,
         transformErrorXHR: options.transformErrorXHR,
         headers: options.headers,
@@ -194,7 +193,7 @@ function setup(options) {
             stateToken: 'dummy'
           }
         };
-        return generateXHRPair(request, options.status, options.uri)
+        return generateXHRPair(request, options.status, baseUri)
           .then(function(pair) {
             ajaxMock.setNextPair({
               request: pair.request,


### PR DESCRIPTION
- issuer is now a required option
- option 'url' is deprecated and no longer used
