### PR TITLE
Repro for sameSite issue (DO NOT MERGE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.13.1
+
+### Bug Fixes
+
+- [#334](https://github.com/okta/okta-auth-js/pull/334) - Setting 'SameSite=none' for all cookies (Fix for iFrame)
+
 ## 2.13.0
 
 ### Features

--- a/packages/okta-auth-js/lib/browser/browserStorage.js
+++ b/packages/okta-auth-js/lib/browser/browserStorage.js
@@ -70,7 +70,7 @@ storageUtil.getSessionStorage = function() {
 storageUtil.getCookieStorage = function(options) {
   options = options || {};
   var secure = options.secure; // currently opt-in
-  var sameSite = options.sameSite || 'lax';
+  var sameSite = options.sameSite || 'none';
   return {
     getItem: storageUtil.storage.get,
     setItem: function(key, value) {

--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -644,17 +644,17 @@ function getWithRedirect(sdk, oauthOptions, options) {
         urls: urls,
         ignoreSignature: oauthParams.ignoreSignature
       }), null, {
-        sameSite: 'lax'
+        sameSite: 'none'
       });
 
       // Set nonce cookie for servers to validate nonce in id_token
       cookies.set(constants.REDIRECT_NONCE_COOKIE_NAME, oauthParams.nonce, null, {
-        sameSite: 'lax'
+        sameSite: 'none'
       });
 
       // Set state cookie for servers to validate state
       cookies.set(constants.REDIRECT_STATE_COOKIE_NAME, oauthParams.state, null, {
-        sameSite: 'lax'
+        sameSite: 'none'
       });
 
       sdk.token.getWithRedirect._setLocation(requestUrl);

--- a/packages/okta-auth-js/package.json
+++ b/packages/okta-auth-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "lib/server/serverIndex.js",

--- a/packages/okta-auth-js/test/spec/cookies.js
+++ b/packages/okta-auth-js/test/spec/cookies.js
@@ -43,11 +43,11 @@ describe('cookie', function () {
 
     it('proxies JsCookie.set with "sameSite" setting',  function ()  {
       Cookies.set('foo', 'bar', null, {
-        sameSite: 'lax'
+        sameSite: 'none'
       });
       expect(JsCookie.set).toHaveBeenCalledWith('foo', 'bar', {
         path: '/',
-        sameSite: 'lax'
+        sameSite: 'none'
       });
     });
   });

--- a/packages/okta-auth-js/test/spec/oauthUtil.js
+++ b/packages/okta-auth-js/test/spec/oauthUtil.js
@@ -252,7 +252,7 @@ describe('getWellKnown', function() {
         }),
         '2200-01-01T00:00:00.000Z',
         {
-          sameSite: 'lax'
+          sameSite: 'none'
         }
       );
     }

--- a/packages/okta-auth-js/test/spec/token.js
+++ b/packages/okta-auth-js/test/spec/token.js
@@ -1196,7 +1196,7 @@ describe('token.getWithRedirect', function() {
       oauthUtil.mockedNonce,
       null, // expiresAt
       {
-        sameSite: 'lax'
+        sameSite: 'none'
       }
     ];
 
@@ -1205,7 +1205,7 @@ describe('token.getWithRedirect', function() {
       oauthUtil.mockedState,
       null, // expiresAt
       {
-        sameSite: 'lax'
+        sameSite: 'none'
       }
     ];
   });
@@ -1237,7 +1237,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1276,7 +1276,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1311,7 +1311,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1352,7 +1352,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1397,7 +1397,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1435,7 +1435,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1478,7 +1478,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1515,7 +1515,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1557,7 +1557,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1594,7 +1594,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1635,7 +1635,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1678,7 +1678,7 @@ describe('token.getWithRedirect', function() {
             ignoreSignature: false
           }),
 null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1723,7 +1723,7 @@ null, {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1761,7 +1761,7 @@ null, {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1803,7 +1803,7 @@ null, {
           ignoreSignature: false
         }),
         null, {
-          sameSite: 'lax'
+          sameSite: 'none'
         }
       ],
       nonceCookie,
@@ -1843,7 +1843,7 @@ null, {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1879,7 +1879,7 @@ null, {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1915,7 +1915,7 @@ null, {
             ignoreSignature: false
           }),
           null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,
@@ -1951,7 +1951,7 @@ null, {
             ignoreSignature: false
           }),
 null, {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         ],
         nonceCookie,

--- a/packages/okta-auth-js/test/spec/tokenManager.js
+++ b/packages/okta-auth-js/test/spec/tokenManager.js
@@ -198,7 +198,7 @@ describe('TokenManager', function() {
         'okta-token-storage',
         JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
         '2200-01-01T00:00:00.000Z', {
-          sameSite: 'lax'
+          sameSite: 'none'
         }
       );
     });
@@ -221,7 +221,7 @@ describe('TokenManager', function() {
         'okta-token-storage',
         JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
         '2200-01-01T00:00:00.000Z', {
-          sameSite: 'lax'
+          sameSite: 'none'
         }
       );
     });
@@ -1242,7 +1242,7 @@ describe('TokenManager', function() {
           'okta-token-storage',
           JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
           '2200-01-01T00:00:00.000Z', {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         );
       });
@@ -1256,7 +1256,7 @@ describe('TokenManager', function() {
           JSON.stringify({'test-idToken': tokens.standardIdTokenParsed}),
           '2200-01-01T00:00:00.000Z', {
             secure: true,
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         );
       });
@@ -1295,7 +1295,7 @@ describe('TokenManager', function() {
           'okta-token-storage',
           JSON.stringify({anotherKey: tokens.standardIdTokenParsed}),
           '2200-01-01T00:00:00.000Z', {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         );
       });
@@ -1312,7 +1312,7 @@ describe('TokenManager', function() {
           'okta-token-storage',
           '{}',
           '2200-01-01T00:00:00.000Z', {
-            sameSite: 'lax'
+            sameSite: 'none'
           }
         );
       });

--- a/test/e2e/specs/login.js
+++ b/test/e2e/specs/login.js
@@ -23,7 +23,7 @@ describe('E2E login', () => {
         (flow === 'pkce') ? await openPKCE() : await openImplicit();
       });
 
-      it('can login using redirect', async () => {
+      it.only('can login using redirect', async () => {
         await loginRedirect(flow);
         await TestApp.getUserInfo();
         await TestApp.assertUserInfo();

--- a/test/e2e/wdio.conf.js
+++ b/test/e2e/wdio.conf.js
@@ -19,7 +19,10 @@ const CI = process.env.CI;
 const defaultTimeoutInterval = DEBUG ? (24 * 60 * 60 * 1000) : 10000;
 const logLevel = CI ? 'warn' : 'info';
 const chromeOptions = {
-    args: []
+    args: [],
+    localState: {
+        'browser.enabled_labs_experiments': [ 'same-site-by-default-cookies@1', 'cookies-without-same-site-must-be-secure@1' ]
+    }
 };
 
 if (CI) {

--- a/test/e2e/wdio.conf.js
+++ b/test/e2e/wdio.conf.js
@@ -19,7 +19,9 @@ const CI = process.env.CI;
 const defaultTimeoutInterval = DEBUG ? (24 * 60 * 60 * 1000) : 10000;
 const logLevel = CI ? 'warn' : 'info';
 const chromeOptions = {
-    args: [],
+    args: [
+        // '--headless'
+    ],
     localState: {
         'browser.enabled_labs_experiments': [ 'same-site-by-default-cookies@1', 'cookies-without-same-site-must-be-secure@1' ]
     }
@@ -59,7 +61,7 @@ exports.config = {
     // directory is where your package.json resides, so `wdio` will be called from there.
     //
     specs: [
-        './specs/**/*.js'
+        './specs/login.js'
     ],
     // Patterns to exclude.
     exclude: [


### PR DESCRIPTION
- Issue reproduces if you run E2E tests locally

From `./test/e2e` run `yarn start:app` to start the test app. You should be able to see the issue by choosing `login with redirect`

From another terminal in `./test/e2e` run `yarn start:runner`. This will run E2E tests in a chrome browser. You should see the login redirect test fail.

You can run tests in CI mode by setting CI env variable `CI=1 yarn start:runner` or set `--headless` option here: https://github.com/okta/okta-auth-js/pull/341/files#diff-57b4b1ce5c88d034b53ad34ecc4ba4a4R22

With headless option, tests pass!