### PR TITLE
fixes flakey tests related to autoRenew

### DIFF
--- a/jest.browser.js
+++ b/jest.browser.js
@@ -10,6 +10,9 @@ module.exports = {
   'moduleNameMapper': {
     '^@okta/okta-auth-js$': OktaAuth
   },
+  'setupFiles': [
+    '<rootDir>/test/support/nodeExceptions.js'
+  ],
   'testMatch': [
     '**/test/spec/*.{js,ts}'
   ],

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -289,7 +289,7 @@ export class TokenManager {
   
     const onTokenExpiredHandler = (key) => {
       if (options.autoRenew) {
-        this.renew(key);
+        this.renew(key).catch(() => {}); // Renew errors will emit an "error" event 
       } else {
         this.remove(key);
       }

--- a/test/support/nodeExceptions.js
+++ b/test/support/nodeExceptions.js
@@ -1,0 +1,5 @@
+// Catch unhandled promise rejections. These should never happen.
+// If you see one of these, debug the test and set a breakpoint below.
+process.on('unhandledRejection', error => {
+  console.log('FLAKEY TEST or CODE! unhandledRejection', error);
+});

--- a/test/support/oauthUtil.js
+++ b/test/support/oauthUtil.js
@@ -173,6 +173,9 @@ oauthUtil.setup = function(opts) {
     authClient = opts.authClient;
   } else {
     authClient = new OktaAuth({
+      tokenManager: {
+        autoRenew: false,
+      },
       pkce: false,
       issuer: 'https://auth-js-test.okta.com'
     });
@@ -247,6 +250,11 @@ oauthUtil.setup = function(opts) {
       } else {
         console.error(err); // eslint-disable-line
         expect('not to be hit').toBe(true);
+      }
+    })
+    .finally(function() {
+      if (authClient && authClient._tokenQueue) {
+        expect(authClient._tokenQueue.queue.length).toBe(0);
       }
     });
 };

--- a/test/support/util.js
+++ b/test/support/util.js
@@ -195,7 +195,10 @@ function setup(options) {
         issuer: options.issuer,
         transformErrorXHR: options.transformErrorXHR,
         headers: options.headers,
-        ignoreSignature: options.bypassCrypto === true
+        ignoreSignature: options.bypassCrypto === true,
+        tokenManager: {
+          autoRenew: false
+        }
       });
 
       // 3. Initialize status if passed in


### PR DESCRIPTION
- adds unhandled promise rejection handler which will cause test to fail if there is an unhandled promise rejection after the test is complete
- will fail test if PromiseQueue is not empty at the end of the test
- sets autoRenew to false by default within tests
- tokenManager will clear() after each test involving autoRenew (to clear timeouts)