### PR TITLE
feat: support responseMode=query for PKCE flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.13.0
+
+### Features
+
+- [#324](https://github.com/okta/okta-auth-js/pull/324) - Support `responseMode: "query"` option for SPA apps using PKCE flow
+
 ## 2.12.1
 
 ### Bug Fixes

--- a/packages/okta-auth-js/lib/browser/browser.js
+++ b/packages/okta-auth-js/lib/browser/browser.js
@@ -48,6 +48,7 @@ function OktaAuthBuilder(args) {
     pkce: usePKCE,
     redirectUri: args.redirectUri,
     postLogoutRedirectUri: args.postLogoutRedirectUri,
+    responseMode: args.responseMode,
     httpRequestClient: args.httpRequestClient,
     storageUtil: args.storageUtil,
     transformErrorXHR: args.transformErrorXHR,

--- a/packages/okta-auth-js/lib/oauthUtil.js
+++ b/packages/okta-auth-js/lib/oauthUtil.js
@@ -236,13 +236,13 @@ function getOAuthUrls(sdk, oauthParams, options) {
   };
 }
 
-function hashToObject(hash) {
+function urlParamsToObject(hashOrSearch) {
   // Predefine regexs for parsing hash
   var plus2space = /\+/g;
   var paramSplit = /([^&=]+)=?([^&]*)/g;
 
-  // Remove the leading hash
-  var fragment = hash.substring(1);
+  // Remove the leading # or ?
+  var fragment = hashOrSearch.substring(1);
 
   var obj = {};
 
@@ -274,7 +274,7 @@ module.exports = {
   getOAuthUrls: getOAuthUrls,
   loadFrame: loadFrame,
   loadPopup: loadPopup,
-  hashToObject: hashToObject,
+  urlParamsToObject: urlParamsToObject,
   isToken: isToken,
   addListener: addListener,
   removeListener: removeListener

--- a/packages/okta-auth-js/package.json
+++ b/packages/okta-auth-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "lib/server/serverIndex.js",

--- a/packages/okta-auth-js/test/spec/token.js
+++ b/packages/okta-auth-js/test/spec/token.js
@@ -1219,6 +1219,80 @@ describe('token.getWithRedirect', function() {
     spyOn(pkce, 'computeChallenge').and.returnValue(Q.resolve(codeChallenge));
   }
 
+  it('Can pass responseMode=query', function() {
+    return oauthUtil.setupRedirect({
+      getWithRedirectArgs: {
+        responseMode: 'query',
+      },
+      expectedCookies: [
+        [
+          'okta-oauth-redirect-params',
+          JSON.stringify({
+            responseType: 'id_token',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
+            scopes: ['openid', 'email'],
+            clientId: 'NPSfOkH5eZrTy8PMDlvx',
+            urls: defaultUrls,
+            ignoreSignature: false
+          }),
+          null, {
+            sameSite: 'lax'
+          }
+        ],
+        nonceCookie,
+        stateCookie
+      ],
+      expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
+                            'client_id=NPSfOkH5eZrTy8PMDlvx&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
+                            'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
+                            'response_mode=query&' +
+                            'response_type=id_token&' +
+                            'state=' + oauthUtil.mockedState + '&' +
+                            'scope=openid%20email'
+    });
+  });
+
+  it('Can set responseMode=query on SDK instance', function() {
+    return oauthUtil.setupRedirect({
+      oktaAuthArgs: {
+        issuer: 'https://auth-js-test.okta.com',
+        clientId: 'NPSfOkH5eZrTy8PMDlvx',
+        redirectUri: 'https://example.com/redirect',
+        responseMode: 'query'
+      },
+      getWithRedirectArgs: {},
+      expectedCookies: [
+        [
+          'okta-oauth-redirect-params',
+          JSON.stringify({
+            responseType: 'id_token',
+            state: oauthUtil.mockedState,
+            nonce: oauthUtil.mockedNonce,
+            scopes: ['openid', 'email'],
+            clientId: 'NPSfOkH5eZrTy8PMDlvx',
+            urls: defaultUrls,
+            ignoreSignature: false
+          }),
+          null, {
+            sameSite: 'lax'
+          }
+        ],
+        nonceCookie,
+        stateCookie
+      ],
+      expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
+                            'client_id=NPSfOkH5eZrTy8PMDlvx&' +
+                            'nonce=' + oauthUtil.mockedNonce + '&' +
+                            'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
+                            'response_mode=query&' +
+                            'response_type=id_token&' +
+                            'state=' + oauthUtil.mockedState + '&' +
+                            'scope=openid%20email'
+    });
+  });
+
   it('sets authorize url and cookie for id_token using sessionToken', function() {
     return oauthUtil.setupRedirect({
       getWithRedirectArgs: {
@@ -1900,8 +1974,94 @@ null, {
 describe('token.parseFromUrl', function() {
   it('does not change the hash if a url is passed directly', function() {
     return oauthUtil.setupParseUrl({
-      directUrl: 'http://example.com#id_token=' + tokens.standardIdToken +
+      parseFromUrlArgs: 'http://example.com#id_token=' + tokens.standardIdToken +
                 '&state=' + oauthUtil.mockedState,
+      oauthCookie: JSON.stringify({
+        responseType: 'id_token',
+        state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        scopes: ['openid', 'email'],
+        urls: {
+          issuer: 'https://auth-js-test.okta.com',
+          tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
+          authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+          userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+        }
+      }),
+      expectedResp: {
+        idToken: tokens.standardIdToken,
+        claims: tokens.standardIdTokenClaims,
+        expiresAt: 1449699930,
+        scopes: ['openid', 'email']
+      }
+    });
+  });
+
+  it('does not change the hash if a url is passed as an option', function() {
+    return oauthUtil.setupParseUrl({
+      parseFromUrlArgs: {
+        url: 'http://example.com#id_token=' + tokens.standardIdToken +
+                '&state=' + oauthUtil.mockedState,
+      },
+      oauthCookie: JSON.stringify({
+        responseType: 'id_token',
+        state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        scopes: ['openid', 'email'],
+        urls: {
+          issuer: 'https://auth-js-test.okta.com',
+          tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
+          authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+          userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+        }
+      }),
+      expectedResp: {
+        idToken: tokens.standardIdToken,
+        claims: tokens.standardIdTokenClaims,
+        expiresAt: 1449699930,
+        scopes: ['openid', 'email']
+      }
+    });
+  });
+
+  it('Can pass responseMode=query in options', function() {
+    return oauthUtil.setupParseUrl({
+      parseFromUrlArgs: {
+        responseMode: 'query'
+      },
+      searchMock: '?id_token=' + tokens.standardIdToken +
+      '&state=' + oauthUtil.mockedState,
+      oauthCookie: JSON.stringify({
+        responseType: 'id_token',
+        state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        scopes: ['openid', 'email'],
+        urls: {
+          issuer: 'https://auth-js-test.okta.com',
+          tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
+          authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+          userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+        }
+      }),
+      expectedResp: {
+        idToken: tokens.standardIdToken,
+        claims: tokens.standardIdTokenClaims,
+        expiresAt: 1449699930,
+        scopes: ['openid', 'email']
+      }
+    });
+  });
+
+  it('Can set responseMode=query in SDK options', function() {
+    return oauthUtil.setupParseUrl({
+      oktaAuthArgs: {
+        url: 'https://auth-js-test.okta.com',
+        clientId: 'NPSfOkH5eZrTy8PMDlvx',
+        redirectUri: 'https://example.com/redirect',
+        responseMode: 'query'
+      },
+      searchMock: '?id_token=' + tokens.standardIdToken +
+      '&state=' + oauthUtil.mockedState,
       oauthCookie: JSON.stringify({
         responseType: 'id_token',
         state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',

--- a/test/app/src/config.js
+++ b/test/app/src/config.js
@@ -23,6 +23,7 @@ function getConfigFromUrl() {
   const pkce = url.searchParams.get('pkce') && url.searchParams.get('pkce') !== 'false';
   const scopes = (url.searchParams.get('scopes') || 'openid,email').split(',');
   const responseType = (url.searchParams.get('responseType') || 'id_token,token').split(',');
+  const responseMode = url.searchParams.get('responseMode') || undefined;
   const storage = url.searchParams.get('storage') || undefined;
   const secure = url.searchParams.get('secure') === 'on'; // currently opt-in.
   return {
@@ -32,6 +33,7 @@ function getConfigFromUrl() {
     pkce,
     scopes,
     responseType,
+    responseMode,
     tokenManager: {
       storage,
       secure,

--- a/test/app/src/form.js
+++ b/test/app/src/form.js
@@ -6,6 +6,12 @@ const Form = `
   <label for="issuer">Issuer</label><input id="issuer" name="issuer" type="text" /><br/>
   <label for="clientId">Client ID</label><input id="clientId" name="clientId" type="text" /><br/>
   <label for="pkce">PKCE</label><input id="pkce" name="pkce" type="checkbox"/><br/>
+  <label for="responseMode">Response Mode</label>
+  <select id="responseMode" name="responseMode">
+    <option value="" selected>Auto</option>
+    <option value="fragment">Fragment</option>
+    <option value="query">Query</option>
+  </select><br/>
   <label for="storage">Storage</label>
   <select id="storage" name="storage">
     <option value="" selected>Auto</option>
@@ -25,6 +31,7 @@ function updateForm(config) {
   document.getElementById('issuer').value = config.issuer;
   document.getElementById('clientId').value = config.clientId;
   document.getElementById('pkce').checked = !!config.pkce;
+  document.querySelector(`#responseMode [value="${config.responseMode || ''}"]`).selected = true;
   document.querySelector(`#storage [value="${config.storage || ''}"]`).selected = true;
   document.getElementById('secure').checked = !!config.secure;
 }

--- a/test/e2e/pageobjects/TestApp.js
+++ b/test/e2e/pageobjects/TestApp.js
@@ -31,6 +31,7 @@ class TestApp {
 
   // Form
   get pkceOption() { return $('#pkce'); }
+  get responseModeQuery() { return $('#responseMode [value="query"]'); }
   get clientId() { return $('#clientId'); }
   get issuer() { return $('#issuer'); }
 

--- a/test/e2e/specs/login.js
+++ b/test/e2e/specs/login.js
@@ -1,8 +1,21 @@
+import assert from 'assert';
 import TestApp from '../pageobjects/TestApp';
 import { flows, openImplicit, openPKCE } from '../util/appUtils';
 import { loginRedirect, loginPopup, loginDirect } from '../util/loginUtils';
 
 describe('E2E login', () => {
+
+  // responseMode=query is not supported for implicit flow
+  it('can login using redirect (responseMode=query)', async () => {
+    await openPKCE({ responseMode: 'query' });
+    await TestApp.responseModeQuery.then(el => el.isSelected()).then(isSelected => {
+      assert(isSelected === true);
+    });
+    await loginRedirect('pkce', 'query');
+    await TestApp.getUserInfo();
+    await TestApp.assertUserInfo();
+    await TestApp.logout();
+  });
 
   flows.forEach(flow => {
     describe(flow + ' flow', () => {

--- a/test/e2e/util/appUtils.js
+++ b/test/e2e/util/appUtils.js
@@ -6,8 +6,8 @@ const CLIENT_ID = process.env.CLIENT_ID;
 
 const flows = ['implicit', 'pkce'];
 
-async function openImplicit() {
-  await TestApp.open({ issuer: ISSUER, clientId: CLIENT_ID });
+async function openImplicit(options) {
+  await TestApp.open(Object.assign({ issuer: ISSUER, clientId: CLIENT_ID }, options));
   await TestApp.pkceOption.then(el => el.isSelected()).then(isSelected => {
     assert(isSelected === false);
   });
@@ -19,8 +19,8 @@ async function openImplicit() {
   });
 }
 
-async function openPKCE() {
-  await TestApp.open({ issuer: ISSUER, clientId: CLIENT_ID, pkce: true });
+async function openPKCE(options) {
+  await TestApp.open(Object.assign({ issuer: ISSUER, clientId: CLIENT_ID, pkce: true }, options));
   await TestApp.pkceOption.then(el => el.isSelected()).then(isSelected => {
     assert(isSelected);
   });

--- a/test/e2e/util/loginUtils.js
+++ b/test/e2e/util/loginUtils.js
@@ -6,20 +6,22 @@ import { switchToPopupWindow, switchToMainWindow } from './browserUtils';
 const USERNAME = process.env.USERNAME;
 const PASSWORD = process.env.PASSWORD;
 
-function assertPKCE(url) {
-  const hash = url.split('#')[1];
-  assert(hash.indexOf('code' > 0));
+function assertPKCE(url, responseMode) {
+  const char = responseMode === 'query' ? '?' : '#';
+  const str = url.split(char)[1];
+  assert(str.indexOf('code' > 0));
 }
 
-function assertImplicit(url) {
-  const hash = url.split('#')[1];
-  assert(hash.indexOf('id_token' > 0));
+function assertImplicit(url, responseMode) {
+  const char = responseMode === 'query' ? '?' : '#';
+  const str = url.split(char)[1];
+  assert(str.indexOf('id_token' > 0));
 }
 
-async function handleCallback(flow) {
+async function handleCallback(flow, responseMode) {
   await TestApp.waitForCallback();
   const url = await browser.getUrl();
-  (flow === 'pkce') ? assertPKCE(url) : assertImplicit(url);
+  (flow === 'pkce') ? assertPKCE(url, responseMode) : assertImplicit(url, responseMode);
   await TestApp.handleCallback();
   await TestApp.assertCallbackSuccess();
   await TestApp.returnHome();
@@ -34,10 +36,10 @@ async function loginPopup() {
   await TestApp.assertLoggedIn();
 }
 
-async function loginRedirect(flow) {
+async function loginRedirect(flow, responseMode) {
   await TestApp.loginRedirect();
   await OktaLogin.signin(USERNAME, PASSWORD);
-  return handleCallback(flow);
+  return handleCallback(flow, responseMode);
 }
 
 async function loginDirect(flow) {


### PR DESCRIPTION
- adds support for `responseMode="query"` if using PKCE flow (server returns an unsupported response mode error if using implicit flow)
- option can be passed either in SDK constructor or as an option to `getWithRedirect` and `parseFromUrl`