### PR TITLE
fix: responseType=code: return code, support pkce=false

### DIFF
--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -229,16 +229,18 @@ function handleOAuthResponse(sdk, oauthParams, res, urls) {
 
   var scopes = util.clone(oauthParams.scopes);
   var clientId = oauthParams.clientId || sdk.options.clientId;
+  var pkce = sdk.options.pkce !== false;
 
   return Promise.resolve()
   .then(function() {
     validateResponse(res, oauthParams);
 
+    // PKCE flow
     // We do not support "hybrid" scenarios where the response includes both a code and a token.
     // If the response contains a code it is used immediately to obtain new tokens.
-    if (res['code']) {
+    if (res.code && pkce) {
       responseType = ['token', 'id_token']; // what we expect the code to provide us
-      return exchangeCodeForToken(sdk, oauthParams, res['code'], urls);
+      return exchangeCodeForToken(sdk, oauthParams, res.code, urls);
     }
     return res;
   }).then(function(res) {
@@ -307,7 +309,8 @@ function handleOAuthResponse(sdk, oauthParams, res, urls) {
 
     return {
       tokens: tokenDict,
-      state: res.state
+      state: res.state,
+      code: res.code
     };
   });
 }

--- a/packages/okta-auth-js/test/spec/token.js
+++ b/packages/okta-auth-js/test/spec/token.js
@@ -2089,6 +2089,35 @@ describe('token.parseFromUrl', function() {
     spyOn(pkce, 'getToken').and.returnValue(Promise.resolve(response));
   }
 
+  it('authorization_code: Will return code', function() {
+    return oauthUtil.setupParseUrl({
+      oktaAuthArgs: {
+        pkce: false,
+        responseMode: 'query',
+        responseType: ['code']
+      },
+      searchMock: '?code=fake' +
+      '&state=' + oauthUtil.mockedState,
+      oauthCookie: JSON.stringify({
+        responseType: ['code'],
+        state: oauthUtil.mockedState,
+        nonce: oauthUtil.mockedNonce,
+        scopes: ['openid', 'email'],
+        urls: {
+          issuer: 'https://auth-js-test.okta.com',
+          tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
+          authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+          userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+        }
+      }),
+      expectedResp: {
+        code: 'fake',
+        state: oauthUtil.mockedState,
+        tokens: {}
+      }
+    });
+  });
+
   it('does not change the hash if a url is passed directly', function() {
     return oauthUtil.setupParseUrl({
       parseFromUrlArgs: 'http://example.com#id_token=' + tokens.standardIdToken +
@@ -2169,6 +2198,7 @@ describe('token.parseFromUrl', function() {
         }
       }),
       expectedResp: {
+        code: 'fake',
         state: oauthUtil.mockedState,
         tokens: {
           accessToken: tokens.standardAccessTokenParsed,
@@ -2205,6 +2235,7 @@ describe('token.parseFromUrl', function() {
         }
       }),
       expectedResp: {
+        code: 'fake',
         state: oauthUtil.mockedState,
         tokens: {
           accessToken: tokens.standardAccessTokenParsed,
@@ -2239,6 +2270,7 @@ describe('token.parseFromUrl', function() {
         }
       }),
       expectedResp: {
+        code: 'fake',
         state: oauthUtil.mockedState,
         tokens: {
           idToken: {

--- a/test/support/oauthUtil.js
+++ b/test/support/oauthUtil.js
@@ -117,6 +117,7 @@ function validateResponse(res, expectedResp) {
     expect(actual.accessToken).toEqual(expected.accessToken);
     expect(actual.expiresAt).toEqual(expected.expiresAt);
     expect(actual.tokenType).toEqual(expected.tokenType);
+    expect(actual.code).toEqual(expected.code);
   }
 
   if (Array.isArray(expectedResp)) {


### PR DESCRIPTION
This is a fix for non-SPA applications, using authorization_code flow. Generally these apps will process the code server-side and so will not need to call `parseFromUrl`, but if they do they will receive an error. This fixes the logic so the code will not be exchanged for a token if pkce=false. The code will be returned.