### PR TITLE
fix: clear PKCE meta before save. favor localSession when reading meta.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - [#422](https://github.com/okta/okta-auth-js/pull/422) Fix bad accessToken storage key in signOut method
+- [#441](https://github.com/okta/okta-auth-js/pull/441) Fixes issue involving an "invalid grant" error: "PKCE verification failed."
 
 ## 3,2.1
 

--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -511,6 +511,12 @@ function getToken(sdk, options) {
       default:
         throw new AuthSdkError('The full page redirect flow is not supported');
     }
+  })
+  .catch(e => {
+    if (sdk.options.pkce) {
+      PKCE.clearMeta(sdk);
+    }
+    throw e;
   });
 }
 

--- a/packages/okta-auth-js/test/spec/pkce.js
+++ b/packages/okta-auth-js/test/spec/pkce.js
@@ -21,8 +21,19 @@ describe('pkce', function() {
       const meta = { codeVerifier: 'fake', redirectUri: 'http://localhost/fake' };
       window.sessionStorage.setItem('okta-pkce-storage', JSON.stringify(meta));
       const sdk = new OktaAuth({ issuer: 'https://foo.com' });
+      expect(pkce.loadMeta(sdk)).toEqual(meta);
       pkce.clearMeta(sdk);
       const res = JSON.parse(window.sessionStorage.getItem('okta-pkce-storage'));
+      expect(res).toEqual({});
+    });
+    // This is for compatibility with older versions of the signin widget. OKTA-304806
+    it('clears meta from localStorage', () => {
+      const meta = { codeVerifier: 'fake', redirectUri: 'http://localhost/fake' };
+      window.localStorage.setItem('okta-pkce-storage', JSON.stringify(meta));
+      const sdk = new OktaAuth({ issuer: 'https://foo.com' });
+      expect(pkce.loadMeta(sdk)).toEqual(meta);
+      pkce.clearMeta(sdk);
+      const res = JSON.parse(window.localStorage.getItem('okta-pkce-storage'));
       expect(res).toEqual({});
     });
   });
@@ -33,6 +44,18 @@ describe('pkce', function() {
       pkce.saveMeta(sdk, meta);
       const res = JSON.parse(window.sessionStorage.getItem('okta-pkce-storage'));
       expect(res).toEqual(meta);
+    });
+    it('clears old meta storage before save', () => {
+      const oldMeta = { codeVerifier: 'old', redirectUri: 'http://localhost/old' };
+      window.localStorage.setItem('okta-pkce-storage', JSON.stringify(oldMeta));
+      window.sessionStorage.setItem('okta-pkce-storage', JSON.stringify(oldMeta));
+
+      const meta = { codeVerifier: 'fake', redirectUri: 'http://localhost/fake' };
+      const sdk = new OktaAuth({ issuer: 'https://foo.com' });
+
+      pkce.saveMeta(sdk, meta);
+      expect(JSON.parse(window.sessionStorage.getItem('okta-pkce-storage'))).toEqual(meta);
+      expect(JSON.parse(window.localStorage.getItem('okta-pkce-storage'))).toEqual({});
     });
   });
   describe('loadMeta', () => {

--- a/test/app/public/index.html
+++ b/test/app/public/index.html
@@ -1,6 +1,9 @@
 <html>
   <head>
     <link rel="stylesheet" href="/oidc-app.css"/>
+    <!-- Latest CDN production Javascript and CSS -->
+    <script src="https://global.oktacdn.com/okta-signin-widget/4.1.1/js/okta-sign-in.min.js" type="text/javascript"></script>
+    <link href="https://global.oktacdn.com/okta-signin-widget/4.1.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
   </head>
   <body class="oidc-app landing">
     <div id="root"></div>

--- a/test/app/public/oidc-app.css
+++ b/test/app/public/oidc-app.css
@@ -1,3 +1,32 @@
+#layout {
+  position: relative;
+  z-index: 1;
+}
+#modal {
+  display: none;
+  position: fixed;
+  z-index: 2;
+  width: 100%;
+  height: 100%;
+  background: rgb(200, 200, 200, 0.8);
+}
+#widget-container {
+  position: absolute;
+  left: 50%;
+  top: 10%;
+}
+#widget {
+  position: relative;
+  left: -50%;
+  background: white;
+  min-width: 100px;
+  min-height: 100px;
+  border: 1px black solid;
+}
+#okta-sign-in {
+  margin: 0 !important;
+}
+
 .flex-row {
   flex-direction: row;
   display: flex;

--- a/test/app/src/webpackEntry.js
+++ b/test/app/src/webpackEntry.js
@@ -24,6 +24,19 @@ function mount() {
   return app;
 }
 
+// Login page, read config from URL
+window.getWidgetConfig = function() {
+  const siwConfig = window.location.search ? getConfigFromUrl() : getDefaultConfig();
+  Object.assign(siwConfig, {
+    baseUrl: config.issuer.split('/oauth2')[0],
+    el: '#widget',
+    authParams: {
+      display: 'page'
+    }
+  });
+  return siwConfig;
+};
+
 // Regular landing, read config from URL
 window.bootstrapLanding = function() {
   config = window.location.search ? getConfigFromUrl() : getDefaultConfig();


### PR DESCRIPTION
This PR fixes an issue involving PKCE metadata:

 - current version of the widget stores PKCE code in localStorage
- current version of authJS looks for code in sessionStorage, but falls back to localStorage if code is not present
- token renew failure does not cleanup but leaves a code in sessionStorage. token renew failure can occur if the session is expired OR if 3rd party cookies are blocked
- the error occurs because the code from token renew (in sessionStorage) is passed to the /token endpoint instead of the code saved from the widget (in localStorage)

This PR fixes the issue by favoring localStorage over sessionStorage in `loadMeta`. If meta exists in both locations, we will use the value in localStorage because it is assumed the meta was put there by an older version of the signin widget, and the data in sessionStorage may be left over from a failed token call that did not clean up after itself.

Additionally, we add extra protections:
- Adding catch block on `getToken` to clear PKCE storage. This is where the meta was being left behind by failed token renew
- Before saving, storage is read for existing values. If meta is found in either location a warning message is printed. This may help developers detect a concurrency issue and provide better bug reports
- All PKCE storage is cleared before saving, in both local and session storage. This should prevent the wrong code from being sent to a token call. For concurrency issues, we will see an error that the PKCE code is not found in storage.

This PR also adds a "login using signin widget" option to test app. This was used to manually reproduce the issue.
