### PR TITLE
breaking changes for 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 ### Features
 
 - [#413](https://github.com/okta/okta-auth-js/pull/413) Adds support for Typescript. Uses named exports instead of default export.
+- [#444](https://github.com/okta/okta-auth-js/pull/444) New method `tokenManager.hasExpired` to test if a token is expired
+
+### Breaking Changes
+
+- [#444](https://github.com/okta/okta-auth-js/pull/444)
+  - Implements "active" autoRenew.  Previously tokens would be renewed or removed when calling `tokenManager.get`. Now they will be renewed or removed in the background. If autoRenew is true, tokens will be renewed before expiration. If autoRenew is false, tokens will be removed from storage on expiration.
+  - `onSessionExpired` option has been removed. [TokenManager events](#tokenmanageronevent-callback-context) can be used to detect and handle token renewal errors.
+  - `tokenManager.get` no longer implements autoRenew functionality (autoRenew is done by a separate process within `TokenManager`). Even with `autoRenew`, it is possible that the token returned from the TokenManager may be expired, since renewal is an asynchronous process. New method `tokenManager.hasExpired` can be used to test the token and avoid this potential race condition.
 
 ## 3.2.3
 

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -101,7 +101,6 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
       postLogoutRedirectUri: args.postLogoutRedirectUri,
       responseMode: args.responseMode,
       transformErrorXHR: args.transformErrorXHR,
-      onSessionExpired: args.onSessionExpired,
       cookies: cookieSettings
     });
   
@@ -183,19 +182,6 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
 
     this.emitter = new Emitter();
     this.tokenManager = new TokenManager(this, args.tokenManager);
-    this.tokenManager.on('error', this._onTokenManagerError, this);
-  }
-
-  _onTokenManagerError(error) {
-    var code = error.errorCode;
-    if (code === 'login_required' && error.accessToken) {
-      if (this.options.onSessionExpired) {
-        this.options.onSessionExpired();
-      } else {
-        // eslint-disable-next-line no-console
-        console.error('Session has expired or was closed outside the application.');
-      }
-    }
   }
 
   signIn(opts) {

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -36,8 +36,6 @@ export interface CustomUrls {
   logoutUrl?: string;
 }
 
-export type OnSessionExpiredFunction = () => void;
-
 export interface OktaAuthOptions extends CustomUrls {
   pkce?: boolean;
   clientId?: string;
@@ -48,7 +46,6 @@ export interface OktaAuthOptions extends CustomUrls {
   ignoreSignature?: boolean;
   tokenManager?: TokenManagerOptions;
   postLogoutRedirectUri?: string;
-  onSessionExpired?: OnSessionExpiredFunction;
   storageUtil?: StorageUtil;
   ajaxRequest?: object;
   httpRequestClient?: HttpRequestClient;

--- a/test/app/src/testApp.ts
+++ b/test/app/src/testApp.ts
@@ -98,9 +98,6 @@ class TestApp {
   oktaAuth?: OktaAuth;
   constructor(config: Config) {
     this.config = config;
-    Object.assign(this.config, {
-      onSessionExpired: this._onSessionExpired.bind(this)
-    });
   }
 
   // Mount into the DOM
@@ -141,10 +138,6 @@ class TestApp {
 
   _onTokenError(error: string): void {
     document.getElementById('token-error').innerText = error;
-  }
-
-  _onSessionExpired(): void {
-    document.getElementById('session-expired').innerText = 'SESSION EXPIRED';
   }
 
   async bootstrapCallback(): Promise<void> {

--- a/test/e2e/specs/tokens.js
+++ b/test/e2e/specs/tokens.js
@@ -88,9 +88,6 @@ describe('E2E token flows', () => {
         await TestApp.tokenError.then(el => el.getText()).then(msg => {
           assert(msg.trim() === 'OAuthError: The client specified not to prompt, but the user is not logged in.');
         });
-        await TestApp.sessionExpired.then(el => el.getText()).then(txt => {
-          assert(txt === 'SESSION EXPIRED');
-        });
         await TestApp.clearTokens();
         await browser.refresh();
         await TestApp.waitForLoginBtn(); // assert we are logged out

--- a/test/spec/browser.js
+++ b/test/spec/browser.js
@@ -2,7 +2,6 @@
 /* global window */
 jest.mock('cross-fetch');
 
-import Emitter from 'tiny-emitter';
 import { OktaAuth, AuthApiError, ACCESS_TOKEN_STORAGE_KEY, ID_TOKEN_STORAGE_KEY } from '@okta/okta-auth-js';
 
 describe('Browser', function() {
@@ -28,52 +27,6 @@ describe('Browser', function() {
 
   it('is a valid constructor', function() {
     expect(auth instanceof OktaAuth).toBe(true);
-  });
-
-  describe('Error handling', function() {
-    it('Listens to error events from TokenManager', function() {
-      jest.spyOn(Emitter.prototype, 'on');
-      jest.spyOn(OktaAuth.prototype, '_onTokenManagerError');
-      var auth = new OktaAuth({ issuer: 'http://localhost/fake', pkce: false });
-      expect(Emitter.prototype.on).toHaveBeenCalledWith('error', auth._onTokenManagerError, auth);
-      var emitter = Emitter.prototype.on.mock.instances[0];
-      var error = { errorCode: 'anything'};
-      emitter.emit('error', error);
-      expect(OktaAuth.prototype._onTokenManagerError).toHaveBeenCalledWith(error);
-    });
-  
-    it('errorCode "login_required" and accessToken: true will call option "onSessionExpired" function', function() {
-      var onSessionExpired = jest.fn();
-      jest.spyOn(Emitter.prototype, 'on');
-      new OktaAuth({ issuer: 'http://localhost/fake', pkce: false, onSessionExpired: onSessionExpired });
-      var emitter = Emitter.prototype.on.mock.instances[0];
-      expect(onSessionExpired).not.toHaveBeenCalled();
-      var error = { errorCode: 'login_required', accessToken: true };
-      emitter.emit('error', error);
-      expect(onSessionExpired).toHaveBeenCalled();
-    });
-
-    it('error with errorCode "login_required" (not accessToken) does not call option "onSessionExpired" function', function() {
-      var onSessionExpired = jest.fn();
-      jest.spyOn(Emitter.prototype, 'on');
-      new OktaAuth({ issuer: 'http://localhost/fake', pkce: false, onSessionExpired: onSessionExpired });
-      var emitter = Emitter.prototype.on.mock.instances[0];
-      expect(onSessionExpired).not.toHaveBeenCalled();
-      var error = { errorCode: 'login_required' };
-      emitter.emit('error', error);
-      expect(onSessionExpired).not.toHaveBeenCalled();
-    });
-    
-    it('error with unknown errorCode does not call option "onSessionExpired" function', function() {
-      var onSessionExpired = jest.fn();
-      jest.spyOn(Emitter.prototype, 'on');
-      new OktaAuth({ issuer: 'http://localhost/fake', pkce: false, onSessionExpired: onSessionExpired });
-      var emitter = Emitter.prototype.on.mock.instances[0];
-      expect(onSessionExpired).not.toHaveBeenCalled();
-      var error = { errorCode: 'unknown', accessToken: true };
-      emitter.emit('error', error);
-      expect(onSessionExpired).not.toHaveBeenCalled();
-    });
   });
 
   describe('options', function() {

--- a/test/spec/token.js
+++ b/test/spec/token.js
@@ -842,8 +842,19 @@ describe('token.getWithoutPrompt', function() {
     });
   });
 
-  oauthUtil.itpErrorsCorrectly('throws an error if multiple responseTypes are sent as a string',
-    {
+  it('throws an error if multiple responseTypes are sent as a string', () => {
+    const error = {
+      name: 'AuthSdkError',
+      message: 'Multiple OAuth responseTypes must be defined as an array',
+      errorCode: 'INTERNAL',
+      errorSummary: 'Multiple OAuth responseTypes must be defined as an array',
+      errorLink: 'INTERNAL',
+      errorId: 'INTERNAL',
+      errorCauses: []
+    };
+
+    return oauthUtil.setupFrame({
+      willFail: true,
       oktaAuthArgs: {
         pkce: false,
         issuer: 'https://auth-js-test.okta.com',
@@ -854,17 +865,11 @@ describe('token.getWithoutPrompt', function() {
         responseType: 'id_token token',
         sessionToken: 'testSessionToken'
       }
-    },
-    {
-      name: 'AuthSdkError',
-      message: 'Multiple OAuth responseTypes must be defined as an array',
-      errorCode: 'INTERNAL',
-      errorSummary: 'Multiple OAuth responseTypes must be defined as an array',
-      errorLink: 'INTERNAL',
-      errorId: 'INTERNAL',
-      errorCauses: []
-    }
-  );
+    })
+    .catch(function(e) {
+      util.expectErrorToEqual(e, error);
+    });
+  });
 
   it('should throw AuthSdkError when in callback state', async () => {
     delete global.window.location;
@@ -2609,9 +2614,18 @@ describe('token.parseFromUrl', function() {
     });
   });
 
-  oauthUtil.itpErrorsCorrectly('throws an error if nothing to parse',
-    {
-      setupMethod: oauthUtil.setupParseUrl,
+  it('throws an error if nothing to parse', () => {
+    const error = {
+      name: 'AuthSdkError',
+      message: 'Unable to parse a token from the url',
+      errorCode: 'INTERNAL',
+      errorSummary: 'Unable to parse a token from the url',
+      errorLink: 'INTERNAL',
+      errorId: 'INTERNAL',
+      errorCauses: []
+    };
+    return oauthUtil.setupParseUrl({
+      willFail: true,
       hashMock: '',
       oauthCookie: JSON.stringify({
         responseType: ['id_token', 'token'],
@@ -2625,29 +2639,15 @@ describe('token.parseFromUrl', function() {
           userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
         }
       })
-    },
-    {
-      name: 'AuthSdkError',
-      message: 'Unable to parse a token from the url',
-      errorCode: 'INTERNAL',
-      errorSummary: 'Unable to parse a token from the url',
-      errorLink: 'INTERNAL',
-      errorId: 'INTERNAL',
-      errorCauses: []
-    }
-  );
+    })
+    .catch(function(e) {
+      util.expectErrorToEqual(e, error);
+    });
 
-  oauthUtil.itpErrorsCorrectly('throws an error if no cookie set',
-    {
-      setupMethod: oauthUtil.setupParseUrl,
-      hashMock: '#access_token=' + tokens.standardAccessToken +
-                '&id_token=' + tokens.standardIdToken +
-                '&expires_in=3600' +
-                '&token_type=Bearer' +
-                '&state=' + oauthUtil.mockedState,
-      oauthCookie: ''
-    },
-    {
+  });
+
+  it('throws an error if no cookie set', () => {
+    const error = {
       name: 'AuthSdkError',
       message: 'Unable to retrieve OAuth redirect params cookie',
       errorCode: 'INTERNAL',
@@ -2655,12 +2655,35 @@ describe('token.parseFromUrl', function() {
       errorLink: 'INTERNAL',
       errorId: 'INTERNAL',
       errorCauses: []
-    }
-  );
+    };
 
-  oauthUtil.itpErrorsCorrectly('throws an error if state doesn\'t match',
-    {
-      setupMethod: oauthUtil.setupParseUrl,
+    return oauthUtil.setupParseUrl({
+      willFail: true,
+      hashMock: '#access_token=' + tokens.standardAccessToken +
+                '&id_token=' + tokens.standardIdToken +
+                '&expires_in=3600' +
+                '&token_type=Bearer' +
+                '&state=' + oauthUtil.mockedState,
+      oauthCookie: ''
+    })
+    .catch(function(e) {
+      util.expectErrorToEqual(e, error);
+    });
+  });
+
+  it('throws an error if state doesn\'t match', () => {
+    const error = {
+      name: 'AuthSdkError',
+      message: 'OAuth flow response state doesn\'t match request state',
+      errorCode: 'INTERNAL',
+      errorSummary: 'OAuth flow response state doesn\'t match request state',
+      errorLink: 'INTERNAL',
+      errorId: 'INTERNAL',
+      errorCauses: []
+    };
+
+    return oauthUtil.setupParseUrl({
+      willFail: true,
       hashMock: '#access_token=' + tokens.standardAccessToken +
                 '&id_token=' + tokens.standardIdToken +
                 '&expires_in=3600' +
@@ -2678,21 +2701,24 @@ describe('token.parseFromUrl', function() {
           userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
         }
       })
-    },
-    {
+    })
+    .catch(function(e) {
+      util.expectErrorToEqual(e, error);
+    });
+  });
+
+  it('throws an error if nonce doesn\'t match', () => {
+    const error = {
       name: 'AuthSdkError',
-      message: 'OAuth flow response state doesn\'t match request state',
+      message: 'OAuth flow response nonce doesn\'t match request nonce',
       errorCode: 'INTERNAL',
-      errorSummary: 'OAuth flow response state doesn\'t match request state',
+      errorSummary: 'OAuth flow response nonce doesn\'t match request nonce',
       errorLink: 'INTERNAL',
       errorId: 'INTERNAL',
       errorCauses: []
-    }
-  );
-
-  oauthUtil.itpErrorsCorrectly('throws an error if nonce doesn\'t match',
-    {
-      setupMethod: oauthUtil.setupParseUrl,
+    };
+    return oauthUtil.setupParseUrl({
+      willFail: true,
       hashMock: '#access_token=' + tokens.standardAccessToken +
                 '&id_token=' + tokens.standardIdToken +
                 '&expires_in=3600' +
@@ -2710,74 +2736,78 @@ describe('token.parseFromUrl', function() {
           userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
         }
       })
-    },
-    {
+    })
+    .catch(function(e) {
+      util.expectErrorToEqual(e, error);
+    });
+  });
+
+  it('throws an error if access_token was not returned', () => {
+    const error = {
       name: 'AuthSdkError',
-      message: 'OAuth flow response nonce doesn\'t match request nonce',
+      message: 'Unable to parse OAuth flow response: response type "token" was requested but "access_token" was not returned.',
       errorCode: 'INTERNAL',
-      errorSummary: 'OAuth flow response nonce doesn\'t match request nonce',
+      errorSummary: 'Unable to parse OAuth flow response: response type "token" was requested but "access_token" was not returned.',
       errorLink: 'INTERNAL',
       errorId: 'INTERNAL',
       errorCauses: []
-    }
-  );
-
-  oauthUtil.itpErrorsCorrectly('throws an error if access_token was not returned', {
-    setupMethod: oauthUtil.setupParseUrl,
-    hashMock: '#id_token=' + tokens.standardIdToken +
-              '&expires_in=3600' +
-              '&token_type=Bearer' +
-              '&state=' + oauthUtil.mockedState,
-    oauthCookie: JSON.stringify({
-      responseType: ['id_token', 'token'],
-      state: oauthUtil.mockedState,
-      nonce: oauthUtil.mockedNonce,
-      scopes: ['openid', 'email'],
-      urls: {
-        issuer: 'https://auth-js-test.okta.com',
-        tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
-        authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-        userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-      }
+    };
+    return oauthUtil.setupParseUrl({
+      willFail: true,
+      hashMock: '#id_token=' + tokens.standardIdToken +
+                '&expires_in=3600' +
+                '&token_type=Bearer' +
+                '&state=' + oauthUtil.mockedState,
+      oauthCookie: JSON.stringify({
+        responseType: ['id_token', 'token'],
+        state: oauthUtil.mockedState,
+        nonce: oauthUtil.mockedNonce,
+        scopes: ['openid', 'email'],
+        urls: {
+          issuer: 'https://auth-js-test.okta.com',
+          tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
+          authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+          userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+        }
+      })
     })
-  },
-  {
-    name: 'AuthSdkError',
-    message: 'Unable to parse OAuth flow response: response type "token" was requested but "access_token" was not returned.',
-    errorCode: 'INTERNAL',
-    errorSummary: 'Unable to parse OAuth flow response: response type "token" was requested but "access_token" was not returned.',
-    errorLink: 'INTERNAL',
-    errorId: 'INTERNAL',
-    errorCauses: []
+    .catch(function(e) {
+      util.expectErrorToEqual(e, error);
+    });
   });
 
-  oauthUtil.itpErrorsCorrectly('throws an error if id_token was not returned', {
-    setupMethod: oauthUtil.setupParseUrl,
-    hashMock: '#access_token=' + tokens.standardAccessToken +
-              '&expires_in=3600' +
-              '&token_type=Bearer' +
-              '&state=' + oauthUtil.mockedState,
-    oauthCookie: JSON.stringify({
-      responseType: ['id_token', 'token'],
-      state: oauthUtil.mockedState,
-      nonce: oauthUtil.mockedNonce,
-      scopes: ['openid', 'email'],
-      urls: {
-        issuer: 'https://auth-js-test.okta.com',
-        tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
-        authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
-        userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
-      }
+  it('throws an error if id_token was not returned', () => {
+    const error = {
+      name: 'AuthSdkError',
+      message: 'Unable to parse OAuth flow response: response type "id_token" was requested but "id_token" was not returned.',
+      errorCode: 'INTERNAL',
+      errorSummary: 'Unable to parse OAuth flow response: response type "id_token" was requested but "id_token" was not returned.',
+      errorLink: 'INTERNAL',
+      errorId: 'INTERNAL',
+      errorCauses: []
+    };
+    return oauthUtil.setupParseUrl({
+      willFail: true,
+      hashMock: '#access_token=' + tokens.standardAccessToken +
+                '&expires_in=3600' +
+                '&token_type=Bearer' +
+                '&state=' + oauthUtil.mockedState,
+      oauthCookie: JSON.stringify({
+        responseType: ['id_token', 'token'],
+        state: oauthUtil.mockedState,
+        nonce: oauthUtil.mockedNonce,
+        scopes: ['openid', 'email'],
+        urls: {
+          issuer: 'https://auth-js-test.okta.com',
+          tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
+          authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+          userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+        }
+      })
     })
-  },
-  {
-    name: 'AuthSdkError',
-    message: 'Unable to parse OAuth flow response: response type "id_token" was requested but "id_token" was not returned.',
-    errorCode: 'INTERNAL',
-    errorSummary: 'Unable to parse OAuth flow response: response type "id_token" was requested but "id_token" was not returned.',
-    errorLink: 'INTERNAL',
-    errorId: 'INTERNAL',
-    errorCauses: []
+    .catch(function(e) {
+      util.expectErrorToEqual(e, error);
+    });
   });
 });
 
@@ -2905,17 +2935,8 @@ describe('token.renew', function() {
     });
   });
 
-  oauthUtil.itpErrorsCorrectly('throws an error if a non-token is passed',
-    {
-      oktaAuthArgs: {
-        pkce: false,
-        issuer: 'https://auth-js-test.okta.com',
-        clientId: 'NPSfOkH5eZrTy8PMDlvx',
-        redirectUri: 'https://example.com/redirect'
-      },
-      tokenRenewArgs: [{non:'token'}]
-    },
-    {
+  it('throws an error if a non-token is passed', () => {
+    const error = {
       name: 'AuthSdkError',
       message: 'Renew must be passed a token with an array of scopes and an accessToken or idToken',
       errorCode: 'INTERNAL',
@@ -2923,8 +2944,21 @@ describe('token.renew', function() {
       errorLink: 'INTERNAL',
       errorId: 'INTERNAL',
       errorCauses: []
-    }
-  );
+    };
+    return oauthUtil.setupFrame({
+      willFail: true,
+      oktaAuthArgs: {
+        pkce: false,
+        issuer: 'https://auth-js-test.okta.com',
+        clientId: 'NPSfOkH5eZrTy8PMDlvx',
+        redirectUri: 'https://example.com/redirect'
+      },
+      tokenRenewArgs: [{non:'token'}]
+    })
+    .catch(function(e) {
+      util.expectErrorToEqual(e, error);
+    });
+  });
 });
 
 describe('token.getUserInfo', function() {


### PR DESCRIPTION
# breaking changes
- remove `onSessionExpired`
- implement active autoRenew
- remove renew logic from `tokenManager.get()`

# new features
- adds `tokenManager.hasExpired(token)` to test if a token is expired or not.
