### PR TITLE
feat: add isAuthCallback util and setup validations based on it - OKTA-285863

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 -[#408](https://github.com/okta/okta-auth-js/pull/408) Provides a polyfill for IE 11+
+-[#410](https://github.com/okta/okta-auth-js/pull/410) Add `isOAuthCallback` util function to prevent app from starting new Oauth flow while already in OAuth callback state.
 
 ## 3.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 -[#408](https://github.com/okta/okta-auth-js/pull/408) Provides a polyfill for IE 11+
--[#410](https://github.com/okta/okta-auth-js/pull/410) Add `isOAuthCallback` util function to prevent app from starting new Oauth flow while already in OAuth callback state.
+-[#410](https://github.com/okta/okta-auth-js/pull/410) Add `token.isLoginRedirect` function to prevent app from starting new Oauth flow while already in OAuth callback state.
 
 ## 3.1.4
 

--- a/README.md
+++ b/README.md
@@ -1620,7 +1620,7 @@ authClient.token.getWithoutPrompt({
   authClient.tokenManager.add('idToken', tokens.idToken);
 })
 .catch(function(err) {
-  // handle OAuthError
+  // handle OAuthError or AuthSdkError
 });
 ```
 
@@ -1644,7 +1644,7 @@ authClient.token.getWithoutPrompt({
   authClient.tokenManager.add('idToken', tokens.idToken);
 })
 .catch(function(err) {
-  // handle OAuthError
+  // handle OAuthError or AuthSdkError (AuthSdkError will be thrown if app is in OAuthCallback state)
 });
 ```
 
@@ -1663,7 +1663,7 @@ authClient.token.getWithPopup(options)
   authClient.tokenManager.add('idToken', tokens.idToken);
 })
 .catch(function(err) {
-  // handle OAuthError
+  // handle OAuthError or AuthSdkError (AuthSdkError will be thrown if app is in OAuthCallback state)
 });
 ```
 
@@ -1677,6 +1677,9 @@ Create token using a redirect. After a successful authentication, the browser wi
 authClient.token.getWithRedirect({
   responseType: ['token', 'id_token'],
   state: 'any-string-you-want-to-pass-to-callback' // will be URI encoded
+})
+.catch(function(err) {
+  // handle AuthSdkError (AuthSdkError will be thrown if app is in OAuthCallback state)
 });
 ```
 
@@ -1794,17 +1797,26 @@ By default, if no parameters are passed, both the access token and ID token obje
 authClient.token.getUserInfo()
 .then(function(user) {
   // user has details about the user
+})
+.catch(function(err) {
+  // handle OAuthError or AuthSdkError (AuthSdkError will be thrown if app is in OAuthCallback state)
 });
 ```
 
 ```javascript
-// In this example, the access token is stored under the key 'myAccessToken'
-const accessTokenObject = authClient.tokenManager.get('myAccessToken');
-// In this example, the ID token is stored under the key "myIdToken"
-const idTokenObject = authClient.tokenManager.get('myIdToken');
-authClient.token.getUserInfo(accessTokenObject, idTokenObject)
+// In this example, the access token is stored under the key 'myAccessToken', the ID token is stored under the key "myIdToken"
+Promise.all([
+  authClient.tokenManager.get('myAccessToken'),
+  authClient.tokenManager.get('myAccessToken')
+])
+.then(([accessTokenObject, idTokenObject]) => {
+  return authClient.token.getUserInfo(accessTokenObject, idTokenObject);
+})
 .then(function(user) {
   // user has details about the user
+})
+.catch((err) => {
+  // handle AuthSdkError (AuthSdkError will be thrown if app is in OAuthCallback state)
 });
 ```
 
@@ -1864,7 +1876,7 @@ authClient.tokenManager.get('idToken')
   }
 })
 .catch(function(err) {
-  // OAuth Error
+  // handle OAuthError or AuthSdkError (AuthSdkError will be thrown if app is in OAuthCallback state)
   console.error(err);
 });
 ```

--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ var config = {
   * [token.renew](#tokenrenewtokentorenew)
   * [token.getUserInfo](#tokengetuserinfoaccesstokenobject-idtokenobject)
   * [token.verify](#tokenverifyidtokenobject)
+  * [token.isLoginRedirect](#tokenisloginredirect)
 * [tokenManager](#tokenmanager)
   * [tokenManager.add](#tokenmanageraddkey-token)
   * [tokenManager.get](#tokenmanagergetkey)
@@ -443,8 +444,6 @@ var config = {
   * [tokenManager.renew](#tokenmanagerrenewkey)
   * [tokenManager.on](#tokenmanageronevent-callback-context)
   * [tokenManager.off](#tokenmanageroffevent-callback)
-* [oauthUtil](#oauthutil)
-  * [oauthutil.isOAuthCallback](#oauthutilisoauthcallback)
 
 ------
 
@@ -1845,6 +1844,14 @@ authClient.token.verify(idTokenObject, validationOptions)
 });
 ```
 
+#### `token.isLoginRedirect`
+
+Check `window.location` to verify if the app is in OAuth callback state or not. This function is synchronous and returns `true` or `false`.
+
+```javascript
+authClient.token.isLoginRedirect();
+```
+
 ### `tokenManager`
 
 #### `tokenManager.add(key, token)`
@@ -1969,16 +1976,6 @@ Unsubscribe from `tokenManager` events. If no callback is provided, unsubscribes
 ```javascript 
 authClient.tokenManager.off('renewed');
 authClient.tokenManager.off('renewed', myRenewedCallback);
-```
-
-### `oauthUtil`
-
-#### `oauthUtil.isOAuthCallback`
-
-Check `window.location` to verify if the app is in OAuth callback state or not. This function is synchronous and returns `true` or `false`.
-
-```javascript
-authClient.oauthUtil.isOAuthCallback();
 ```
 
 ## Node JS and React Native Usage

--- a/README.md
+++ b/README.md
@@ -443,6 +443,8 @@ var config = {
   * [tokenManager.renew](#tokenmanagerrenewkey)
   * [tokenManager.on](#tokenmanageronevent-callback-context)
   * [tokenManager.off](#tokenmanageroffevent-callback)
+* [oauthUtil](#oauthutil)
+  * [oauthutil.isOAuthCallback](#oauthutilisoauthcallback)
 
 ------
 
@@ -1967,6 +1969,16 @@ Unsubscribe from `tokenManager` events. If no callback is provided, unsubscribes
 ```javascript 
 authClient.tokenManager.off('renewed');
 authClient.tokenManager.off('renewed', myRenewedCallback);
+```
+
+### `oauthUtil`
+
+#### `oauthUtil.isOAuthCallback`
+
+Check `window.location` to verify if the app is in OAuth callback state or not. This function is synchronous and returns `true` or `false`.
+
+```javascript
+authClient.oauthUtil.isOAuthCallback();
 ```
 
 ## Node JS and React Native Usage

--- a/packages/okta-auth-js/lib/TokenManager.js
+++ b/packages/okta-auth-js/lib/TokenManager.js
@@ -116,7 +116,7 @@ function get(storage, key) {
 
 function getAsync(sdk, tokenMgmtRef, storage, key) {
   return new Promise(function(resolve, reject) {
-    if (tokenMgmtRef.options.autoRenew && oauthUtil.isOAuthCallback(sdk)) {
+    if (tokenMgmtRef.options.autoRenew && oauthUtil.isLoginRedirect(sdk)) {
       return reject(new AuthSdkError(
         'The app should not attempt to call authorize API on callback. ' + 
         'Authorize flow is already in process. Use parseFromUrl() to receive tokens.'

--- a/packages/okta-auth-js/lib/TokenManager.js
+++ b/packages/okta-auth-js/lib/TokenManager.js
@@ -116,9 +116,9 @@ function get(storage, key) {
 
 function getAsync(sdk, tokenMgmtRef, storage, key) {
   return new Promise(function(resolve, reject) {
-    if (sdk.options.autoRenew && oauthUtil.isAuthCallback(sdk)) {
+    if (tokenMgmtRef.options.autoRenew && oauthUtil.isOAuthCallback(sdk)) {
       return reject(new AuthSdkError(
-        'App should not attempt to call authorize API on callback. ' + 
+        'The app should not attempt to call authorize API on callback. ' + 
         'Authorize flow is already in process. Use parseFromUrl() to receive tokens.'
       ));
     }

--- a/packages/okta-auth-js/lib/TokenManager.js
+++ b/packages/okta-auth-js/lib/TokenManager.js
@@ -18,6 +18,7 @@ var storageUtil = require('./browser/browserStorage');
 var constants = require('./constants');
 var storageBuilder = require('./storageBuilder');
 var SdkClock = require('./clock');
+var oauthUtil = require('./oauthUtil');
 
 var DEFAULT_OPTIONS = {
   autoRenew: true,
@@ -114,7 +115,14 @@ function get(storage, key) {
 }
 
 function getAsync(sdk, tokenMgmtRef, storage, key) {
-  return new Promise(function(resolve) {
+  return new Promise(function(resolve, reject) {
+    if (sdk.options.autoRenew && oauthUtil.isAuthCallback(sdk)) {
+      return reject(new AuthSdkError(
+        'App should not attempt to call authorize API on callback. ' + 
+        'Authorize flow is already in process. Use parseFromUrl() to receive tokens.'
+      ));
+    }
+
     var token = get(storage, key);
     if (!token || !hasExpired(tokenMgmtRef, token)) {
       return resolve(token);

--- a/packages/okta-auth-js/lib/browser/browser.js
+++ b/packages/okta-auth-js/lib/browser/browser.js
@@ -175,6 +175,10 @@ function OktaAuthBuilder(args) {
   sdk.emitter = new Emitter();
   sdk.tokenManager = new TokenManager(sdk, args.tokenManager);
   sdk.tokenManager.on('error', this._onTokenManagerError, this);
+
+  sdk.oauthUtil = {
+    isOAuthCallback: util.bind(oauthUtil.isOAuthCallback, null, sdk)
+  };
 }
 
 var proto = OktaAuthBuilder.prototype;

--- a/packages/okta-auth-js/lib/browser/browser.js
+++ b/packages/okta-auth-js/lib/browser/browser.js
@@ -132,7 +132,8 @@ function OktaAuthBuilder(args) {
     revoke: util.bind(token.revokeToken, null, sdk),
     renew: util.bind(token.renewToken, null, sdk),
     getUserInfo: util.bind(token.getUserInfo, null, sdk),
-    verify: util.bind(token.verifyToken, null, sdk)
+    verify: util.bind(token.verifyToken, null, sdk),
+    isLoginRedirect: util.bind(oauthUtil.isLoginRedirect, null, sdk)
   };
   // Wrap all async token API methods using MethodQueue to avoid issues with concurrency
   Object.keys(sdk.token).forEach(key => {
@@ -175,10 +176,6 @@ function OktaAuthBuilder(args) {
   sdk.emitter = new Emitter();
   sdk.tokenManager = new TokenManager(sdk, args.tokenManager);
   sdk.tokenManager.on('error', this._onTokenManagerError, this);
-
-  sdk.oauthUtil = {
-    isOAuthCallback: util.bind(oauthUtil.isOAuthCallback, null, sdk)
-  };
 }
 
 var proto = OktaAuthBuilder.prototype;

--- a/packages/okta-auth-js/lib/oauthUtil.js
+++ b/packages/okta-auth-js/lib/oauthUtil.js
@@ -243,7 +243,7 @@ function hasCodeInUrl(hashOrSearch) {
  * Check if tokens or a code have been passed back into the url, which happens in
  * the social auth IDP redirect flow.
  */
-function isOAuthCallback (sdk) {
+function isLoginRedirect (sdk) {
   var authParams = sdk.options;
   if (authParams.pkce || authParams.responseType === 'code' || authParams.responseMode === 'query') {
     // Look for code
@@ -268,5 +268,5 @@ module.exports = {
   isToken: isToken,
   addListener: addListener,
   removeListener: removeListener,
-  isOAuthCallback: isOAuthCallback
+  isLoginRedirect: isLoginRedirect
 };

--- a/packages/okta-auth-js/lib/oauthUtil.js
+++ b/packages/okta-auth-js/lib/oauthUtil.js
@@ -231,6 +231,30 @@ function urlParamsToObject(hashOrSearch) {
   return obj;
 }
 
+function hasTokensInHash(hash) {
+  return /((id|access)_token=)/i.test(hash);
+}
+
+function hasCodeInUrl(hashOrSearch) {
+  return /(code=)/i.test(hashOrSearch);
+}
+
+/**
+ * Check if tokens or a code have been passed back into the url, which happens in
+ * the social auth IDP redirect flow.
+ */
+function isAuthCallback (sdk) {
+  var authParams = sdk.options;
+  if (authParams.pkce || authParams.responseType === 'code' || authParams.responseMode === 'query') {
+    // Look for code
+    return authParams.responseMode === 'fragment' ?
+      hasCodeInUrl(window.location.hash) :
+      hasCodeInUrl(window.location.search);
+  }
+  // Look for tokens (Implicit OIDC flow)
+  return hasTokensInHash(window.location.hash);
+}
+
 module.exports = {
   generateState: generateState,
   generateNonce: generateNonce,
@@ -243,5 +267,6 @@ module.exports = {
   urlParamsToObject: urlParamsToObject,
   isToken: isToken,
   addListener: addListener,
-  removeListener: removeListener
+  removeListener: removeListener,
+  isAuthCallback: isAuthCallback
 };

--- a/packages/okta-auth-js/lib/oauthUtil.js
+++ b/packages/okta-auth-js/lib/oauthUtil.js
@@ -243,7 +243,7 @@ function hasCodeInUrl(hashOrSearch) {
  * Check if tokens or a code have been passed back into the url, which happens in
  * the social auth IDP redirect flow.
  */
-function isAuthCallback (sdk) {
+function isOAuthCallback (sdk) {
   var authParams = sdk.options;
   if (authParams.pkce || authParams.responseType === 'code' || authParams.responseMode === 'query') {
     // Look for code
@@ -268,5 +268,5 @@ module.exports = {
   isToken: isToken,
   addListener: addListener,
   removeListener: removeListener,
-  isAuthCallback: isAuthCallback
+  isOAuthCallback: isOAuthCallback
 };

--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -437,6 +437,13 @@ function getToken(sdk, options) {
   if (arguments.length > 2) {
     return Promise.reject(new AuthSdkError('As of version 3.0, "getToken" takes only a single set of options'));
   }
+
+  if (oauthUtil.isAuthCallback(sdk)) {
+    return Promise.reject(new AuthSdkError(
+      'The app should not attempt to call getToken on callback. ' +
+      'Authorize flow is already in process. Use parseFromUrl() to receive tokens.'
+    ));
+  }
   
   options = options || {};
 
@@ -854,5 +861,5 @@ module.exports = {
   getUserInfo: getUserInfo,
   verifyToken: verifyToken,
   handleOAuthResponse: handleOAuthResponse,
-  prepareOauthParams: prepareOauthParams
+  _prepareOauthParams: prepareOauthParams
 };

--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -437,13 +437,6 @@ function getToken(sdk, options) {
   if (arguments.length > 2) {
     return Promise.reject(new AuthSdkError('As of version 3.0, "getToken" takes only a single set of options'));
   }
-
-  if (oauthUtil.isAuthCallback(sdk)) {
-    return Promise.reject(new AuthSdkError(
-      'The app should not attempt to call getToken on callback. ' +
-      'Authorize flow is already in process. Use parseFromUrl() to receive tokens.'
-    ));
-  }
   
   options = options || {};
 
@@ -600,6 +593,13 @@ function getWithPopup(sdk, options) {
 }
 
 function prepareOauthParams(sdk, options) {
+  if (oauthUtil.isOAuthCallback(sdk)) {
+    return Promise.reject(new AuthSdkError(
+      'The app should not attempt to call getToken on callback. ' +
+      'Authorize flow is already in process. Use parseFromUrl() to receive tokens.'
+    ));
+  }
+
   // clone and prepare options
   options = util.clone(options) || {};
 
@@ -861,5 +861,5 @@ module.exports = {
   getUserInfo: getUserInfo,
   verifyToken: verifyToken,
   handleOAuthResponse: handleOAuthResponse,
-  _prepareOauthParams: prepareOauthParams
+  prepareOauthParams: prepareOauthParams
 };

--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -593,7 +593,7 @@ function getWithPopup(sdk, options) {
 }
 
 function prepareOauthParams(sdk, options) {
-  if (oauthUtil.isOAuthCallback(sdk)) {
+  if (oauthUtil.isLoginRedirect(sdk)) {
     return Promise.reject(new AuthSdkError(
       'The app should not attempt to call getToken on callback. ' +
       'Authorize flow is already in process. Use parseFromUrl() to receive tokens.'

--- a/packages/okta-auth-js/test/spec/oauthUtil.js
+++ b/packages/okta-auth-js/test/spec/oauthUtil.js
@@ -912,7 +912,7 @@ describe('validateClaims', function () {
   });
 });
 
-describe('isOAuthCallback', function() {
+describe('isLoginRedirect', function() {
   let sdk;
   let originalLocation;
   beforeEach(() => {
@@ -936,7 +936,7 @@ describe('isOAuthCallback', function() {
       window.location = {
         hash: '#id_token=fakeidtoken'
       }
-      const result = oauthUtil.isOAuthCallback(sdk);
+      const result = oauthUtil.isLoginRedirect(sdk);
       expect(result).toBe(true);
     });
 
@@ -945,7 +945,7 @@ describe('isOAuthCallback', function() {
       window.location = {
         hash: '#access_token=fakeaccesstoken'
       }
-      const result = oauthUtil.isOAuthCallback(sdk);
+      const result = oauthUtil.isLoginRedirect(sdk);
       expect(result).toBe(true);
     });
 
@@ -954,7 +954,7 @@ describe('isOAuthCallback', function() {
       window.location = {
         hash: '#random_token=fakerandomtoken'
       }
-      const result = oauthUtil.isOAuthCallback(sdk);
+      const result = oauthUtil.isLoginRedirect(sdk);
       expect(result).toBe(false);
     });
   });
@@ -971,7 +971,7 @@ describe('isOAuthCallback', function() {
         issuer: 'https://auth-js-test.okta.com',
         clientId: 'foo'
       });
-      const result = oauthUtil.isOAuthCallback(sdk);
+      const result = oauthUtil.isLoginRedirect(sdk);
       expect(result).toBe(true);
     });
 
@@ -985,7 +985,7 @@ describe('isOAuthCallback', function() {
         issuer: 'https://auth-js-test.okta.com',
         clientId: 'foo'
       });
-      const result = oauthUtil.isOAuthCallback(sdk);
+      const result = oauthUtil.isLoginRedirect(sdk);
       expect(result).toBe(true);
     });
 
@@ -1000,7 +1000,7 @@ describe('isOAuthCallback', function() {
         issuer: 'https://auth-js-test.okta.com',
         clientId: 'foo'
       });
-      const result = oauthUtil.isOAuthCallback(sdk);
+      const result = oauthUtil.isLoginRedirect(sdk);
       expect(result).toBe(true);
     });
   });

--- a/packages/okta-auth-js/test/spec/pkce.js
+++ b/packages/okta-auth-js/test/spec/pkce.js
@@ -64,7 +64,7 @@ describe('pkce', function() {
     it('throws an error if pkce is true and PKCE is not supported', function() {
       spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(false);
       var sdk = new OktaAuth({ issuer: 'https://foo.com', pkce: false });
-      return token._prepareOauthParams(sdk, {
+      return token.prepareOauthParams(sdk, {
         pkce: true,
       })
       .then(function() {
@@ -93,7 +93,7 @@ describe('pkce', function() {
         spyOn(pkce, 'computeChallenge').and.returnValue(Promise.resolve());
         
         var sdk = new OktaAuth({ issuer: 'https://foo.com', pkce: true });
-        return token._prepareOauthParams(sdk, {
+        return token.prepareOauthParams(sdk, {
           responseType: 'token'
         })
         .then(function(params) {
@@ -109,7 +109,7 @@ describe('pkce', function() {
       spyOn(oauthUtil, 'getWellKnown').and.returnValue(Promise.resolve({
         'code_challenge_methods_supported': []
       }))
-      return token._prepareOauthParams(sdk, {})
+      return token.prepareOauthParams(sdk, {})
       .then(function() {
         expect(false).toBe(true); // should not reach this line
       })
@@ -132,7 +132,7 @@ describe('pkce', function() {
       spyOn(pkce, 'generateVerifier').and.returnValue(codeVerifier);
       spyOn(pkce, 'saveMeta');
       spyOn(pkce, 'computeChallenge').and.returnValue(Promise.resolve(codeChallenge));
-      return token._prepareOauthParams(sdk, {
+      return token.prepareOauthParams(sdk, {
         codeChallengeMethod: codeChallengeMethod
       })
       .then(function(oauthParams) {

--- a/packages/okta-auth-js/test/spec/pkce.js
+++ b/packages/okta-auth-js/test/spec/pkce.js
@@ -64,7 +64,7 @@ describe('pkce', function() {
     it('throws an error if pkce is true and PKCE is not supported', function() {
       spyOn(OktaAuth.features, 'isPKCESupported').and.returnValue(false);
       var sdk = new OktaAuth({ issuer: 'https://foo.com', pkce: false });
-      return token.prepareOauthParams(sdk, {
+      return token._prepareOauthParams(sdk, {
         pkce: true,
       })
       .then(function() {
@@ -93,7 +93,7 @@ describe('pkce', function() {
         spyOn(pkce, 'computeChallenge').and.returnValue(Promise.resolve());
         
         var sdk = new OktaAuth({ issuer: 'https://foo.com', pkce: true });
-        return token.prepareOauthParams(sdk, {
+        return token._prepareOauthParams(sdk, {
           responseType: 'token'
         })
         .then(function(params) {
@@ -109,7 +109,7 @@ describe('pkce', function() {
       spyOn(oauthUtil, 'getWellKnown').and.returnValue(Promise.resolve({
         'code_challenge_methods_supported': []
       }))
-      return token.prepareOauthParams(sdk, {})
+      return token._prepareOauthParams(sdk, {})
       .then(function() {
         expect(false).toBe(true); // should not reach this line
       })
@@ -132,7 +132,7 @@ describe('pkce', function() {
       spyOn(pkce, 'generateVerifier').and.returnValue(codeVerifier);
       spyOn(pkce, 'saveMeta');
       spyOn(pkce, 'computeChallenge').and.returnValue(Promise.resolve(codeChallenge));
-      return token.prepareOauthParams(sdk, {
+      return token._prepareOauthParams(sdk, {
         codeChallengeMethod: codeChallengeMethod
       })
       .then(function(oauthParams) {

--- a/packages/okta-auth-js/test/spec/token.js
+++ b/packages/okta-auth-js/test/spec/token.js
@@ -14,6 +14,7 @@ var sdkUtil = require('../../lib/oauthUtil');
 var pkce = require('../../lib/pkce');
 var http = require('../../lib/http');
 var sdkCrypto = require('../../lib/crypto');
+var AuthSdkError = require('../../lib/errors/AuthSdkError');
 
 function setupSync(options) {
   options = Object.assign({ issuer: 'http://example.okta.com', pkce: false }, options);
@@ -865,6 +866,27 @@ describe('token.getWithoutPrompt', function() {
       errorCauses: []
     }
   );
+
+  it('should throw AuthSdkError when in callback state', async () => {
+    delete global.window.location;
+    global.window.location = {
+      protocol: 'https:',
+      hostname: 'somesite.local',
+      search: '?code=fakecode'
+    };
+    const client = new OktaAuth({
+      pkce: true,
+      issuer: 'https://auth-js-test.okta.com',
+      clientId: 'foo'
+    });
+
+    try {
+      await client.token.getWithoutPrompt();
+    } catch (err) {
+      expect(err).toBeInstanceOf(AuthSdkError);
+      expect(err.message).toBe('The app should not attempt to call getToken on callback. Authorize flow is already in process. Use parseFromUrl() to receive tokens.');
+    }
+  });
 });
 
 describe('token.getWithPopup', function() {
@@ -1340,6 +1362,28 @@ describe('token.getWithPopup', function() {
       }
     });
   });
+
+  it('should throw AuthSdkError when in callback state', async () => {
+    delete global.window.location;
+    global.window.location = {
+      protocol: 'https:',
+      hostname: 'somesite.local',
+      search: '?code=fakecode'
+    };
+    const client = new OktaAuth({
+      pkce: true,
+      issuer: 'https://auth-js-test.okta.com',
+      clientId: 'foo'
+    });
+
+    try {
+      await client.token.getWithPopup();
+    } catch (err) {
+      expect(err).toBeInstanceOf(AuthSdkError);
+      expect(err.message).toBe('The app should not attempt to call getToken on callback. Authorize flow is already in process. Use parseFromUrl() to receive tokens.');
+    }
+  });
+
 });
 
 describe('token.getWithRedirect', function() {
@@ -2129,6 +2173,27 @@ describe('token.getWithRedirect', function() {
                             'state=' + oauthUtil.mockedState + '&' +
                             'scope=openid%20email'
     });
+  });
+
+  it('should throw AuthSdkError when in callback state', async () => {
+    delete global.window.location;
+    global.window.location = {
+      protocol: 'https:',
+      hostname: 'somesite.local',
+      search: '?code=fakecode'
+    };
+    const client = new OktaAuth({
+      pkce: true,
+      issuer: 'https://auth-js-test.okta.com',
+      clientId: 'foo'
+    });
+
+    try {
+      await client.token.getWithRedirect();
+    } catch (err) {
+      expect(err).toBeInstanceOf(AuthSdkError);
+      expect(err.message).toBe('The app should not attempt to call getToken on callback. Authorize flow is already in process. Use parseFromUrl() to receive tokens.');
+    }
   });
 
 });


### PR DESCRIPTION
Changes: 

1. add `isOAuthCallback` function in oauthUtil module
2. guard token.get* (different getToken methods) with isOAuthCallback
3. guard tokeManager.get with isOAuthCallback (if autoRenew is on)
4. add unit tests
5. add error handling examples in README
