### PR TITLE
fix: signout session already expired scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.2.3
 
+- [#440](https://github.com/okta/okta-auth-js/pull/440) Fixes signOut XHR fallback to reload page only if postLogoutRedirectUri matches the current URI
 - [#445](https://github.com/okta/okta-auth-js/pull/445) Clears access token from storage after token revocation
 
 ## 3.2.2

--- a/packages/okta-auth-js/lib/browser/browser.js
+++ b/packages/okta-auth-js/lib/browser/browser.js
@@ -279,6 +279,7 @@ proto.signOut = async function (options) {
 
   // postLogoutRedirectUri must be whitelisted in Okta Admin UI
   var defaultUri = window.location.origin;
+  var currentUri = window.location.href;
   var postLogoutRedirectUri = options.postLogoutRedirectUri
     || this.options.postLogoutRedirectUri
     || defaultUri;
@@ -306,12 +307,12 @@ proto.signOut = async function (options) {
   }
 
   // No idToken? This can happen if the storage was cleared.
-  // Fallback to XHR signOut, then redirect to the post logout uri
+  // Fallback to XHR signOut, then simulate a redirect to the post logout uri
   if (!idToken) {
     return sdk.closeSession() // can throw if the user cannot be signed out
     .then(function() {
-      if (postLogoutRedirectUri === defaultUri) {
-        window.location.reload();
+      if (postLogoutRedirectUri === currentUri) {
+        window.location.reload(); // force a hard reload if URI is not changing
       } else {
         window.location.assign(postLogoutRedirectUri);
       }

--- a/packages/okta-auth-js/test/spec/browser.js
+++ b/packages/okta-auth-js/test/spec/browser.js
@@ -221,13 +221,16 @@ describe('Browser', function() {
 
   describe('signOut', function() {
     let origin;
+    let href;
     let encodedOrigin;
   
     beforeEach(function() {
       origin = 'https://somesite.local';
+      href = `${origin}/some-route`;
       encodedOrigin = encodeURIComponent(origin);
       Object.assign(global.window.location, {
         origin,
+        href,
         assign: jest.fn(),
         reload: jest.fn()
       });
@@ -258,7 +261,7 @@ describe('Browser', function() {
         initSpies();
       });
 
-      it('Default options: will revokeAccessToken and use window.location.href for postLogoutRedirectUri', function() {
+      it('Default options: will revokeAccessToken and use window.location.origin for postLogoutRedirectUri', function() {
         return auth.signOut()
           .then(function() {
             expect(auth.tokenManager.get).toHaveBeenNthCalledWith(1, constants.ID_TOKEN_STORAGE_KEY);
@@ -299,10 +302,21 @@ describe('Browser', function() {
             expect(auth.tokenManager.get).toHaveBeenCalledTimes(1);
             expect(auth.tokenManager.get).toHaveBeenNthCalledWith(1, constants.ACCESS_TOKEN_STORAGE_KEY);
             expect(auth.closeSession).toHaveBeenCalled();
-            expect(window.location.reload).toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith(window.location.origin);
           });
       });
   
+      it('if idToken=false and origin===href will reload the page', function() {
+        global.window.location.href = origin;
+        return auth.signOut({ idToken: false })
+          .then(function() {
+            expect(auth.tokenManager.get).toHaveBeenCalledTimes(1);
+            expect(auth.tokenManager.get).toHaveBeenNthCalledWith(1, constants.ACCESS_TOKEN_STORAGE_KEY);
+            expect(auth.closeSession).toHaveBeenCalled();
+            expect(window.location.reload).toHaveBeenCalled();
+          });
+      });
+
       describe('postLogoutRedirectUri', function() {
         it('can be set by config', function() {
           const postLogoutRedirectUri = 'http://someother';
@@ -376,8 +390,22 @@ describe('Browser', function() {
         spyOn(auth, 'revokeAccessToken').and.returnValue(Promise.resolve());
       });
 
-      it('Default options: will revokeAccessToken and fallback to closeSession and window.location.reload()', function() {
+      it('Default options: will revokeAccessToken and fallback to closeSession and redirect to window.location.origin', function() {
         spyOn(auth, 'closeSession').and.returnValue(Promise.resolve());
+        return auth.signOut()
+          .then(function() {
+            expect(auth.tokenManager.get).toHaveBeenNthCalledWith(1, constants.ID_TOKEN_STORAGE_KEY);
+            expect(auth.tokenManager.get).toHaveBeenNthCalledWith(2, constants.ACCESS_TOKEN_STORAGE_KEY);
+            expect(auth.revokeAccessToken).toHaveBeenCalledWith(accessToken);
+            expect(auth.tokenManager.clear).toHaveBeenCalled();
+            expect(auth.closeSession).toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith(window.location.origin);
+          });
+      });
+
+      it('Default options: if href===origin will reload the page', function() {
+        spyOn(auth, 'closeSession').and.returnValue(Promise.resolve());
+        global.window.location.href = origin;
         return auth.signOut()
           .then(function() {
             expect(auth.tokenManager.get).toHaveBeenNthCalledWith(1, constants.ID_TOKEN_STORAGE_KEY);

--- a/test/app/src/config.js
+++ b/test/app/src/config.js
@@ -3,7 +3,7 @@ import { CALLBACK_PATH, STORAGE_KEY } from './constants';
 const HOST = window.location.host;
 const PROTO = window.location.protocol;
 const REDIRECT_URI = `${PROTO}//${HOST}${CALLBACK_PATH}`;
-const POST_LOGOUT_REDIRECT_URI = `${PROTO}//${HOST}`;
+const POST_LOGOUT_REDIRECT_URI = `${PROTO}//${HOST}/`;
 
 function getDefaultConfig() {
   const ISSUER = process.env.ISSUER;


### PR DESCRIPTION
Fixes:
- by default to redirect to `window.location.origin` in signOut when users session already expired. This will fix an issue when user already in a secure route (in SPA, like `/profile`), signOut should redirect user to `window.location.origin` instead of reload the `/profile` route.

(Edit by @aarongranick-okta ): This logic only occurs if `idToken` is missing during signOut. User will be redirected to origin or `postLogoutRedirectUri` after the XHR signOut method is used. If the postLogoutRedirectUri matches the current URI, the page will be reloaded to match the logic of a full redirect.