### PR TITLE
feat: responseMode uses openid defaults

### DIFF
--- a/packages/okta-auth-js/test/karma/spec/loginFlow.js
+++ b/packages/okta-auth-js/test/karma/spec/loginFlow.js
@@ -123,10 +123,11 @@ describe('Complete login flow', function() {
 
   it('implicit login flow', function() {
     // First hit /authorize
-    return bootstrap({})
+    return bootstrap({
+      pkce: false
+    })
     .then(function(app) {
       return app.loginRedirect({
-        pkce: false,
         nonce: NONCE
       });
     })
@@ -143,7 +144,6 @@ describe('Complete login flow', function() {
       expect(url.searchParams.get('client_id')).toBe(CLIENT_ID);
       expect(url.searchParams.get('redirect_uri')).toBe(REDIRECT_URI);
       expect(url.searchParams.get('response_type')).toBe('id_token token');
-      expect(url.searchParams.get('response_mode')).toBe('fragment');
       expect(url.searchParams.get('scope')).toBe('openid email');
       expect(url.searchParams.get('state')).toBeTruthy();
       expect(url.searchParams.get('nonce')).toBe(NONCE);
@@ -154,7 +154,7 @@ describe('Complete login flow', function() {
       mockWellKnown();
       const state = url.searchParams.get('state');
       const pathname = `${CALLBACK_PATH}#access_token=${ACCESS_TOKEN}&id_token=${ID_TOKEN}&state=${state}&nonce=${NONCE}&expires_in=1000`;
-      return bootstrap({}, pathname)
+      return bootstrap({ pkce: false }, pathname)
       .then(function() {
 
         expect(getLocation).toHaveBeenCalled();
@@ -194,7 +194,6 @@ describe('Complete login flow', function() {
       expect(url.searchParams.get('client_id')).toBe(CLIENT_ID);
       expect(url.searchParams.get('redirect_uri')).toBe(REDIRECT_URI);
       expect(url.searchParams.get('response_type')).toBe('code');
-      expect(url.searchParams.get('response_mode')).toBe('fragment');
       expect(url.searchParams.get('scope')).toBe('openid email');
       expect(url.searchParams.get('state')).toBeTruthy();
       expect(url.searchParams.get('nonce')).toBeTruthy();
@@ -206,7 +205,7 @@ describe('Complete login flow', function() {
 
       // Now we handle the redirect & hit /token
       const state = url.searchParams.get('state');
-      const pathname = `${CALLBACK_PATH}#code=${AUTHORIZATION_CODE}&state=${state}`;
+      const pathname = `${CALLBACK_PATH}?code=${AUTHORIZATION_CODE}&state=${state}`;
       const tokenResponse = {
         'access_token': ACCESS_TOKEN,
         'id_token': ID_TOKEN,

--- a/packages/okta-auth-js/test/spec/token.js
+++ b/packages/okta-auth-js/test/spec/token.js
@@ -1346,7 +1346,6 @@ describe('token.getWithRedirect', function() {
     return oauthUtil.setupRedirect({
       willFail: true,
       oktaAuthArgs: {
-        pkce: false,
         issuer: 'https://auth-js-test.okta.com',
       },
       getWithRedirectArgs: [{
@@ -1371,16 +1370,20 @@ describe('token.getWithRedirect', function() {
     });
   });
 
-  it('Can pass responseMode=query', function() {
+  it('PKCE: Can pass responseMode=fragment', function() {
+    mockPKCE();
     return oauthUtil.setupRedirect({
+      oktaAuthArgs: {
+        pkce: true
+      },
       getWithRedirectArgs: {
-        responseMode: 'query',
+        responseMode: 'fragment',
       },
       expectedCookies: [
         [
           'okta-oauth-redirect-params',
           JSON.stringify({
-            responseType: ['token', 'id_token'],
+            responseType: 'code',
             state: oauthUtil.mockedState,
             nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
@@ -1398,29 +1401,30 @@ describe('token.getWithRedirect', function() {
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
+                            'code_challenge=' + codeChallenge + '&' +
+                            'code_challenge_method=' + codeChallengeMethod + '&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=query&' +
-                            'response_type=token%20id_token&' +
+                            'response_mode=fragment&' +
+                            'response_type=code&' +
                             'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
 
-  it('Can set responseMode=query on SDK instance', function() {
+  it('PKCE: Can set responseMode=fragment on SDK instance', function() {
+    mockPKCE();
     return oauthUtil.setupRedirect({
       oktaAuthArgs: {
-        issuer: 'https://auth-js-test.okta.com',
-        clientId: 'NPSfOkH5eZrTy8PMDlvx',
-        redirectUri: 'https://example.com/redirect',
-        responseMode: 'query'
+        pkce: true,
+        responseMode: 'fragment'
       },
       getWithRedirectArgs: {},
       expectedCookies: [
         [
           'okta-oauth-redirect-params',
           JSON.stringify({
-            responseType: ['token', 'id_token'],
+            responseType: 'code',
             state: oauthUtil.mockedState,
             nonce: oauthUtil.mockedNonce,
             scopes: ['openid', 'email'],
@@ -1438,10 +1442,12 @@ describe('token.getWithRedirect', function() {
       ],
       expectedRedirectUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize?' +
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
+                            'code_challenge=' + codeChallenge + '&' +
+                            'code_challenge_method=' + codeChallengeMethod + '&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=query&' +
-                            'response_type=token%20id_token&' +
+                            'response_mode=fragment&' +
+                            'response_type=code&' +
                             'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
@@ -1476,7 +1482,6 @@ describe('token.getWithRedirect', function() {
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=fragment&' +
                             'response_type=token%20id_token&' +
                             'sessionToken=testToken&' +
                             'state=' + oauthUtil.mockedState + '&' +
@@ -1519,7 +1524,6 @@ describe('token.getWithRedirect', function() {
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=fragment&' +
                             'response_type=token%20id_token&' +
                             'sessionToken=testToken&' +
                             'state=' + oauthUtil.mockedState + '&' +
@@ -1565,7 +1569,6 @@ describe('token.getWithRedirect', function() {
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=fragment&' +
                             'response_type=token&' +
                             'sessionToken=testToken&' +
                             'state=' + oauthUtil.mockedState + '&' +
@@ -1604,7 +1607,6 @@ describe('token.getWithRedirect', function() {
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=fragment&' +
                             'response_type=token&' +
                             'sessionToken=testToken&' +
                             'state=' + oauthUtil.mockedState + '&' +
@@ -1649,7 +1651,6 @@ describe('token.getWithRedirect', function() {
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=fragment&' +
                             'response_type=token&' +
                             'sessionToken=testToken&' +
                             'state=' + oauthUtil.mockedState + '&' +
@@ -1688,7 +1689,6 @@ describe('token.getWithRedirect', function() {
                             'idp=testIdp&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=fragment&' +
                             'response_type=token%20id_token&' +
                             'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
@@ -1732,14 +1732,13 @@ describe('token.getWithRedirect', function() {
                             'idp=testIdp&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=fragment&' +
                             'response_type=token%20id_token&' +
                             'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
   });
 
-  it('sets authorize url for authorization code requests, defaulting responseMode to query', function() {
+  it('sets authorize url for authorization code requests', function() {
     return oauthUtil.setupRedirect({
       getWithRedirectArgs: {
         sessionToken: 'testToken',
@@ -1769,7 +1768,6 @@ describe('token.getWithRedirect', function() {
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=query&' +
                             'response_type=code&' +
                             'sessionToken=testToken&' +
                             'state=' + oauthUtil.mockedState + '&' +
@@ -1777,7 +1775,7 @@ describe('token.getWithRedirect', function() {
     });
   });
 
-  it('PKCE: sets authorize url for authorization code requests, defaulting responseMode to fragment', function() {
+  it('PKCE: sets authorize url for authorization code requests', function() {
     mockPKCE();
     return oauthUtil.setupRedirect({
       oktaAuthArgs: {
@@ -1785,7 +1783,6 @@ describe('token.getWithRedirect', function() {
       },
       getWithRedirectArgs: {
         sessionToken: 'testToken',
-        responseType: 'code'
       },
       expectedCookies: [
         [
@@ -1813,7 +1810,6 @@ describe('token.getWithRedirect', function() {
                             'code_challenge_method=' + codeChallengeMethod + '&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=fragment&' +
                             'response_type=code&' +
                             'sessionToken=testToken&' +
                             'state=' + oauthUtil.mockedState + '&' +
@@ -1822,7 +1818,6 @@ describe('token.getWithRedirect', function() {
   });
 
   it('sets authorize url for authorization code requests with an authorization server', function() {
-    mockPKCE();
     return oauthUtil.setupRedirect({
       oktaAuthArgs: {
         pkce: false,
@@ -1858,7 +1853,6 @@ describe('token.getWithRedirect', function() {
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=query&' +
                             'response_type=code&' +
                             'sessionToken=testToken&' +
                             'state=' + oauthUtil.mockedState + '&' +
@@ -1897,7 +1891,6 @@ describe('token.getWithRedirect', function() {
                             'client_id=NPSfOkH5eZrTy8PMDlvx&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=query&' +
                             'response_type=code&' +
                             'sessionToken=testToken&' +
                             'state=' + oauthUtil.mockedState + '&' +
@@ -1942,7 +1935,6 @@ describe('token.getWithRedirect', function() {
                           'code_challenge_method=' + codeChallengeMethod + '&' +
                           'nonce=' + oauthUtil.mockedNonce + '&' +
                           'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                          'response_mode=fragment&' +
                           'response_type=code&' +
                           'sessionToken=testToken&' +
                           'state=' + oauthUtil.mockedState + '&' +
@@ -2019,7 +2011,6 @@ describe('token.getWithRedirect', function() {
                             'login_hint=JoeUser&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=fragment&' +
                             'response_type=token%20id_token&' +
                             'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
@@ -2056,7 +2047,6 @@ describe('token.getWithRedirect', function() {
                             'idp_scope=scope1%20scope2&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=fragment&' +
                             'response_type=token%20id_token&' +
                             'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
@@ -2093,7 +2083,6 @@ describe('token.getWithRedirect', function() {
                             'idp_scope=scope1%20scope2&' +
                             'nonce=' + oauthUtil.mockedNonce + '&' +
                             'redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&' +
-                            'response_mode=fragment&' +
                             'response_type=token%20id_token&' +
                             'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
@@ -2103,6 +2092,19 @@ describe('token.getWithRedirect', function() {
 });
 
 describe('token.parseFromUrl', function() {
+  function mockPKCE(response) {
+    var codeVerifier = 'fake';
+    var redirectUri = 'https://example.com/redirect';
+  
+    spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(true);
+    spyOn(pkce, 'loadMeta').and.returnValue({
+      codeVerifier,
+      redirectUri
+    });
+    spyOn(pkce, 'clearMeta');
+    spyOn(pkce, 'getToken').and.returnValue(Promise.resolve(response));
+  }
+
   it('does not change the hash if a url is passed directly', function() {
     return oauthUtil.setupParseUrl({
       parseFromUrlArgs: 'http://example.com#id_token=' + tokens.standardIdToken +
@@ -2159,14 +2161,17 @@ describe('token.parseFromUrl', function() {
     });
   });
 
-  it('Can pass responseMode=query in options', function() {
+  it('PKCE: can parse code in query', function() {
+    mockPKCE({
+      id_token: tokens.standardIdToken,
+      access_token: tokens.standardAccessToken
+    });
     return oauthUtil.setupParseUrl({
-      parseFromUrlArgs: {
-        responseMode: 'query'
+      oktaAuthArgs: {
+        pkce: true
       },
-      searchMock: '?id_token=' + tokens.standardIdToken +
-      '&access_token=' + tokens.standardAccessToken +
-      '&state=' + oauthUtil.mockedState,
+      searchMock: '?code=fake' + 
+        '&state=' + oauthUtil.mockedState,
       oauthCookie: JSON.stringify({
         responseType: ['token', 'id_token'],
         state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -2189,19 +2194,56 @@ describe('token.parseFromUrl', function() {
     });
   });
 
-  it('Can set responseMode=query in SDK options', function() {
+  it('PKCE: can pass responseMode=fragment in options', function() {
+    mockPKCE({
+      id_token: tokens.standardIdToken,
+      access_token: tokens.standardAccessToken
+    })
     return oauthUtil.setupParseUrl({
       oktaAuthArgs: {
-        pkce: false,
-        issuer: 'https://auth-js-test.okta.com',
-        clientId: 'NPSfOkH5eZrTy8PMDlvx',
-        redirectUri: 'https://example.com/redirect',
-        responseMode: 'query'
+        pkce: true
       },
-      searchMock: '?id_token=' + tokens.standardIdToken +
+      parseFromUrlArgs: {
+        responseMode: 'fragment'
+      },
+      hashMock: '#code=fake' + 
+        '&state=' + oauthUtil.mockedState,
+      oauthCookie: JSON.stringify({
+        responseType: ['token', 'id_token'],
+        state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        scopes: ['openid', 'email'],
+        urls: {
+          issuer: 'https://auth-js-test.okta.com',
+          tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
+          authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+          userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+        }
+      }),
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+          accessToken: tokens.standardAccessTokenParsed,
+          idToken: tokens.standardIdTokenParsed
+        }
+      }
+    });
+  });
+
+  it('PKCE: Can set responseMode=fragment in SDK options', function() {
+    mockPKCE({
+      id_token: tokens.standardIdToken,
+      access_token: tokens.standardAccessToken
+    });
+    return oauthUtil.setupParseUrl({
+      oktaAuthArgs: {
+        pkce: true,
+        responseMode: 'fragment'
+      },
+      hashMock: '#code=fake' +
       '&state=' + oauthUtil.mockedState,
       oauthCookie: JSON.stringify({
-        responseType: 'id_token',
+        responseType: ['token', 'id_token'],
         state: oauthUtil.mockedState,
         nonce: oauthUtil.mockedNonce,
         scopes: ['openid', 'email'],

--- a/test/e2e/pageobjects/TestApp.js
+++ b/test/e2e/pageobjects/TestApp.js
@@ -31,6 +31,7 @@ class TestApp {
 
   // Form
   get responseModeQuery() { return $('#responseMode [value="query"]'); }
+  get responseModeFragment() { return $('#responseMode [value="fragment"]'); }
   get pkceOption() { return $('#pkce-on'); }
   get clientId() { return $('#clientId'); }
   get issuer() { return $('#issuer'); }

--- a/test/e2e/specs/login.js
+++ b/test/e2e/specs/login.js
@@ -6,12 +6,12 @@ import { loginRedirect, loginPopup, loginDirect } from '../util/loginUtils';
 describe('E2E login', () => {
 
   // responseMode=query is not supported for implicit flow
-  it('can login using redirect (responseMode=query)', async () => {
-    await openPKCE({ responseMode: 'query' });
-    await TestApp.responseModeQuery.then(el => el.isSelected()).then(isSelected => {
+  it('PKCE: can login using redirect with responseMode=fragment', async () => {
+    await openPKCE({ responseMode: 'fragment' });
+    await TestApp.responseModeFragment.then(el => el.isSelected()).then(isSelected => {
       assert(isSelected === true);
     });
-    await loginRedirect('pkce', 'query');
+    await loginRedirect('pkce', 'fragment');
     await TestApp.getUserInfo();
     await TestApp.assertUserInfo();
     await TestApp.logoutRedirect();

--- a/test/e2e/util/loginUtils.js
+++ b/test/e2e/util/loginUtils.js
@@ -7,7 +7,7 @@ const USERNAME = process.env.USERNAME;
 const PASSWORD = process.env.PASSWORD;
 
 function assertPKCE(url, responseMode) {
-  const char = responseMode === 'query' ? '?' : '#';
+  const char = responseMode === 'fragment' ? '#' : '?';
   const str = url.split(char)[1];
   assert(str.indexOf('code' > 0));
 }

--- a/test/support/oauthUtil.js
+++ b/test/support/oauthUtil.js
@@ -391,12 +391,12 @@ oauthUtil.setupRedirect = function(opts) {
 };
 
 oauthUtil.setupParseUrl = function(opts) {
-  var client = new OktaAuth(opts.oktaAuthArgs || {
+  var client = new OktaAuth(Object.assign({
     pkce: false,
     issuer: 'https://auth-js-test.okta.com',
     clientId: 'NPSfOkH5eZrTy8PMDlvx',
     redirectUri: 'https://example.com/redirect'
-  });
+  }, opts.oktaAuthArgs));
 
   // Mock the well-known and keys request
   oauthUtil.loadWellKnownAndKeysCache();


### PR DESCRIPTION
- responseMode will not be passed to authorize endpoint unless explicitly specified
- default responseMode for PKCE is "query"
