### PR TITLE
Fix resend example for MFA_ENROLL_ACTIVATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1258,7 +1258,7 @@ The user must activate the factor to complete enrollment.
 Send another OTP if user doesn’t receive the original activation SMS OTP.
 
 ```javascript
-transaction.resend();
+transaction.resend('sms');
 ```
 
 ##### `activate(options)`


### PR DESCRIPTION
This was never updated, as described in #90.
Not providing the name argument results in an exception, from this line:
https://github.com/okta/okta-auth-js/blob/%40okta/okta-auth-js%403.1.0/packages/okta-auth-js/lib/tx.js#L207