### PR TITLE
fix: fingerprint iframe message - OKTA-314036

### DIFF
--- a/packages/okta-auth-js/lib/browser/browser.js
+++ b/packages/okta-auth-js/lib/browser/browser.js
@@ -366,7 +366,6 @@ proto.fingerprint = function(options) {
         var msg = JSON.parse(e.data);
       } catch (err) {
         // iframe messages should all be parsable
-        // https://github.com/okta/okta-core/blob/master/webapp/src/main/resources/META-INF/resources/WEB-INF/jsp/auth/device-fingerprint.jsp
         // skip not parsable messages come from other sources in same origin (browser extensions)
         // TODO: add namespace flag in okta-core to distinguish messages that come from other sources
         return;

--- a/packages/okta-auth-js/lib/browser/browser.js
+++ b/packages/okta-auth-js/lib/browser/browser.js
@@ -365,7 +365,11 @@ proto.fingerprint = function(options) {
       try {
         var msg = JSON.parse(e.data);
       } catch (err) {
-        return reject(new AuthSdkError('Unable to parse iframe response'));
+        // iframe messages should all be parsable
+        // https://github.com/okta/okta-core/blob/master/webapp/src/main/resources/META-INF/resources/WEB-INF/jsp/auth/device-fingerprint.jsp
+        // skip not parsable messages come from other sources in same origin (browser extensions)
+        // TODO: add namespace flag in okta-core to distinguish messages that come from other sources
+        return;
       }
 
       if (!msg) { return; }

--- a/packages/okta-auth-js/test/spec/fingerprint.js
+++ b/packages/okta-auth-js/test/spec/fingerprint.js
@@ -109,16 +109,6 @@ describe('fingerprint', function() {
     });
   });
 
-  it('fails if the iframe sends invalid message content', function () {
-    return setup({ firstMessage: 'invalidMessageContent' }).fingerprint()
-    .then(function() {
-      throw new Error('Fingerprint promise should have been rejected');
-    })
-    .catch(function(err) {
-      util.assertAuthSdkError(err, 'Unable to parse iframe response');
-    });
-  });
-
   it('fails if user agent is not defined', function () {
     return setup({ userAgent: '' }).fingerprint()
     .then(function() {
@@ -208,20 +198,5 @@ describe('fingerprint', function() {
         sendFingerprint: false
       });
     }
-  });
-
-  it('fails signIn request if fingerprinting fails', function() {
-    return setup({ firstMessage: 'invalidMessageContent' })
-    .signIn({
-      username: 'not',
-      password: 'real',
-      sendFingerprint: true
-    })
-    .then(function() {
-      throw new Error('signIn promise should have been rejected');
-    })
-    .catch(function(err) {
-      util.assertAuthSdkError(err, 'Unable to parse iframe response');
-    });
   });
 });


### PR DESCRIPTION
Based on https://github.com/okta/okta-core/blob/master/webapp/src/main/resources/META-INF/resources/WEB-INF/jsp/auth/device-fingerprint.jsp, the message listener only should expect parsable JSON strings.
This PR can be a short-term fix, a more robust fix can be adding prefix or namespace flag to messages that originated from OKTA.