### PR TITLE
fix: assert PKCE only for OIDC flows. Warn for insecure cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.1.1
+
+### Bug Fixes
+
+- [#369](https://github.com/okta/okta-auth-js/pull/369)
+  - Will reject with error if PKCE is enabled but not supported when OIDC flow is initiated. Previously this check was done in the constructor and affected non-OIDC flows
+
+  - Will print a console warning and disable secure cookies if cookies.secure is enabled on an HTTP connection. Previously this would throw in the constructor.
+
 ## 3.1.0
 
 ### Features

--- a/packages/okta-auth-js/lib/browser/browser.js
+++ b/packages/okta-auth-js/lib/browser/browser.js
@@ -44,11 +44,13 @@ function OktaAuthBuilder(args) {
     cookieSettings.sameSite = cookieSettings.secure ? 'none' : 'lax';
   }
   if (cookieSettings.secure && !sdk.features.isHTTPS()) {
-    throw new AuthSdkError(
+    // eslint-disable-next-line no-console
+    console.warn(
       'The current page is not being served with the HTTPS protocol.\n' +
       'For security reasons, we strongly recommend using HTTPS.\n' +
       'If you cannot use HTTPS, set "cookies.secure" option to false.'
     );
+    cookieSettings.secure = false;
   }
 
   this.options = {
@@ -70,17 +72,6 @@ function OktaAuthBuilder(args) {
     onSessionExpired: args.onSessionExpired,
     cookies: cookieSettings
   };
-
-  if (this.options.pkce && !sdk.features.isPKCESupported()) {
-    var errorMessage = 'PKCE requires a modern browser with encryption support running in a secure context.';
-    if (!sdk.features.isHTTPS()) {
-      errorMessage += '\nThe current page is not being served with HTTPS protocol. Try using HTTPS.';
-    }
-    if (!sdk.features.hasTextEncoder()) {
-      errorMessage += '\n"TextEncoder" is not defined. You may need a polyfill/shim for this browser.';
-    }
-    throw new AuthSdkError(errorMessage);
-  }
 
   this.userAgent = builderUtil.getUserAgent(args, SDK_VERSION) || 'okta-auth-js-' + SDK_VERSION;
 

--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -433,6 +433,7 @@ function getToken(sdk, options) {
   if (arguments.length > 2) {
     return Promise.reject(new AuthSdkError('As of version 3.0, "getToken" takes only a single set of options'));
   }
+  
   options = options || {};
 
   return prepareOauthParams(sdk, options)
@@ -601,7 +602,16 @@ function prepareOauthParams(sdk, options) {
 
   // PKCE flow
   if (!sdk.features.isPKCESupported()) {
-    return Promise.reject(new AuthSdkError('This browser doesn\'t support PKCE'));
+    var errorMessage = 'PKCE requires a modern browser with encryption support running in a secure context.';
+    if (!sdk.features.isHTTPS()) {
+      // eslint-disable-next-line max-len
+      errorMessage += '\nThe current page is not being served with HTTPS protocol. PKCE requires secure HTTPS protocol.';
+    }
+    if (!sdk.features.hasTextEncoder()) {
+      // eslint-disable-next-line max-len
+      errorMessage += '\n"TextEncoder" is not defined. To use PKCE, you may need to include a polyfill/shim for this browser.';
+    }
+    return Promise.reject(new AuthSdkError(errorMessage));
   }
 
   // set default code challenge method, if none provided

--- a/packages/okta-auth-js/package.json
+++ b/packages/okta-auth-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "lib/server/serverIndex.js",

--- a/packages/okta-auth-js/test/spec/browser.js
+++ b/packages/okta-auth-js/test/spec/browser.js
@@ -100,13 +100,14 @@ describe('Browser', function() {
         expect(auth.options.cookies.sameSite).toBe('lax');
       });
 
-      it('throws if running on HTTP (not localhost)', () => {
+      it('console warning if running on HTTP (not localhost)', () => {
         window.location.protocol = 'http:';
         window.location.hostname = 'not-localhost';
-        function fn() {
-          auth = new OktaAuth({ issuer: 'http://my-okta-domain' });
-        }
-        expect(fn).toThrowError(
+        jest.spyOn(console, 'warn').mockReturnValue(null);
+        auth = new OktaAuth({ issuer: 'http://my-okta-domain' });
+        
+        // eslint-disable-next-line no-console
+        expect(console.warn).toHaveBeenCalledWith(
           'The current page is not being served with the HTTPS protocol.\n' +
           'For security reasons, we strongly recommend using HTTPS.\n' +
           'If you cannot use HTTPS, set "cookies.secure" option to false.'
@@ -135,42 +136,6 @@ describe('Browser', function() {
       it('can be set to "false" by arg', function() {
         auth = new OktaAuth({ pkce: false, issuer: 'http://my-okta-domain' });
         expect(auth.options.pkce).toBe(false);
-      });
-
-      it('throws if PKCE is not supported (HTTP)', function() {
-        spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(false);
-        global.window.location.protocol = 'http:';
-        function fn() {
-          auth = new OktaAuth({ pkce: true, cookies: { secure: false }, issuer: 'http://my-okta-domain' });
-        }
-        expect(fn).toThrowError(
-          'PKCE requires a modern browser with encryption support running in a secure context.\n' +
-          'The current page is not being served with HTTPS protocol. Try using HTTPS.\n' +
-          '"TextEncoder" is not defined. You may need a polyfill/shim for this browser.'
-        );
-      });
-
-      it('throws if PKCE is not supported (HTTPS, no TextEncoder)', function() {
-        spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(false);
-        expect(global.window.TextEncoder).toBe(undefined);
-        function fn() {
-          auth = new OktaAuth({ pkce: true, issuer: 'http://my-okta-domain' });
-        }
-        expect(fn).toThrowError(
-          'PKCE requires a modern browser with encryption support running in a secure context.\n' +
-          '"TextEncoder" is not defined. You may need a polyfill/shim for this browser.'
-        );
-      });
-
-      it('throws if PKCE is not supported (HTTPS, with TextEncoder)', function() {
-        spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(false);
-        global.window.TextEncoder = {};
-        function fn() {
-          auth = new OktaAuth({ pkce: true, issuer: 'http://my-okta-domain' });
-        }
-        expect(fn).toThrowError(
-          'PKCE requires a modern browser with encryption support running in a secure context.'
-        );
       });
     })
   });

--- a/packages/okta-auth-js/test/spec/features.js
+++ b/packages/okta-auth-js/test/spec/features.js
@@ -105,60 +105,69 @@ describe('features', function() {
       expect(OktaAuth.features.isPKCESupported()).toBe(false);
     });
 
-    it('throw an error during construction if pkce is true and PKCE is not supported', function () {
+    it('rejects with an error when calling getToken if pkce is true and PKCE is not supported', function () {
       var err;
       spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(false);
       spyOn(OktaAuth.features, 'isHTTPS').and.returnValue(true);
-      try {
-        new OktaAuth({
-          issuer: 'https://dev-12345.oktapreview.com',
-          pkce: true,
+      var auth = new OktaAuth({
+        issuer: 'https://dev-12345.oktapreview.com',
+        pkce: true,
+      });
+
+      return auth.token.getWithoutPrompt()
+        .catch (e => {
+          err = e;
+        })
+        .then(() => {
+          expect(err.name).toEqual('AuthSdkError');
+          expect(err.errorSummary).toEqual('PKCE requires a modern browser with encryption support running in a secure context.');
         });
-      } catch (e) {
-        err = e;
-      }
-      expect(err.name).toEqual('AuthSdkError');
-      expect(err.errorSummary).toEqual('PKCE requires a modern browser with encryption support running in a secure context.');
     });
 
 
-    it('HTTPS: throw a more specific error', function () {
+    it('HTTPS: rejects with a more specific error', function () {
       var err;
       spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(false);
       spyOn(OktaAuth.features, 'isHTTPS').and.returnValue(false);
-      try {
-        new OktaAuth({
-          issuer: 'https://dev-12345.oktapreview.com',
-          pkce: true,
+      var auth = new OktaAuth({
+        issuer: 'https://dev-12345.oktapreview.com',
+        pkce: true,
+      });
+      
+      return auth.token.getWithoutPrompt()
+        .catch (e => {
+          err = e;
+        })
+        .then(() => {
+          expect(err.name).toEqual('AuthSdkError');
+          expect(err.errorSummary).toEqual(
+            'PKCE requires a modern browser with encryption support running in a secure context.\n' +
+            'The current page is not being served with HTTPS protocol. PKCE requires secure HTTPS protocol.'
+          );
         });
-      } catch (e) {
-        err = e;
-      }
-      expect(err.name).toEqual('AuthSdkError');
-      expect(err.errorSummary).toEqual(
-        'PKCE requires a modern browser with encryption support running in a secure context.\n' +
-        'The current page is not being served with HTTPS protocol. Try using HTTPS.'
-      );
     });
 
-    it('TextEncoder: throw a more specific error', function () {
+    it('TextEncoder: rejects with a more specific error', function () {
       var err;
       spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(false);
       spyOn(OktaAuth.features, 'isHTTPS').and.returnValue(true);
       window.TextEncoder = undefined;
-      try {
-        new OktaAuth({
-          issuer: 'https://dev-12345.oktapreview.com',
-          pkce: true,
+
+      var auth = new OktaAuth({
+        issuer: 'https://dev-12345.oktapreview.com',
+        pkce: true,
+      });
+      return auth.token.getWithoutPrompt()
+        .catch (e => {
+          err = e;
+        })
+        .then(() => {
+          expect(err.name).toEqual('AuthSdkError');
+          expect(err.errorSummary).toEqual(
+            'PKCE requires a modern browser with encryption support running in a secure context.\n' +
+            '"TextEncoder" is not defined. To use PKCE, you may need to include a polyfill/shim for this browser.'
+          );
         });
-      } catch (e) {
-        err = e;
-      }
-      expect(err.name).toEqual('AuthSdkError');
-      expect(err.errorSummary).toEqual(
-        'PKCE requires a modern browser with encryption support running in a secure context.\n' +
-        '"TextEncoder" is not defined. You may need a polyfill/shim for this browser.'
-      );
     });
 
     it('TextEncoder & HTTPS: throw a more specific error', function () {
@@ -166,20 +175,23 @@ describe('features', function() {
       spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(false);
       spyOn(OktaAuth.features, 'isHTTPS').and.returnValue(false);
       window.TextEncoder = undefined;
-      try {
-        new OktaAuth({
-          issuer: 'https://dev-12345.oktapreview.com',
-          pkce: true,
+
+      var auth = new OktaAuth({
+        issuer: 'https://dev-12345.oktapreview.com',
+        pkce: true,
+      });
+      return auth.token.getWithoutPrompt()
+        .catch (e => {
+          err = e;
+        })
+        .then(() => {
+          expect(err.name).toEqual('AuthSdkError');
+          expect(err.errorSummary).toEqual(
+            'PKCE requires a modern browser with encryption support running in a secure context.\n' +
+            'The current page is not being served with HTTPS protocol. PKCE requires secure HTTPS protocol.\n' +
+            '"TextEncoder" is not defined. To use PKCE, you may need to include a polyfill/shim for this browser.'
+          );
         });
-      } catch (e) {
-        err = e;
-      }
-      expect(err.name).toEqual('AuthSdkError');
-      expect(err.errorSummary).toEqual(
-        'PKCE requires a modern browser with encryption support running in a secure context.\n' +
-        'The current page is not being served with HTTPS protocol. Try using HTTPS.\n' +
-        '"TextEncoder" is not defined. You may need a polyfill/shim for this browser.'
-      );
     });
 
   });

--- a/packages/okta-auth-js/test/spec/pkce.js
+++ b/packages/okta-auth-js/test/spec/pkce.js
@@ -27,7 +27,11 @@ describe('pkce', function() {
       })
       .catch(function (e) {
         expect(e.name).toEqual('AuthSdkError');
-        expect(e.errorSummary).toEqual('This browser doesn\'t support PKCE');
+        expect(e.errorSummary).toEqual(
+          'PKCE requires a modern browser with encryption support running in a secure context.\n' +
+          'The current page is not being served with HTTPS protocol. PKCE requires secure HTTPS protocol.\n' +
+          '"TextEncoder" is not defined. To use PKCE, you may need to include a polyfill/shim for this browser.'
+        );
       });
     });
     

--- a/yarn.lock
+++ b/yarn.lock
@@ -1560,6 +1560,13 @@ after@0.8.2:
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
   integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
 
+agent-base@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
+  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
+  dependencies:
+    es6-promisify "^5.0.0"
+
 aggregate-error@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"


### PR DESCRIPTION
  - Will reject with error if PKCE is enabled but not supported when OIDC flow is initiated. Previously this check was done in the constructor and affected non-OIDC flows

  - Will print a console warning and disable secure cookies if cookies.secure is enabled on an HTTP connection. Previously this would throw in the constructor.

Related issues:
OKTA-291890
OKTA-291889