### PR TITLE
fix: user agent

### DIFF
--- a/packages/okta-auth-js/lib/browser/browser.js
+++ b/packages/okta-auth-js/lib/browser/browser.js
@@ -73,7 +73,7 @@ function OktaAuthBuilder(args) {
     cookies: cookieSettings
   };
 
-  this.userAgent = builderUtil.getUserAgent(args, SDK_VERSION) || 'okta-auth-js-' + SDK_VERSION;
+  this.userAgent = builderUtil.getUserAgent(args, `okta-auth-js/${SDK_VERSION}`);
 
   // Digital clocks will drift over time, so the server
   // can misalign with the time reported by the browser.

--- a/packages/okta-auth-js/lib/builderUtil.js
+++ b/packages/okta-auth-js/lib/builderUtil.js
@@ -100,22 +100,18 @@ function buildOktaAuth(OktaAuthBuilder) {
   };
 }
 
-function getUserAgent(args, sdkVersion) {
-  var userAgent = args.userAgent;
-
-  if (!userAgent) {
-    return '';
-  }
+function getUserAgent(args, sdkValue) {
+  var userAgent = args.userAgent || {};
 
   if (userAgent.value) {
     return userAgent.value;
   }
 
   if (userAgent.template) {
-    return userAgent.template.replace('$OKTA_AUTH_JS', `okta-auth-js/${sdkVersion}`);
+    return userAgent.template.replace('$OKTA_AUTH_JS', sdkValue);
   }
 
-  return '';
+  return sdkValue;
 }
 
 module.exports = {

--- a/packages/okta-auth-js/lib/server/server.js
+++ b/packages/okta-auth-js/lib/server/server.js
@@ -29,7 +29,7 @@ function OktaAuthBuilder(args) {
     headers: args.headers
   };
 
-  this.userAgent = builderUtil.getUserAgent(args, SDK_VERSION) || 'okta-auth-js-server' + SDK_VERSION;
+  this.userAgent = builderUtil.getUserAgent(args, `okta-auth-js-server/${SDK_VERSION}`);
 
   sdk.tx = {
     status: util.bind(tx.transactionStatus, null, sdk),

--- a/packages/okta-auth-js/test/spec/builderUtil.js
+++ b/packages/okta-auth-js/test/spec/builderUtil.js
@@ -1,11 +1,9 @@
 const builderUtil  = require('../../lib/builderUtil');
 
-const SDK_VERSION = '0.0.0';
-
 describe('builderUtil', () => {
 
   describe('getUserAgent', () => {
-    it('should return userAgent if "userAgent" is provided in args', () => {
+    it('should return userAgent if "userAgent.value" is provided in args', () => {
       const args = { 
         userAgent: {
           value: 'fake userAgent'
@@ -14,19 +12,41 @@ describe('builderUtil', () => {
       const userAgent = builderUtil.getUserAgent(args);
       expect(userAgent).toEqual('fake userAgent');
     });
-    it('should replace "$OKTA_AUTH_JS" with current authJs version if only with userAgentTemplate in args', () => {
+    it('should replace "$OKTA_AUTH_JS" with current authJs user agent value if only with userAgentTemplate in args', () => {
       const args = { 
         userAgent: {
           template: 'fake userAgent $OKTA_AUTH_JS' 
         } 
       };
-      const userAgent = builderUtil.getUserAgent(args, SDK_VERSION);
+      const sdkUserAgentValue = 'okta-auth-js/0.0.0';
+      const userAgent = builderUtil.getUserAgent(args, sdkUserAgentValue);
       expect(userAgent).toEqual(`fake userAgent okta-auth-js/0.0.0`);
     });
-    it('should return undefined if neither with userAgent nor userAgentTemplate in args', () => {
+    it('should return undefined if no userAgent object is in args', () => {
       const args = {};
       const userAgent = builderUtil.getUserAgent(args);
-      expect(userAgent).toEqual('');
+      expect(userAgent).toEqual(undefined);
+    });
+    it('should return undefined if neither with userAgent.value nor userAgent.template in args', () => {
+      const args = {
+        userAgent: {}
+      };
+      const userAgent = builderUtil.getUserAgent(args);
+      expect(userAgent).toEqual(undefined);
+    });
+    it('should return sdk defined user agent if no userAgent object is in args', () => {
+      const args = {};
+      const sdkUserAgentValue = 'okta-auth-js-fake/0.0.0';
+      const userAgent = builderUtil.getUserAgent(args, sdkUserAgentValue);
+      expect(userAgent).toEqual('okta-auth-js-fake/0.0.0');
+    });
+    it('should return sdk defined user agent if neither with userAgent.value nor userAgent.template in args', () => {
+      const args = {
+        userAgent: {}
+      };
+      const sdkUserAgentValue = 'okta-auth-js-fake/0.0.0';
+      const userAgent = builderUtil.getUserAgent(args, sdkUserAgentValue);
+      expect(userAgent).toEqual('okta-auth-js-fake/0.0.0');
     });
   });
 

--- a/packages/okta-auth-js/test/spec/fingerprint.js
+++ b/packages/okta-auth-js/test/spec/fingerprint.js
@@ -164,7 +164,7 @@ describe('fingerprint', function() {
             headers: {
               'Accept': 'application/json',
               'Content-Type': 'application/json',
-              'X-Okta-User-Agent-Extended': 'okta-auth-js-' + packageJson.version,
+              'X-Okta-User-Agent-Extended': 'okta-auth-js/' + packageJson.version,
               'X-Device-Fingerprint': 'ABCD'
             }
           },
@@ -194,7 +194,7 @@ describe('fingerprint', function() {
             headers: {
               'Accept': 'application/json',
               'Content-Type': 'application/json',
-              'X-Okta-User-Agent-Extended': 'okta-auth-js-' + packageJson.version
+              'X-Okta-User-Agent-Extended': 'okta-auth-js/' + packageJson.version
             }
           },
           response: 'success'

--- a/packages/okta-auth-js/test/spec/general.js
+++ b/packages/okta-auth-js/test/spec/general.js
@@ -144,7 +144,7 @@ describe('General Methods', function () {
           headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'X-Okta-User-Agent-Extended': 'custom okta-auth-js-' + packageJson.version
+            'X-Okta-User-Agent-Extended': 'custom okta-auth-js/' + packageJson.version
           }
         },
         response: 'session'
@@ -172,7 +172,7 @@ describe('General Methods', function () {
             'X-Custom-Header': 'custom',
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'X-Okta-User-Agent-Extended': 'okta-auth-js-' + packageJson.version
+            'X-Okta-User-Agent-Extended': 'okta-auth-js/' + packageJson.version
           }
         },
         response: 'session'

--- a/packages/okta-auth-js/test/spec/pkce.js
+++ b/packages/okta-auth-js/test/spec/pkce.js
@@ -123,7 +123,7 @@ describe('pkce', function() {
               headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/x-www-form-urlencoded',
-                'X-Okta-User-Agent-Extended': 'okta-auth-js-' + packageJson.version
+                'X-Okta-User-Agent-Extended': 'okta-auth-js/' + packageJson.version
               }
             },
             response: 'pkce-token-success',

--- a/packages/okta-auth-js/test/spec/token.js
+++ b/packages/okta-auth-js/test/spec/token.js
@@ -2820,7 +2820,7 @@ describe('token.getUserInfo', function() {
           headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'X-Okta-User-Agent-Extended': 'okta-auth-js-' + packageJson.version,
+            'X-Okta-User-Agent-Extended': 'okta-auth-js/' + packageJson.version,
             'Authorization': 'Bearer ' + tokens.standardAccessToken
           }
         },
@@ -2845,7 +2845,7 @@ describe('token.getUserInfo', function() {
           headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'X-Okta-User-Agent-Extended': 'okta-auth-js-' + packageJson.version,
+            'X-Okta-User-Agent-Extended': 'okta-auth-js/' + packageJson.version,
             'Authorization': 'Bearer ' + tokens.standardAccessToken
           }
         },
@@ -2873,7 +2873,7 @@ describe('token.getUserInfo', function() {
           headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'X-Okta-User-Agent-Extended': 'okta-auth-js-' + packageJson.version,
+            'X-Okta-User-Agent-Extended': 'okta-auth-js/' + packageJson.version,
             'Authorization': 'Bearer ' + tokens.authServerAccessToken
           }
         },
@@ -2956,7 +2956,7 @@ describe('token.getUserInfo', function() {
         headers: {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
-          'X-Okta-User-Agent-Extended': 'okta-auth-js-' + packageJson.version,
+          'X-Okta-User-Agent-Extended': 'okta-auth-js/' + packageJson.version,
           'Authorization': 'Bearer ' + tokens.standardAccessToken
         }
       },
@@ -2983,7 +2983,7 @@ describe('token.getUserInfo', function() {
         headers: {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
-          'X-Okta-User-Agent-Extended': 'okta-auth-js-' + packageJson.version,
+          'X-Okta-User-Agent-Extended': 'okta-auth-js/' + packageJson.version,
           'Authorization': 'Bearer ' + tokens.standardAccessToken
         }
       },


### PR DESCRIPTION
corrects user agent. It will be:

`okta-auth-js/version` for browser code
`okta-auth-js-server/version` for server code

custom template will include the default user agent (browser or server)