### PR TITLE
compat fix: PKCE loadMeta will fallback to local storage

### DIFF
--- a/packages/okta-auth-js/lib/browser/browserStorage.js
+++ b/packages/okta-auth-js/lib/browser/browserStorage.js
@@ -40,7 +40,8 @@ storageUtil.browserHasSessionStorage = function() {
 };
 
 storageUtil.getPKCEStorage = function(options) {
-  if (storageUtil.browserHasSessionStorage()) {
+  options = options || {};
+  if (!options.preferLocalStorage && storageUtil.browserHasSessionStorage()) {
     return storageBuilder(storageUtil.getSessionStorage(), constants.PKCE_STORAGE_NAME);
   } else if (storageUtil.browserHasLocalStorage()) {
     return storageBuilder(storageUtil.getLocalStorage(), constants.PKCE_STORAGE_NAME);

--- a/packages/okta-auth-js/lib/pkce.js
+++ b/packages/okta-auth-js/lib/pkce.js
@@ -57,7 +57,7 @@ function loadMeta(sdk) {
   // Verify the Meta
   if (!obj.codeVerifier) {
     // If meta is not valid, try reading from localStorage.
-    // This is for compatibility with older versions of the signin widget.
+    // This is for compatibility with older versions of the signin widget. OKTA-304806
     storage = getStorage(sdk, { preferLocalStorage: true });
     obj = storage.getStorage();
     if (!obj.codeVerifier) {

--- a/packages/okta-auth-js/test/spec/browserStorage.js
+++ b/packages/okta-auth-js/test/spec/browserStorage.js
@@ -134,6 +134,13 @@ describe('browserStorage', () => {
       expect(browserStorage.getCookieStorage).toHaveBeenCalledWith(opts);
     });
 
+    it('Uses localStorage instead of sessionStorage if options.preferLocalStorage is set', () => {
+      browserStorage.getPKCEStorage({ preferLocalStorage: true });
+      expect(storageBuilder).toHaveBeenCalledTimes(1);
+      // .toHaveBeenCalledWith doesn't do a strict comparison, so an empty localStorage reads the same as an empty sessionStorage
+      expect(storageBuilder.mock.calls[0][0]).toBe(global.window.localStorage);
+      expect(storageBuilder.mock.calls[0][1]).toBe('okta-pkce-storage');
+    });
   });
 
   describe('getHttpCache', () => {

--- a/packages/okta-auth-js/test/spec/pkce.js
+++ b/packages/okta-auth-js/test/spec/pkce.js
@@ -12,6 +12,52 @@ var token = require('../../lib/token');
 var oauthUtil = require('../../lib/oauthUtil');
 
 describe('pkce', function() {
+  afterEach(() => {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+  describe('clearMeta', () => {
+    it('clears meta from sessionStorage', () => {
+      const meta = { codeVerifier: 'fake', redirectUri: 'http://localhost/fake' };
+      window.sessionStorage.setItem('okta-pkce-storage', JSON.stringify(meta));
+      const sdk = new OktaAuth({ issuer: 'https://foo.com' });
+      pkce.clearMeta(sdk);
+      const res = JSON.parse(window.sessionStorage.getItem('okta-pkce-storage'));
+      expect(res).toEqual({});
+    });
+  });
+  describe('saveMeta', () => {
+    it('saves meta in sessionStorage', () => {
+      const meta = { codeVerifier: 'fake', redirectUri: 'http://localhost/fake' };
+      const sdk = new OktaAuth({ issuer: 'https://foo.com' });
+      pkce.saveMeta(sdk, meta);
+      const res = JSON.parse(window.sessionStorage.getItem('okta-pkce-storage'));
+      expect(res).toEqual(meta);
+    });
+  });
+  describe('loadMeta', () => {
+    it('can return the meta from sessionStorage', () => {
+      const meta = { codeVerifier: 'fake' };
+      window.sessionStorage.setItem('okta-pkce-storage', JSON.stringify(meta));
+      const sdk = new OktaAuth({ issuer: 'https://foo.com' });
+      const res = pkce.loadMeta(sdk);
+      expect(res.codeVerifier).toBe(meta.codeVerifier);
+    });
+    it('can return the meta from localStorage', () => {
+      const meta = { codeVerifier: 'fake' };
+      window.localStorage.setItem('okta-pkce-storage', JSON.stringify(meta));
+      const sdk = new OktaAuth({ issuer: 'https://foo.com' });
+      const res = pkce.loadMeta(sdk);
+      expect(res.codeVerifier).toBe(meta.codeVerifier);
+    });
+    it('throws an error if meta cannot be found', () => {
+      const sdk = new OktaAuth({ issuer: 'https://foo.com' });
+      const fn = () => {
+        pkce.loadMeta(sdk);
+      };
+      expect(fn).toThrowError('Could not load PKCE codeVerifier from storage');
+    });
+  });
 
   describe('prepare oauth params', function() {
 


### PR DESCRIPTION
This fixes an error involving PKCE flow and the signin widget. In version 3.1.2 of `okta-auth-js` the PKCE meta storage was changed to use sessionStorage. However, current and older versions of the signin widget which are bundled with an older version of `okta-auth-js` will store the PKCE meta in local storage. This will cause an error: **The redirectUri passed to /authorize must also be passed to /token** on callback. The underlying cause is that PKCE meta was not found in storage and an empty codeVerifier was passed to the `/token` endpoint.

This PR adds logic to read from local storage if the meta cannot be found in session storage. This will provide compatibility for older versions of `okta-auth-js` including the bundled version within the signin widget.

Additionally, this PR adds logic so that if the meta cannot be found in either session or local storage, an error will be thrown. This will avoid making a call to `/token` with an empty codeVerifier which causes the misleading error about "redirectUri"