### PR TITLE
refactor: token state management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 -[#408](https://github.com/okta/okta-auth-js/pull/408) Provides a polyfill for IE 11+
 -[#410](https://github.com/okta/okta-auth-js/pull/410) Add `token.isLoginRedirect` function to prevent app from starting new Oauth flow while already in OAuth callback state.
 
+### Bug Fixes
+
+-[#420](https://github.com/okta/okta-auth-js/pull/420) Clear accessToken from storage when revoke happen
+
 ## 3.1.4
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -1870,7 +1870,7 @@ authClient.token.getWithPopup()
 
 #### `tokenManager.get(key)`
 
-Get a token that you have previously added to the `tokenManager` with the given `key`. The token object will be returned if it has not expired.
+Returns a Promise that resolves with a valid token that paired with the given `key` in the `tokenManager`.
 
 * `key` - Key for the token you want to get
 
@@ -1963,6 +1963,24 @@ authClient.tokenManager.on('error', function (err) {
     // The application should return to an unauthenticated state
     // This error can also be handled using the 'onSessionExpired' option
   }
+});
+```
+
+**NOTE**: If you manage the tokens state outside of this SDK, subscribe to `expired` event published by the `tokenManager` to get tokens properly renewed .
+
+```javascript
+// autoRenew set to true
+authClient.tokenManager.on('expired', function(key, expiredToken) {
+  // retrieves a new valid token with tokenManager.get
+  const token = await authClient.tokenManager.get(key);
+  // manage the new token state
+});
+
+// autoRenew set to false
+authClient.tokenManager.on('expired', function(key, expiredToken) {
+  // get a renewed token with tokenManager.renew
+  const token = await authClient.tokenManager.renew(key);
+  // manage the new token state
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1966,7 +1966,7 @@ authClient.tokenManager.on('error', function (err) {
 });
 ```
 
-**NOTE**: If you manage the tokens state outside of this SDK, subscribe to `expired` event published by the `tokenManager` to get tokens properly renewed .
+**NOTE**: If you manage the tokens' state outside of this SDK, subscribe to `expired` event published by the `tokenManager` to get tokens properly renewed .
 
 ```javascript
 authClient.tokenManager.on('expired', function(key, expiredToken) {

--- a/README.md
+++ b/README.md
@@ -1969,14 +1969,6 @@ authClient.tokenManager.on('error', function (err) {
 **NOTE**: If you manage the tokens state outside of this SDK, subscribe to `expired` event published by the `tokenManager` to get tokens properly renewed .
 
 ```javascript
-// autoRenew set to true
-authClient.tokenManager.on('expired', function(key, expiredToken) {
-  // retrieves a new valid token with tokenManager.get
-  const token = await authClient.tokenManager.get(key);
-  // manage the new token state
-});
-
-// autoRenew set to false
 authClient.tokenManager.on('expired', function(key, expiredToken) {
   // get a renewed token with tokenManager.renew
   const token = await authClient.tokenManager.renew(key);

--- a/packages/okta-auth-js/lib/browser/browser.js
+++ b/packages/okta-auth-js/lib/browser/browser.js
@@ -263,6 +263,7 @@ proto.revokeAccessToken = async function revokeAccessToken(accessToken) {
   var sdk = this;
   if (!accessToken) {
     accessToken = await sdk.tokenManager.get('accessToken');
+    sdk.tokenManager.remove('accessToken');
   }
   // Access token may have been removed. In this case, we will silently succeed.
   if (!accessToken) {

--- a/packages/okta-auth-js/test/spec/browser.js
+++ b/packages/okta-auth-js/test/spec/browser.js
@@ -144,10 +144,12 @@ describe('Browser', function() {
     it('will read from TokenManager and call token.revoke', function() {
       var accessToken = { accessToken: 'fake' };
       spyOn(auth.tokenManager, 'get').and.returnValue(Promise.resolve(accessToken));
+      spyOn(auth.tokenManager, 'remove').and.returnValue(Promise.resolve(accessToken));
       spyOn(auth.token, 'revoke').and.returnValue(Promise.resolve());
       return auth.revokeAccessToken()
         .then(function() {
           expect(auth.tokenManager.get).toHaveBeenCalledWith('accessToken');
+          expect(auth.tokenManager.remove).toHaveBeenCalledWith('accessToken');
           expect(auth.token.revoke).toHaveBeenCalledWith(accessToken);
         });
     });


### PR DESCRIPTION
* clear token from storage when revoke happen
* refactor tokenManager.get definition
* add code samples for senarios of how to manage token state outside of the SDK