### PR TITLE
fix: sameSite: use "lax" on HTTP

### DIFF
--- a/packages/okta-auth-js/jest.server.js
+++ b/packages/okta-auth-js/jest.server.js
@@ -12,6 +12,7 @@ module.exports = {
   ],
   'testPathIgnorePatterns': [
     './test/spec/browser.js',
+    './test/spec/browserStorage.js',
     './test/spec/fingerprint.js',
     './test/spec/general.js',
     './test/spec/oauthUtil.js',

--- a/packages/okta-auth-js/lib/browser/browserStorage.js
+++ b/packages/okta-auth-js/lib/browser/browserStorage.js
@@ -44,7 +44,9 @@ storageUtil.getPKCEStorage = function() {
   } else if (storageUtil.browserHasSessionStorage()) {
     return storageBuilder(storageUtil.getSessionStorage(), constants.PKCE_STORAGE_NAME);
   } else {
-    return storageBuilder(storageUtil.getCookieStorage(), constants.PKCE_STORAGE_NAME);
+    return storageBuilder(storageUtil.getCookieStorage({
+      secure: window.location.protocol === 'https:'
+    }), constants.PKCE_STORAGE_NAME);
   }
 };
 
@@ -54,7 +56,9 @@ storageUtil.getHttpCache = function() {
   } else if (storageUtil.browserHasSessionStorage()) {
     return storageBuilder(storageUtil.getSessionStorage(), constants.CACHE_STORAGE_NAME);
   } else {
-    return storageBuilder(storageUtil.getCookieStorage(), constants.CACHE_STORAGE_NAME);
+    return storageBuilder(storageUtil.getCookieStorage({
+      secure: window.location.protocol === 'https:'
+    }), constants.CACHE_STORAGE_NAME);
   }
 };
 
@@ -69,8 +73,8 @@ storageUtil.getSessionStorage = function() {
 // Provides webStorage-like interface for cookies
 storageUtil.getCookieStorage = function(options) {
   options = options || {};
-  var secure = options.secure; // currently opt-in
-  var sameSite = options.sameSite || 'none';
+  var secure = options.secure || false; // currently opt-in
+  var sameSite = options.sameSite || (secure ? 'none' : 'lax');
   return {
     getItem: storageUtil.storage.get,
     setItem: function(key, value) {

--- a/packages/okta-auth-js/test/spec/.eslintrc.json
+++ b/packages/okta-auth-js/test/spec/.eslintrc.json
@@ -13,6 +13,10 @@
   "globals": {
     "Promise": "readonly"
   },
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaVersion": 2017
+  },
   "rules": {
     "jasmine/no-unsafe-spy": 0,
     "jasmine/new-line-before-expect": 0,

--- a/packages/okta-auth-js/test/spec/browser.js
+++ b/packages/okta-auth-js/test/spec/browser.js
@@ -96,7 +96,7 @@ describe('Browser', function() {
 
   describe('signOut', function() {
     beforeEach(function() {
-      global.window.location.assign = jest.fn();
+      window.location.assign = jest.fn();
     });
     it('Default options: clear TokenManager, close session, no redirect', function() {
       spyOn(auth.session, 'close').and.returnValue(Promise.resolve());

--- a/packages/okta-auth-js/test/spec/browserStorage.js
+++ b/packages/okta-auth-js/test/spec/browserStorage.js
@@ -1,0 +1,211 @@
+jest.mock('../../lib/storageBuilder');
+
+var browserStorage  = require('../../lib/browser/browserStorage');
+var storageBuilder  = require('../../lib/storageBuilder');
+
+describe('browserStorage', () => {
+  let originalLocalStorage;
+  let originalSessionStorage;
+  let originalLocation;
+
+  beforeEach(() => {
+    originalLocalStorage = window.localStorage;
+    originalSessionStorage = window.sessionStorage;
+    originalLocation = window.location;
+  });
+
+  afterEach(() => {
+    window.localStorage = originalLocalStorage;
+    window.sessionStorage = originalSessionStorage;
+    window.location = originalLocation;
+  });
+
+  it('can return localStorage', () => {
+    expect(window.localStorage).toBeDefined();
+    expect(browserStorage.getLocalStorage()).toBe(global.localStorage);
+  });
+
+  it('can return sessionStorage', () => {
+    expect(window.sessionStorage).toBeDefined();
+    expect(browserStorage.getSessionStorage()).toBe(global.sessionStorage);
+  });
+
+  describe('browserHasLocalStorage', () => {
+    it('returns true if storage exists and passes test', () => {
+      expect(browserStorage.browserHasLocalStorage()).toBe(true);
+    });
+    it('returns false if localStorage does not exist', () => {
+      delete window.localStorage;
+      expect(browserStorage.browserHasLocalStorage()).toBe(false);
+    });
+    it('returns false if testStorage() returns false', () => {
+      jest.spyOn(browserStorage, 'testStorage').mockReturnValue(false);
+      expect(browserStorage.browserHasLocalStorage()).toBe(false);
+    });
+  });
+
+  describe('browserHasSessionStorage', () => {
+    it('returns true if storage exists and passes test', () => {
+      expect(browserStorage.browserHasSessionStorage()).toBe(true);
+    });
+    it('returns false if sessionStorage does not exist', () => {
+      delete window.sessionStorage;
+      expect(browserStorage.browserHasSessionStorage()).toBe(false);
+    });
+    it('returns false if testStorage() returns false', () => {
+      jest.spyOn(browserStorage, 'testStorage').mockReturnValue(false);
+      expect(browserStorage.browserHasSessionStorage()).toBe(false);
+    });
+  });
+
+  describe('testStorage', () => {
+    it('returns true if no exception is thrown', () => {
+      const fakeStorage = {
+        removeItem: jest.fn(),
+        setItem: jest.fn()
+      }
+      expect(browserStorage.testStorage(fakeStorage)).toBe(true);
+      expect(fakeStorage.setItem).toHaveBeenCalledWith('okta-test-storage', 'okta-test-storage');
+      expect(fakeStorage.removeItem).toHaveBeenCalledWith('okta-test-storage');
+    });
+    it('returns false if an exception is thrown on removeItem', () => {
+      const fakeStorage = {
+        removeItem: jest.fn().mockImplementation(() => {
+          throw new Error('removeItem fails');
+        }),
+        setItem: jest.fn()
+      }
+      expect(browserStorage.testStorage(fakeStorage)).toBe(false);
+    });
+    it('returns false if an exception is thrown on setItem', () => {
+      const fakeStorage = {
+        removeItem: jest.fn(),
+        setItem: jest.fn().mockImplementation(() => {
+          throw new Error('setItem fails');
+        }),
+      }
+      expect(browserStorage.testStorage(fakeStorage)).toBe(false);
+    });
+  });
+
+  describe('getPKCEStorage', () => {
+    it('Uses localStorage by default', () => {
+      browserStorage.getPKCEStorage();
+      expect(storageBuilder).toHaveBeenCalledWith(window.localStorage, 'okta-pkce-storage');
+    });
+    it('Uses sessionStorage if localStorage is not available', () => {
+      delete window.localStorage;
+      browserStorage.getPKCEStorage();
+      expect(storageBuilder).toHaveBeenCalledWith(window.sessionStorage, 'okta-pkce-storage');
+    });
+    it('Uses cookie storage if localStorage and sessionStorage are not available', () => {
+      delete window.localStorage;
+      delete window.sessionStorage;
+      const fakeStorage = { fakeStorage: true };
+      jest.spyOn(browserStorage, 'getCookieStorage').mockReturnValue(fakeStorage);
+      browserStorage.getPKCEStorage();
+      expect(storageBuilder).toHaveBeenCalledWith(fakeStorage, 'okta-pkce-storage');
+      expect(browserStorage.getCookieStorage).toHaveBeenCalledWith({
+        secure: false
+      });
+    });
+    it('Uses secure cookie storage if localStorage and sessionStorage are not available on HTTPS', () => {
+      delete window.localStorage;
+      delete window.sessionStorage;
+      delete window.location;
+      window.location = {
+        protocol: 'https:'
+      }
+      const fakeStorage = { fakeStorage: true };
+      jest.spyOn(browserStorage, 'getCookieStorage').mockReturnValue(fakeStorage);
+      browserStorage.getPKCEStorage();
+      expect(storageBuilder).toHaveBeenCalledWith(fakeStorage, 'okta-pkce-storage');
+      expect(browserStorage.getCookieStorage).toHaveBeenCalledWith({
+        secure: true
+      });
+    });
+  });
+
+  describe('getHttpCache', () => {
+    it('Uses localStorage by default', () => {
+      browserStorage.getHttpCache();
+      expect(storageBuilder).toHaveBeenCalledWith(window.localStorage, 'okta-cache-storage');
+    });
+    it('Uses sessionStorage if localStorage is not available', () => {
+      delete window.localStorage;
+      browserStorage.getHttpCache();
+      expect(storageBuilder).toHaveBeenCalledWith(window.sessionStorage, 'okta-cache-storage');
+    });
+    it('Uses cookie storage if localStorage and sessionStorage are not available', () => {
+      delete window.localStorage;
+      delete window.sessionStorage;
+      const fakeStorage = { fakeStorage: true };
+      jest.spyOn(browserStorage, 'getCookieStorage').mockReturnValue(fakeStorage);
+      browserStorage.getHttpCache();
+      expect(storageBuilder).toHaveBeenCalledWith(fakeStorage, 'okta-cache-storage');
+      expect(browserStorage.getCookieStorage).toHaveBeenCalledWith({
+        secure: false
+      });
+    });
+    it('Uses secure cookie storage if localStorage and sessionStorage are not available on HTTPS', () => {
+      delete window.localStorage;
+      delete window.sessionStorage;
+      delete window.location;
+      window.location = {
+        protocol: 'https:'
+      }
+      const fakeStorage = { fakeStorage: true };
+      jest.spyOn(browserStorage, 'getCookieStorage').mockReturnValue(fakeStorage);
+      browserStorage.getHttpCache();
+      expect(storageBuilder).toHaveBeenCalledWith(fakeStorage, 'okta-cache-storage');
+      expect(browserStorage.getCookieStorage).toHaveBeenCalledWith({
+        secure: true
+      });
+    });
+  });
+
+  describe('getCookieStorage', () => {
+    it('Default: sets "secure" to false, sameSite to "lax"', () => {
+      jest.spyOn(browserStorage.storage, 'set').mockReturnValue(null);
+      const storage = browserStorage.getCookieStorage();
+      const key = 'fake-key';
+      const val = { fakeValue: true };
+      storage.setItem(key, val);
+      expect(browserStorage.storage.set).toHaveBeenCalledWith(key, val, '2200-01-01T00:00:00.000Z', {
+        secure: false,
+        sameSite: 'lax'
+      });
+    });
+
+    it('Can pass true for "secure", sets sameSite to "none"', () => {
+      jest.spyOn(browserStorage.storage, 'set').mockReturnValue(null);
+      const storage = browserStorage.getCookieStorage({ secure: true });
+      const key = 'fake-key';
+      const val = { fakeValue: true };
+      storage.setItem(key, val);
+      expect(browserStorage.storage.set).toHaveBeenCalledWith(key, val, '2200-01-01T00:00:00.000Z', {
+        secure: true,
+        sameSite: 'none'
+      });
+    });
+
+    it('getItem: will call storage.get', () => {
+      const retVal = { fakeCookie: true };
+      jest.spyOn(browserStorage.storage, 'get').mockReturnValue(retVal);
+      const storage = browserStorage.getCookieStorage();
+      const key = 'fake-key';
+      expect(storage.getItem(key)).toBe(retVal);
+      expect(browserStorage.storage.get).toHaveBeenCalledWith(key);
+    });
+  });
+
+  describe('getInMemoryStorage', () => {
+    it('can set and retrieve a value from memory', () => {
+      const storage = browserStorage.getInMemoryStorage();
+      const key = 'fake-key';
+      const val = { fakeValue: true };
+      storage.setItem(key, val);
+      expect(storage.getItem(key)).toBe(val);
+    })
+  })
+});

--- a/packages/okta-auth-js/test/spec/session.js
+++ b/packages/okta-auth-js/test/spec/session.js
@@ -5,8 +5,10 @@ var Q = require('q');
 describe('session', function() {
   var sdk;
   var sessionObj;
+  let originalLocation;
 
   beforeEach(function() {
+    originalLocation = window.location;
     sessionObj = {};
     sdk = {
       session: {
@@ -17,7 +19,12 @@ describe('session', function() {
         })
       }
     };
+  });  
+  
+  afterEach(() => {
+    window.location = originalLocation;
   });
+
   describe('sessionExists', function() {
     it('calls sdk.session.get', function() {
       return session.sessionExists(sdk)

--- a/packages/okta-auth-js/test/spec/tokenManager.js
+++ b/packages/okta-auth-js/test/spec/tokenManager.js
@@ -11,6 +11,18 @@ var util = require('@okta/test.support/util');
 var oauthUtil = require('@okta/test.support/oauthUtil');
 var SdkClock = require('../../lib/clock');
 
+// Expected settings with default options
+var cookieSettings = {
+  secure: false,
+  sameSite: 'lax'
+};
+
+// Expected settings when option secure: true
+var secureCookieSettings = {
+  secure: true,
+  sameSite: 'none'
+};
+
 function setupSync(options) {
   options = options || {};
   options.tokenManager = options.tokenManager || {};
@@ -197,9 +209,8 @@ describe('TokenManager', function() {
       expect(setCookieMock).toHaveBeenCalledWith(
         'okta-token-storage',
         JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
-        '2200-01-01T00:00:00.000Z', {
-          sameSite: 'none'
-        }
+        '2200-01-01T00:00:00.000Z',
+        cookieSettings
       );
     });
     it('defaults to cookie-based storage if sessionStorage cannot be written to', function() {
@@ -220,9 +231,8 @@ describe('TokenManager', function() {
       expect(setCookieMock).toHaveBeenCalledWith(
         'okta-token-storage',
         JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
-        '2200-01-01T00:00:00.000Z', {
-          sameSite: 'none'
-        }
+        '2200-01-01T00:00:00.000Z',
+        cookieSettings
       );
     });
   });
@@ -1241,9 +1251,8 @@ describe('TokenManager', function() {
         expect(setCookieMock).toHaveBeenCalledWith(
           'okta-token-storage',
           JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
-          '2200-01-01T00:00:00.000Z', {
-            sameSite: 'none'
-          }
+          '2200-01-01T00:00:00.000Z',
+          cookieSettings
         );
       });
 
@@ -1254,10 +1263,8 @@ describe('TokenManager', function() {
         expect(setCookieMock).toHaveBeenCalledWith(
           'okta-token-storage',
           JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
-          '2200-01-01T00:00:00.000Z', {
-            secure: true,
-            sameSite: 'none'
-          }
+          '2200-01-01T00:00:00.000Z',
+          secureCookieSettings
         );
       });
 
@@ -1294,9 +1301,8 @@ describe('TokenManager', function() {
         expect(setCookieMock).toHaveBeenCalledWith(
           'okta-token-storage',
           JSON.stringify({anotherKey: tokens.standardIdTokenParsed}),
-          '2200-01-01T00:00:00.000Z', {
-            sameSite: 'none'
-          }
+          '2200-01-01T00:00:00.000Z',
+          cookieSettings
         );
       });
     });
@@ -1311,9 +1317,8 @@ describe('TokenManager', function() {
         expect(setCookieMock).toHaveBeenCalledWith(
           'okta-token-storage',
           '{}',
-          '2200-01-01T00:00:00.000Z', {
-            sameSite: 'none'
-          }
+          '2200-01-01T00:00:00.000Z',
+          cookieSettings
         );
       });
     });


### PR DESCRIPTION
Fixes issue with Chrome 80: https://blog.chromium.org/2020/02/samesite-cookie-changes-in-february.html

The main effect is that running within an iFrame is now only supported if the app is being hosted on a HTTPS protocol.

- OAuth redirect and PKCE cookies will default to `SameSite:Lax`, unless running on HTTPS protocol, then cookies will use `SameSite: None; Secure`
- HTTP cache will use `SameSite: Lax` unless running on HTTPS protocol, then cookies will use `SameSite: None; Secure`
- TokenManager (if falling back to using cookie storage) will use `SameSite: Lax` unless the `secure` option is set to true, then it will use `SameSite: None; Secure`

TokenManager is preserving existing opt-in behavior to avoid a breaking change. The scenario is that some customers may have an app running on mixed HTTPS and HTTP and they would like the tokens accessible in both contexts. This behavior is changing in 3.0: secure will be set by default, but there is an option to opt out.

I have tested locally using HTTPS proxy via https://ngrok.com/
