### PR TITLE
Support retrieving an accessToken only, with default scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## PENDING
+
+### Bug Fixes
+
+-[#400](https://github.com/okta/okta-auth-js/pull/400) Allows an accessToken to be retrieved without an idToken. Also allows retrieving "default" scopes as defined by the custom authorization server.
+
 ## 3.1.3
 
 ### Bug Fixes

--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -238,7 +238,12 @@ function handleOAuthResponse(sdk, oauthParams, res, urls) {
     // We do not support "hybrid" scenarios where the response includes both a code and a token.
     // If the response contains a code it is used immediately to obtain new tokens.
     if (res.code && pkce) {
-      responseType = ['token', 'id_token']; // what we expect the code to provide us
+      // responseType is not sent to the token endpoint.
+      // We populate this array to validate the response below
+      responseType = ['token']; // an accessToken will always be returned
+      if (scopes.indexOf('openid') !== -1) {
+        responseType.push('id_token'); // an idToken will be returned if "openid" is in the scopes
+      }
       return exchangeCodeForToken(sdk, oauthParams, res.code, urls);
     }
     return res;

--- a/test/app/src/config.js
+++ b/test/app/src/config.js
@@ -15,6 +15,8 @@ function getDefaultConfig() {
     issuer: ISSUER,
     clientId: CLIENT_ID,
     responseType: ['token', 'id_token'],
+    scopes: ['openid', 'email'],
+    _defaultScopes: false,
     pkce: true,
     cookies: {
       secure: true
@@ -29,6 +31,7 @@ function getConfigFromUrl() {
   const postLogoutRedirectUri = url.searchParams.get('postLogoutRedirectUri') || POST_LOGOUT_REDIRECT_URI;
   const clientId = url.searchParams.get('clientId');
   const pkce = url.searchParams.get('pkce') !== 'false'; // On by default
+  const _defaultScopes = url.searchParams.get('_defaultScopes') === 'true';
   const scopes = (url.searchParams.get('scopes') || 'openid,email').split(',');
   const responseType = (url.searchParams.get('responseType') || 'id_token,token').split(',');
   const responseMode = url.searchParams.get('responseMode') || undefined;
@@ -42,6 +45,7 @@ function getConfigFromUrl() {
     issuer,
     clientId,
     pkce,
+    _defaultScopes,
     scopes,
     responseType,
     responseMode,

--- a/test/app/src/form.js
+++ b/test/app/src/form.js
@@ -6,6 +6,10 @@ const Form = `
   <label for="issuer">Issuer</label><input id="issuer" name="issuer" type="text" /><br/>
   <label for="clientId">Client ID</label><input id="clientId" name="clientId" type="text" /><br/>
   <label for="responseType">Response Type (comma separated)</label><input id="responseType" name="responseType" type="text" /><br/>
+  <label for="_defaultScopes">Use DEFAULT scopes (defined by authorization server)</label><br/>
+  <input id="default-scopes-yes" name="_defaultScopes" type="radio" value="true"/>YES<br/>
+  <input id="default-scopes-no" name="_defaultScopes" type="radio" value="false"/>NO (list scopes below)<br/>
+  <label for="scopes">Scopes (comma separated)</label><input id="scopes" name="scopes" type="text" /><br/>
   <label for="redirectUri">Redirect URI</label><input id="redirectUri" name="redirectUri" type="text" /><br/>
   <label for="postLogoutRedirectUri">Post Logout Redirect URI</label><input id="postLogoutRedirectUri" name="postLogoutRedirectUri" type="text" /><br/>
   <label for="responseMode">Response Mode</label>
@@ -44,6 +48,7 @@ function updateForm(config) {
   document.getElementById('issuer').value = config.issuer;
   document.getElementById('redirectUri').value = config.redirectUri;
   document.getElementById('responseType').value = config.responseType.join(',');
+  document.getElementById('scopes').value = config.scopes.join(',');
   document.getElementById('postLogoutRedirectUri').value = config.postLogoutRedirectUri;
   document.getElementById('clientId').value = config.clientId;
   document.querySelector(`#responseMode [value="${config.responseMode || ''}"]`).selected = true;
@@ -60,6 +65,14 @@ function updateForm(config) {
     document.getElementById('secureCookies-on').checked = true;
   } else {
     document.getElementById('secureCookies-off').checked = true;
+  }
+
+  if (config._defaultScopes) {
+    document.getElementById('default-scopes-yes').checked = true;
+    document.getElementById('scopes').disabled = true;
+  } else {
+    document.getElementById('default-scopes-no').checked = true;
+    document.getElementById('scopes').disabled = false;
   }
 }
 

--- a/test/app/src/testApp.js
+++ b/test/app/src/testApp.js
@@ -101,7 +101,10 @@ Object.assign(TestApp.prototype, {
   getSDKInstance() {
     return Promise.resolve()
       .then(() => {
-        this.oktaAuth = this.oktaAuth || new OktaAuth(Object.assign({}, this.config)); // can throw
+        // can throw
+        this.oktaAuth = this.oktaAuth || new OktaAuth(Object.assign({}, this.config, {
+          scopes: this.config._defaultScopes ? [] : this.config.scopes
+        }));
         this.oktaAuth.tokenManager.on('error', this._onTokenError.bind(this));
       });
   },
@@ -189,7 +192,7 @@ Object.assign(TestApp.prototype, {
     saveConfigToStorage(this.config);
     options = Object.assign({}, {
       responseType: this.config.responseType,
-      scopes: this.config.scopes,
+      scopes: this.config._defaultScopes ? [] : this.config.scopes,
     }, options);
     return this.oktaAuth.token.getWithRedirect(options)
       .catch(e => {
@@ -200,7 +203,7 @@ Object.assign(TestApp.prototype, {
   loginPopup: async function(options) {
     options = Object.assign({}, {
       responseType: this.config.responseType,
-      scopes: this.config.scopes,
+      scopes: this.config._defaultScopes ? [] : this.config.scopes,
     }, options);
     return this.oktaAuth.token.getWithPopup(options)
     .then(res => {
@@ -211,7 +214,7 @@ Object.assign(TestApp.prototype, {
   getToken: async function(options) {
     options = Object.assign({}, {
       responseType: this.config.responseType,
-      scopes: this.config.scopes,
+      scopes: this.config._defaultScopes ? [] : this.config.scopes,
     }, options);
     return this.oktaAuth.token.getWithoutPrompt(options)
     .then(res => {


### PR DESCRIPTION
See related GH issue: https://github.com/okta/okta-auth-js/issues/396

Currently the SDK assumes that PKCE flow will always be used for obtaining both an idToken and an accessToken. This PR unbreaks that assumption and allows an accessToken to be retrieved without an idToken. This also allows retrieving "default" scopes as defined by the custom authorization server