### PR TITLE
feat: validate idToken.claims.at_hash against access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 - [#317](https://github.com/okta/okta-auth-js/pull/317) - `pkce` option is now `true` by default. `grantType` option is removed.
 
+- [#321](https://github.com/okta/okta-auth-js/pull/321)
+  - Default responseType when using implicit flow is now ['token', 'id_token'].
+  - When both access token and id token are returned, the id token's at_hash claim will be validated against the access token
+
 ### Other
 
 ## 2.12.0

--- a/README.md
+++ b/README.md
@@ -1521,8 +1521,8 @@ The following configuration options can **only** be included in `token.getWithou
 | :-------: | ----------|
 | `sessionToken` | Specify an Okta sessionToken to skip reauthentication when the user already authenticated using the Authentication Flow. |
 | `responseMode` | Specify how the authorization response should be returned. You will generally not need to set this unless you want to override the default values for `token.getWithRedirect`. See [Parameter Details](https://developer.okta.com/docs/api/resources/oidc#parameter-details) for a list of available modes. |
-| `responseType` | Specify the [response type](https://developer.okta.com/docs/api/resources/oidc#request-parameters) for OIDC authentication when using the [Implicit OAuth Flow](#implicit-oauth-20-flow). The default value is `id_token`. If `pkce` is `true`, this option will be ingored. |
-| | Use an array if specifying multiple response types - in this case, the response will contain both an ID Token and an Access Token. `responseType: ['id_token', 'token']` |
+| `responseType` | Specify the [response type](https://developer.okta.com/docs/api/resources/oidc#request-parameters) for OIDC authentication when using the [Implicit OAuth Flow](#implicit-oauth-20-flow). The default value is `['token', 'id_token']` which will request both an access token and ID token. If `pkce` is `true`, this option will be ignored. |
+
 | `scopes` | Specify what information to make available in the returned `id_token` or `access_token`. For OIDC, you must include `openid` as one of the scopes. Defaults to `['openid', 'email']`. For a list of available scopes, see [Scopes and Claims](https://developer.okta.com/docs/api/resources/oidc#access-token-scopes-and-claims). |
 | `state` | Specify a state that will be validated in an OAuth response. This is usually only provided during redirect flows to obtain an authorization code. Defaults to a random string. |
 | `nonce` | Specify a nonce that will be validated in an `id_token`. This is usually only provided during redirect flows to obtain an authorization code that will be exchanged for an `id_token`. Defaults to a random string. |

--- a/packages/okta-auth-js/lib/crypto.js
+++ b/packages/okta-auth-js/lib/crypto.js
@@ -9,8 +9,19 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
-/* global crypto */
+/* global crypto, Uint8Array, TextEncoder */
 var util = require('./util');
+
+function getOidcHash(str) {  
+  var buffer = new TextEncoder().encode(str);
+  return crypto.subtle.digest('SHA-256', buffer).then(function(arrayBuffer) {
+    var intBuffer = new Uint8Array(arrayBuffer);
+    var firstHalf = intBuffer.slice(0, 16);
+    var hash = String.fromCharCode.apply(null, firstHalf);
+    var b64u = util.stringToBase64Url(hash); // url-safe base64 variant
+    return b64u;
+  });
+}
 
 function verifyToken(idToken, key) {
   key = util.clone(key);
@@ -51,5 +62,6 @@ function verifyToken(idToken, key) {
 }
 
 module.exports = {
+  getOidcHash: getOidcHash,
   verifyToken: verifyToken
 };

--- a/packages/okta-auth-js/test/karma/spec/crypto.js
+++ b/packages/okta-auth-js/test/karma/spec/crypto.js
@@ -4,6 +4,15 @@ var sdkCrypto = require('../../../lib/crypto');
 var sdkUtil = require('../../../lib/util');
 
 describe('crypto', function() {
+  describe('getOidcHash', () => {
+    it('produces the correct value', () => {
+      // Values are taken from OAuth2JWTTokenServiceImplUnitTest in okta-core
+      return sdkCrypto.getOidcHash('dNZX1hEZ9wBCzNL40Upu646bdzQA')
+        .then(atHash => {
+          expect(atHash).toBe('wfgvmE9VxjAudsl9lc6TqA');
+        });
+    });
+  });
 
   describe('verifyToken', function() {
 

--- a/packages/okta-auth-js/test/spec/token.js
+++ b/packages/okta-auth-js/test/spec/token.js
@@ -13,6 +13,7 @@ var packageJson = require('../../package.json');
 var sdkUtil = require('../../lib/oauthUtil');
 var pkce = require('../../lib/pkce');
 var http = require('../../lib/http');
+var sdkCrypto = require('../../lib/crypto');
 
 function setupSync(options) {
   options = Object.assign({ issuer: 'http://example.okta.com', pkce: false }, options);
@@ -111,6 +112,7 @@ describe('token.getWithoutPrompt', function() {
       fn({
         data: {
           'id_token': tokens.standardIdToken,
+          'access_token': tokens.standardAccessToken,
           state: states[index],
         },
         origin: origin || 'https://auth-js-test.okta.com'
@@ -241,7 +243,7 @@ describe('token.getWithoutPrompt', function() {
     });
   });
 
-  it('returns id_token using sessionToken', function() {
+  it('returns tokens using sessionToken', function() {
     return oauthUtil.setupFrame({
       oktaAuthArgs: {
         pkce: false,
@@ -257,7 +259,7 @@ describe('token.getWithoutPrompt', function() {
         queryParams: {
           'client_id': 'NPSfOkH5eZrTy8PMDlvx',
           'redirect_uri': 'https://example.com/redirect',
-          'response_type': 'id_token',
+          'response_type': 'token id_token',
           'response_mode': 'okta_post_message',
           'state': oauthUtil.mockedState,
           'nonce': oauthUtil.mockedNonce,
@@ -269,7 +271,7 @@ describe('token.getWithoutPrompt', function() {
     });
   });
 
-  it('returns id_token using sessionToken with issuer', function() {
+  it('returns tokens using sessionToken with issuer', function() {
     return oauthUtil.setupFrame({
       oktaAuthArgs: {
         pkce: false,
@@ -285,7 +287,7 @@ describe('token.getWithoutPrompt', function() {
         queryParams: {
           'client_id': 'NPSfOkH5eZrTy8PMDlvx',
           'redirect_uri': 'https://example.com/redirect',
-          'response_type': 'id_token',
+          'response_type': 'token id_token',
           'response_mode': 'okta_post_message',
           'state': oauthUtil.mockedState,
           'nonce': oauthUtil.mockedNonce,
@@ -295,6 +297,7 @@ describe('token.getWithoutPrompt', function() {
         }
       },
       postMessageResp: {
+        'access_token': tokens.authServerAccessToken,
         'id_token': tokens.authServerIdToken,
         'state': oauthUtil.mockedState
       },
@@ -307,7 +310,7 @@ describe('token.getWithoutPrompt', function() {
     });
   });
 
-  it('returns id_token using sessionToken with issuer as id', function() {
+  it('returns tokens using sessionToken with issuer as id', function() {
     return oauthUtil.setupFrame({
       oktaAuthArgs: {
         issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
@@ -323,7 +326,7 @@ describe('token.getWithoutPrompt', function() {
         queryParams: {
           'client_id': 'NPSfOkH5eZrTy8PMDlvx',
           'redirect_uri': 'https://example.com/redirect',
-          'response_type': 'id_token',
+          'response_type': 'token id_token',
           'response_mode': 'okta_post_message',
           'state': oauthUtil.mockedState,
           'nonce': oauthUtil.mockedNonce,
@@ -333,6 +336,7 @@ describe('token.getWithoutPrompt', function() {
         }
       },
       postMessageResp: {
+        'access_token': tokens.authServerAccessToken,
         'id_token': tokens.authServerIdToken,
         'state': oauthUtil.mockedState
       },
@@ -363,7 +367,7 @@ describe('token.getWithoutPrompt', function() {
         queryParams: {
           'client_id': 'NPSfOkH5eZrTy8PMDlvx',
           'redirect_uri': 'https://example.com/redirect',
-          'response_type': 'id_token',
+          'response_type': 'token id_token',
           'response_mode': 'okta_post_message',
           'state': oauthUtil.mockedState,
           'nonce': oauthUtil.mockedNonce,
@@ -373,6 +377,7 @@ describe('token.getWithoutPrompt', function() {
         }
       },
       postMessageResp: {
+        'access_token': tokens.authServerAccessToken,
         'id_token': tokens.authServerIdToken,
         'state': oauthUtil.mockedState
       },
@@ -462,6 +467,7 @@ describe('token.getWithoutPrompt', function() {
 
       // getWithoutPrompt, but don't resolve
       firstPrompt = context.client.token.getWithoutPrompt({
+        responseType: 'id_token',
         sessionToken: 'testSessionToken',
         state: oauthUtil.mockedState,
         nonce: oauthUtil.mockedNonce
@@ -469,6 +475,7 @@ describe('token.getWithoutPrompt', function() {
 
       // getWithoutPrompt, but don't resolve
       secondPrompt = context.client.token.getWithoutPrompt({
+        responseType: 'id_token',
         sessionToken: 'testSessionToken2',
         state: oauthUtil.mockedState2,
         nonce: oauthUtil.mockedNonce2
@@ -865,7 +872,7 @@ describe('token.getWithPopup', function() {
       });
   });
 
-  it('returns id_token using idp', function() {
+  it('returns tokens using idp', function() {
       return oauthUtil.setupPopup({
         oktaAuthArgs: {
           pkce: false,
@@ -881,7 +888,7 @@ describe('token.getWithPopup', function() {
           queryParams: {
             'client_id': 'NPSfOkH5eZrTy8PMDlvx',
             'redirect_uri': 'https://example.com/redirect',
-            'response_type': 'id_token',
+            'response_type': 'token id_token',
             'response_mode': 'okta_post_message',
             'display': 'popup',
             'state': oauthUtil.mockedState,
@@ -893,7 +900,7 @@ describe('token.getWithPopup', function() {
       });
   });
 
-  it('returns id_token using idp with authorization server', function() {
+  it('returns tokens using idp with authorization server', function() {
       return oauthUtil.setupPopup({
         oktaAuthArgs: {
           pkce: false,
@@ -909,7 +916,7 @@ describe('token.getWithPopup', function() {
           queryParams: {
             'client_id': 'NPSfOkH5eZrTy8PMDlvx',
             'redirect_uri': 'https://example.com/redirect',
-            'response_type': 'id_token',
+            'response_type': 'token id_token',
             'response_mode': 'okta_post_message',
             'display': 'popup',
             'state': oauthUtil.mockedState,
@@ -919,6 +926,7 @@ describe('token.getWithPopup', function() {
           }
         },
         postMessageResp: {
+          'access_token': tokens.authServerAccessToken,
           'id_token': tokens.authServerIdToken,
           'state': oauthUtil.mockedState
         },
@@ -949,7 +957,7 @@ describe('token.getWithPopup', function() {
           queryParams: {
             'client_id': 'NPSfOkH5eZrTy8PMDlvx',
             'redirect_uri': 'https://example.com/redirect',
-            'response_type': 'id_token',
+            'response_type': 'token id_token',
             'response_mode': 'okta_post_message',
             'display': 'popup',
             'state': oauthUtil.mockedState,
@@ -959,6 +967,7 @@ describe('token.getWithPopup', function() {
           }
         },
         postMessageResp: {
+          'access_token': tokens.authServerAccessToken,
           'id_token': tokens.authServerIdToken,
           'state': oauthUtil.mockedState
         },
@@ -1002,6 +1011,7 @@ describe('token.getWithPopup', function() {
       // getWithPopup, but don't resolve
       firstPopup = context.client.token.getWithPopup({
         idp: 'testIdp',
+        responseType: 'id_token',
         state: oauthUtil.mockedState,
         nonce: oauthUtil.mockedNonce
       });
@@ -1009,6 +1019,7 @@ describe('token.getWithPopup', function() {
       // getWithPopup, but don't resolve
       secondPopup = context.client.token.getWithPopup({
         idp: 'testIdp2',
+        responseType: 'id_token',
         state: oauthUtil.mockedState2,
         nonce: oauthUtil.mockedNonce2
       });
@@ -1276,7 +1287,7 @@ describe('token.getWithRedirect', function() {
     spyOn(pkce, 'computeChallenge').and.returnValue(Promise.resolve(codeChallenge));
   }
 
-  it('sets authorize url and cookie for id_token using sessionToken', function() {
+  it('sets authorize url and cookie using sessionToken', function() {
     return oauthUtil.setupRedirect({
       getWithRedirectArgs: {
         sessionToken: 'testToken'
@@ -1285,7 +1296,7 @@ describe('token.getWithRedirect', function() {
         [
           'okta-oauth-redirect-params',
           JSON.stringify({
-            responseType: 'id_token',
+            responseType: ['token', 'id_token'],
             state: oauthUtil.mockedState,
             nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
@@ -1306,14 +1317,14 @@ describe('token.getWithRedirect', function() {
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
-                            'response_type=id_token&' +
+                            'response_type=token%20id_token&' +
                             'sessionToken=testToken&' +
                             'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
 
-  it('sets authorize url and cookie for id_token using sessionToken and authorization server', function() {
+  it('sets authorize url and cookie using sessionToken and authorization server', function() {
     return oauthUtil.setupRedirect({
       oktaAuthArgs: {
         pkce: false,
@@ -1328,7 +1339,7 @@ describe('token.getWithRedirect', function() {
         [
           'okta-oauth-redirect-params',
           JSON.stringify({
-            responseType: 'id_token',
+            responseType: ['token', 'id_token'],
             state: oauthUtil.mockedState,
             nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
@@ -1349,7 +1360,7 @@ describe('token.getWithRedirect', function() {
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
-                            'response_type=id_token&' +
+                            'response_type=token%20id_token&' +
                             'sessionToken=testToken&' +
                             'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
@@ -1828,7 +1839,7 @@ describe('token.getWithRedirect', function() {
         [
           'okta-oauth-redirect-params',
           JSON.stringify({
-            responseType: 'id_token',
+            responseType: ['token', 'id_token'],
             state: oauthUtil.mockedState,
             nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
@@ -1850,7 +1861,7 @@ describe('token.getWithRedirect', function() {
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
-                            'response_type=id_token&' +
+                            'response_type=token%20id_token&' +
                             'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
@@ -1865,7 +1876,7 @@ describe('token.getWithRedirect', function() {
         [
           'okta-oauth-redirect-params',
           JSON.stringify({
-            responseType: 'id_token',
+            responseType: ['token', 'id_token'],
             state: oauthUtil.mockedState,
             nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
@@ -1887,7 +1898,7 @@ describe('token.getWithRedirect', function() {
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
-                            'response_type=id_token&' +
+                            'response_type=token%20id_token&' +
                             'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
@@ -1902,7 +1913,7 @@ describe('token.getWithRedirect', function() {
         [
           'okta-oauth-redirect-params',
           JSON.stringify({
-            responseType: 'id_token',
+            responseType: ['token', 'id_token'],
             state: oauthUtil.mockedState,
             nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
@@ -1924,7 +1935,7 @@ describe('token.getWithRedirect', function() {
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
                             'response_mode=fragment&' +
-                            'response_type=id_token&' +
+                            'response_type=token%20id_token&' +
                             'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
@@ -2618,35 +2629,86 @@ describe('token.getUserInfo', function() {
 });
 
 describe('token.verify', function() {
-  var validationParams = {
-    clientId: tokens.standardIdTokenParsed.clientId,
-    issuer: tokens.standardIdTokenParsed.issuer
-  };
+  var validationParams;
+  var client;
+  beforeEach(() => {
+    validationParams = {
+      clientId: tokens.standardIdTokenParsed.clientId,
+      issuer: tokens.standardIdTokenParsed.issuer
+    };
+    client = setupSync();
+  });
+
+  describe('with access token', () => {
+    var idToken;
+    var atHash;
+
+    beforeEach(() => {
+      atHash = 'Gryuqew1_irUBmgZAncMsA'; // based on tokens.standardAccessToken
+
+      // Mock out sdk crypto
+      jest.spyOn(client.features, 'isTokenVerifySupported').mockReturnValue(true);
+      jest.spyOn(sdkCrypto, 'verifyToken').mockReturnValue(true);
+      jest.spyOn(sdkCrypto, 'getOidcHash').mockReturnValue(Promise.resolve(atHash));
+
+      // Return modified idToken
+      idToken = _.cloneDeep(tokens.standardIdTokenParsed);
+      idToken.claims.at_hash = atHash;
+    });
+
+    it('verifies idToken at_hash claim against accessToken', () => {
+      util.warpToUnixTime(1449699929);
+      oauthUtil.loadWellKnownAndKeysCache();
+      validationParams.accessToken = tokens.standardAccessToken;
+      return client.token.verify(idToken, validationParams)
+      .then(function(res) {
+        expect(res).toEqual(idToken);
+        expect(sdkCrypto.getOidcHash).toHaveBeenCalledWith(tokens.standardAccessToken);
+      });
+    });
+
+    it('throws if idToken at_hash claim does not match accessToken', () => {
+      util.warpToUnixTime(1449699929);
+      oauthUtil.loadWellKnownAndKeysCache();
+      validationParams.accessToken = tokens.standardAccessToken;
+      idToken.claims.at_hash = 'other_hash';
+      return client.token.verify(idToken, validationParams)
+      .then(function() {
+        expect('not to be hit').toEqual(true);
+      })
+      .catch(function(err) {
+        util.assertAuthSdkError(err, 'Token hash verification failed');
+      });
+    });
+
+    it('skips verification if idToken does not have at_hash claim', () => {
+      util.warpToUnixTime(1449699929);
+      oauthUtil.loadWellKnownAndKeysCache();
+      validationParams.accessToken = tokens.standardAccessToken;
+      delete idToken.claims.at_hash;
+      return client.token.verify(idToken, validationParams)
+      .then(function(res) {
+        expect(res).toEqual(idToken);
+        expect(sdkCrypto.getOidcHash).not.toHaveBeenCalled();
+      });
+    });
+  });
 
   it('verifies a valid idToken with nonce', function() {
-    var client = setupSync();
     util.warpToUnixTime(1449699929);
     oauthUtil.loadWellKnownAndKeysCache();
-    var alteredParams = _.clone(validationParams);
-    alteredParams.nonce = tokens.standardIdTokenParsed.nonce;
+    validationParams.nonce = tokens.standardIdTokenParsed.nonce;
     return client.token.verify(tokens.standardIdTokenParsed, validationParams)
     .then(function(res) {
       expect(res).toEqual(tokens.standardIdTokenParsed);
-    })
-    .catch(function() {
-      expect('not to be hit').toEqual(true);
-    })
+    });
   });
-  it('verifies a valid idToken without nonce', function() {
-    var client = setupSync();
+  it('verifies a valid idToken without nonce or accessToken', function() {
     util.warpToUnixTime(1449699929);
     oauthUtil.loadWellKnownAndKeysCache();
     return client.token.verify(tokens.standardIdTokenParsed, validationParams)
     .then(function(res) {
       expect(res).toEqual(tokens.standardIdTokenParsed);
-    })
-    .catch(function() {
-      expect('not to be hit').toEqual(true);
     });
   });
 
@@ -2658,7 +2720,6 @@ describe('token.verify', function() {
       jest.useRealTimers();
     });
     function expectError(verifyArgs, message) {
-      var client = setupSync();
       return client.token.verify.apply(null, verifyArgs)
       .then(function() {
         expect('not to be hit').toEqual(true);
@@ -2683,21 +2744,18 @@ describe('token.verify', function() {
         'The JWT expired and is no longer valid');
     });
     it('invalid nonce', function() {
-      var alteredParams = _.clone(validationParams);
-      alteredParams.nonce = 'invalidNonce';
-      return expectError([tokens.standardIdToken2Parsed, alteredParams],
+      validationParams.nonce = 'invalidNonce';
+      return expectError([tokens.standardIdToken2Parsed, validationParams],
         'OAuth flow response nonce doesn\'t match request nonce');
     });
     it('invalid audience', function() {
-      var alteredParams = _.clone(validationParams);
-      alteredParams.clientId = 'invalidAudience';
-      return expectError([tokens.standardIdTokenParsed, alteredParams],
+      validationParams.clientId = 'invalidAudience';
+      return expectError([tokens.standardIdTokenParsed, validationParams],
         'The audience [NPSfOkH5eZrTy8PMDlvx] does not match [invalidAudience]');
     });
     it('invalid issuer', function() {
-      var alteredParams = _.clone(validationParams);
-      alteredParams.issuer = 'http://invalidissuer.example.com';
-      return expectError([tokens.standardIdTokenParsed, alteredParams],
+      validationParams.issuer = 'http://invalidissuer.example.com';
+      return expectError([tokens.standardIdTokenParsed, validationParams],
         'The issuer [https://auth-js-test.okta.com] does not match [http://invalidissuer.example.com]');
     });
     it('expired before issued', function() {

--- a/test/app/server.js
+++ b/test/app/server.js
@@ -29,10 +29,15 @@ app.post('/login', function(req, res) {
   let status = '';
   let sessionToken = '';
   let error = '';
+  let authClient;
 
-  const authClient = new OktaAuthJS( {
-    issuer
-  });
+  try {
+    authClient = new OktaAuthJS({
+      issuer
+    });
+  } catch(e) {
+    console.error('Caught exception in OktaAuthJS constructor: ', e);
+  }
 
   authClient.signIn({
     username,

--- a/test/app/src/config.js
+++ b/test/app/src/config.js
@@ -14,6 +14,7 @@ function getDefaultConfig() {
     postLogoutRedirectUri: POST_LOGOUT_REDIRECT_URI,
     issuer: ISSUER,
     clientId: CLIENT_ID,
+    responseType: ['token', 'id_token'],
     pkce: true,
     secureCookies: true
   };
@@ -25,11 +26,11 @@ function getConfigFromUrl() {
   const redirectUri = url.searchParams.get('redirectUri') || REDIRECT_URI;
   const postLogoutRedirectUri = url.searchParams.get('postLogoutRedirectUri') || POST_LOGOUT_REDIRECT_URI;
   const clientId = url.searchParams.get('clientId');
-  const pkce = url.searchParams.get('pkce') && url.searchParams.get('pkce') !== 'false';
+  const pkce = url.searchParams.get('pkce') !== 'false'; // On by default
   const scopes = (url.searchParams.get('scopes') || 'openid,email').split(',');
   const responseType = (url.searchParams.get('responseType') || 'id_token,token').split(',');
   const storage = url.searchParams.get('storage') || undefined;
-  const secureCookies = url.searchParams.get('secureCookies') !== 'off'; // On by default
+  const secureCookies = url.searchParams.get('secureCookies') !== 'false'; // On by default
   return {
     redirectUri,
     postLogoutRedirectUri,

--- a/test/app/src/form.js
+++ b/test/app/src/form.js
@@ -5,9 +5,12 @@ const Form = `
   <form target="/oidc" method="GET">
   <label for="issuer">Issuer</label><input id="issuer" name="issuer" type="text" /><br/>
   <label for="clientId">Client ID</label><input id="clientId" name="clientId" type="text" /><br/>
+  <label for="responseType">Response Type (comma separated)</label><input id="responseType" name="responseType" type="text" /><br/>
   <label for="redirectUri">Redirect URI</label><input id="redirectUri" name="redirectUri" type="text" /><br/>
   <label for="postLogoutRedirectUri">Post Logout Redirect URI</label><input id="postLogoutRedirectUri" name="postLogoutRedirectUri" type="text" /><br/>
-  <label for="pkce">PKCE</label><input id="pkce" name="pkce" type="checkbox"/><br/>
+  <label for="pkce">PKCE</label><br/>
+  <input id="pkce-on" name="pkce" type="radio" value="true"/>ON<br/>
+  <input id="pkce-off" name="pkce" type="radio" value="false"/>OFF<br/>
   <label for="storage">Storage</label>
   <select id="storage" name="storage">
     <option value="" selected>Auto</option>
@@ -16,7 +19,9 @@ const Form = `
     <option value="cookie">Cookie</option>
     <option value="memory">Memory</option>
   </select><br/>
-  <label for="secure">Secure Cookies</label><input id="secureCookies" name="secureCookies" type="checkbox"/><br/>
+  <label for="secure">Secure Cookies</label><br/>
+  <input id="secureCookies-on" name="secureCookies" type="radio" value="true"/>ON<br/>
+  <input id="secureCookies-off" name="secureCookies" type="radio" value="false"/>OFF<br/>
   <hr/>
   <input id="login-submit" type="submit" value="Update Config"/>
   </form>
@@ -26,11 +31,22 @@ function updateForm(config) {
   config = flattenConfig(config);
   document.getElementById('issuer').value = config.issuer;
   document.getElementById('redirectUri').value = config.redirectUri;
+  document.getElementById('responseType').value = config.responseType.join(',');
   document.getElementById('postLogoutRedirectUri').value = config.postLogoutRedirectUri;
   document.getElementById('clientId').value = config.clientId;
-  document.getElementById('pkce').checked = !!config.pkce;
   document.querySelector(`#storage [value="${config.storage || ''}"]`).selected = true;
-  document.getElementById('secureCookies').checked = !!config.secureCookies;
+
+  if (config.pkce) {
+    document.getElementById('pkce-on').checked = true;
+  } else {
+    document.getElementById('pkce-off').checked = true;
+  }
+
+  if (config.secureCookies) {
+    document.getElementById('secureCookies-on').checked = true;
+  } else {
+    document.getElementById('secureCookies-off').checked = true;
+  }
 }
 
 export { Form, updateForm };

--- a/test/app/src/testApp.js
+++ b/test/app/src/testApp.js
@@ -312,7 +312,7 @@ Object.assign(TestApp.prototype, {
   },
   appHTML: function(props) {
     const { idToken, accessToken } = props || {};
-    if (idToken && accessToken) {
+    if (idToken || accessToken) {
       // Authenticated user home page
       return `
         <strong>Welcome back</strong>
@@ -365,9 +365,10 @@ Object.assign(TestApp.prototype, {
   },
 
   callbackHTML: function(res) {
-    const success = res.tokens && res.tokens.accessToken && res.tokens.idToken;
+    const tokensReceived = res.tokens ? Object.keys(res.tokens): [];
+    const success = res.tokens && tokensReceived.length;
     const errorMessage = success ? '' :  'Tokens not returned. Check error console for more details';
-    const successMessage = success ? 'Successfully received tokens on the callback page!' : '';
+    const successMessage = success ? 'Successfully received tokens on the callback page: ' + tokensReceived.join(', ') : '';
     const content = `
       <div id="callback-result">
         <strong><div id="success">${successMessage}</div></strong>

--- a/test/app/src/tokens.js
+++ b/test/app/src/tokens.js
@@ -2,7 +2,7 @@ import { htmlString } from './util';
 
 function tokensHTML(tokens) {
   const { idToken, accessToken } = tokens;
-  const claims = idToken.claims;
+  const claims = idToken ? idToken.claims : {};
   const html = `
   <table id="claims">
     <thead>
@@ -22,11 +22,11 @@ function tokensHTML(tokens) {
   <div class="flex-row">
     <div class="box">
       <strong>Access Token</strong><br/>
-      <div id="access-token">${ htmlString(accessToken) }</div>
+      <div id="access-token">${ accessToken ? htmlString(accessToken) : 'N/A' }</div>
     </div>
     <div class="box">
       <strong>ID Token</strong><br/>
-      <div id="id-token">${ htmlString(idToken) }</div>
+      <div id="id-token">${ idToken ? htmlString(idToken) : 'N/A' }</div>
     </div>
   </div>
   `;

--- a/test/e2e/pageobjects/TestApp.js
+++ b/test/e2e/pageobjects/TestApp.js
@@ -30,7 +30,7 @@ class TestApp {
   get password() { return $('#password'); }
 
   // Form
-  get pkceOption() { return $('#pkce'); }
+  get pkceOption() { return $('#pkce-on'); }
   get clientId() { return $('#clientId'); }
   get issuer() { return $('#issuer'); }
 

--- a/test/e2e/specs/tokens.js
+++ b/test/e2e/specs/tokens.js
@@ -93,6 +93,7 @@ describe('E2E token flows', () => {
         await TestApp.sessionExpired.then(el => el.getText()).then(txt => {
           assert(txt === 'SESSION EXPIRED');
         });
+        await TestApp.clearTokens();
         await browser.refresh();
         await TestApp.waitForLoginBtn(); // assert we are logged out
       });

--- a/test/e2e/util/appUtils.js
+++ b/test/e2e/util/appUtils.js
@@ -7,7 +7,7 @@ const CLIENT_ID = process.env.CLIENT_ID;
 const flows = ['implicit', 'pkce'];
 
 async function openImplicit() {
-  await TestApp.open({ issuer: ISSUER, clientId: CLIENT_ID });
+  await TestApp.open({ issuer: ISSUER, clientId: CLIENT_ID, pkce: false });
   await TestApp.pkceOption.then(el => el.isSelected()).then(isSelected => {
     assert(isSelected === false);
   });

--- a/test/support/oauthUtil.js
+++ b/test/support/oauthUtil.js
@@ -76,12 +76,17 @@ oauthUtil.loadWellKnownAndKeysCache = function() {
 
 var defaultPostMessage = oauthUtil.defaultPostMessage = {
   'id_token': tokens.standardIdToken,
+  'access_token': tokens.standardAccessToken,
   state: oauthUtil.mockedState
 };
 
 var defaultResponse = {
   state: oauthUtil.mockedState,
   tokens: {
+    accessToken: {
+      value: tokens.standardAccessToken,
+      accessToken: tokens.standardAccessToken
+    },
     idToken: {
       value: tokens.standardIdToken,
       idToken: tokens.standardIdToken,


### PR DESCRIPTION
- default `responseType` is now ['token', 'id_token'] (when using implicit flow. PKCE always requests both tokens)
- when both access token and id token are returned the id token's `at_hash` claim will be validated against the access token
- modifies test app to be handle cases where only 1 token is requested