### PR TITLE
feat: add storageKeys options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Pending
+
+### Features
+
+- [#462](https://github.com/okta/okta-auth-js/pull/462) Adds storageKeys option to accept custom keys for storage
+
 ## 4.0.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -369,24 +369,9 @@ In most cases you will not need to set a value for `responseMode`. Defaults are 
 | `ignoreSignature` | ID token signatures are validated by default when `token.getWithoutPrompt`, `token.getWithPopup`,  `token.getWithRedirect`, and `token.verify` are called. To disable ID token signature validation for these methods, set this value to `true`. |
 | | This option should be used only for browser support and testing purposes. |
 | `maxClockSkew` | Defaults to 300 (five minutes). This is the maximum difference allowed between a client's clock and Okta's, in seconds, when validating tokens. Setting this to 0 is not recommended, because it increases the likelihood that valid tokens will fail validation. |
-| `tokenManager` | An object containing additional properties used to configure the internal token manager. |
-
-* `autoRenew`:
-  By default, the library will attempt to renew tokens before they expire. If you wish to  to disable auto renewal of tokens, set autoRenew to false.
-
-* `storage`:
-  You may pass an object or a string. If passing an object, it should meet the requirements of a [custom storage provider](#storage). Pass a string to specify one of the built-in storage types:
-  * [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) (default)
-  * [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)
-  * [`cookie`](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie)
-  * `memory`: a simple in-memory storage provider
-
-* `storageKey`: By default all tokens will be stored under the key `okta-token-storage`. You may want to change this if you have multiple apps running on a single domain which share the same storage type. Giving each app a unique storage key will prevent them from reading or writing each other's token values.
-
-| `cookies` | An object containing additional properties used when setting cookies. |
-
-* `secure`: Defaults to `true`, unless the application origin is `http://localhost`, in which case it is forced to `false`. If `true`, the SDK will set the "Secure" option on all cookies. When this option is `true`, an exception will be thrown if the application origin is not using the HTTPS protocol. Setting to `false` will allow setting cookies on an HTTP origin, but is not recommended for production applications.
-* `sameSite`: Defaults to `none` if the `secure` option is `true`, or `lax` if the `secure` option is false. Allows fine-grained control over the same-site cookie setting. A value of `none` allows embedding within an iframe. A value of `lax` will avoid being blocked by user "3rd party" cookie settings. A value of `strict` will block all cookies when redirecting from Okta and is not recommended.
+| `tokenManager` | An object containing additional properties used to configure the internal token manager. <ul><li>`autoRenew`: By default, the library will attempt to renew tokens before they expire. If you wish to  to disable auto renewal of tokens, set autoRenew to false.</li><li>`storage`: You may pass an object or a string. If passing an object, it should meet the requirements of a [custom storage provider](#storage). Pass a string to specify one of the built-in storage types:<ul><li>[`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) (default)</li><li>[`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)</li><li>[`cookie`](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie)</li><li>`memory`: a simple in-memory storage provider</li></ul></li><li>`storageKey`: By default all tokens will be stored under the key `okta-token-storage`. You may want to change this if you have multiple apps running on a single domain which share the same storage type. Giving each app a unique storage key will prevent them from reading or writing each other's token values.</li></ul> |
+| `cookies` | An object containing additional properties used when setting cookies. <ul><li>`secure`: Defaults to `true`, unless the application origin is `http://localhost`, in which case it is forced to `false`. If `true`, the SDK will set the "Secure" option on all cookies. When this option is `true`, an exception will be thrown if the application origin is not using the HTTPS protocol. Setting to `false` will allow setting cookies on an HTTP origin, but is not recommended for production applications.</li><li>`sameSite`: Defaults to `none` if the `secure` option is `true`, or `lax` if the `secure` option is false. Allows fine-grained control over the same-site cookie setting. A value of `none` allows embedding within an iframe. A value of `lax` will avoid being blocked by user "3rd party" cookie settings. A value of `strict` will block all cookies when redirecting from Okta and is not recommended.</li></ul>|
+| `storageKeys` | An object containing custom storage keys used to provide consistent storage keys for internal state managers. <ul><li>`idToken`: customized storage key for IDToken, default to `idToken`.</li><li>`accessToken`: customized storage key for AccessToken, default to `accessToken`.</li></ul> |
 
 ##### Example Client
 
@@ -405,6 +390,12 @@ var config = {
   // Configure TokenManager to use sessionStorage instead of localStorage
   tokenManager: {
     storage: 'sessionStorage'
+  },
+
+  // Configure StorageKeys for idToken
+  // This setting let internal state managers know how to find idToken if it's added by key other than `idToken`, like sdk.tokenManager.add('custom-idToken', IDToKen)
+  storageKeys: {
+    idToken: 'custom-idToken'
   }
 };
 

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -101,7 +101,11 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
       postLogoutRedirectUri: args.postLogoutRedirectUri,
       responseMode: args.responseMode,
       transformErrorXHR: args.transformErrorXHR,
-      cookies: cookieSettings
+      cookies: cookieSettings,
+      storageKeys: Object.assign({
+        idToken: ID_TOKEN_STORAGE_KEY,
+        accessToken: ACCESS_TOKEN_STORAGE_KEY
+      }, args.storageKeys)
     });
   
     this.userAgent = getUserAgent(args, `okta-auth-js/${SDK_VERSION}`);
@@ -222,8 +226,9 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
   // Revokes the access token for the application session
   async revokeAccessToken(accessToken?: AccessToken) {
     if (!accessToken) {
-      accessToken = await this.tokenManager.get(ACCESS_TOKEN_STORAGE_KEY) as AccessToken;
-      this.tokenManager.remove(ACCESS_TOKEN_STORAGE_KEY);
+      const { accessToken: accessTokenStorageKey } = this.options.storageKeys;
+      accessToken = await this.tokenManager.get(accessTokenStorageKey) as AccessToken;
+      this.tokenManager.remove(accessTokenStorageKey);
     }
     // Access token may have been removed. In this case, we will silently succeed.
     if (!accessToken) {
@@ -250,11 +255,11 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
     var logoutUrl = getOAuthUrls(this).logoutUrl;
   
     if (typeof idToken === 'undefined') {
-      idToken = await this.tokenManager.get(ID_TOKEN_STORAGE_KEY);
+      idToken = await this.tokenManager.get(this.options.storageKeys.idToken);
     }
   
     if (revokeAccessToken && typeof accessToken === 'undefined') {
-      accessToken = await this.tokenManager.get(ACCESS_TOKEN_STORAGE_KEY);
+      accessToken = await this.tokenManager.get(this.options.storageKeys.accessToken);
     }
   
     // Clear all local tokens

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -33,8 +33,6 @@ import * as sdkCrypto from './crypto';
 import AuthSdkError from './errors/AuthSdkError';
 import OAuthError from './errors/OAuthError';
 import {
-  ACCESS_TOKEN_STORAGE_KEY,
-  ID_TOKEN_STORAGE_KEY,
   REDIRECT_OAUTH_PARAMS_COOKIE_NAME,
   REDIRECT_NONCE_COOKIE_NAME,
   REDIRECT_STATE_COOKIE_NAME
@@ -800,10 +798,10 @@ function parseFromUrl(sdk, options: string | ParseFromUrlOptions): Promise<Token
 async function getUserInfo(sdk, accessTokenObject, idTokenObject): Promise<UserClaims> {
   // If token objects were not passed, attempt to read from the TokenManager
   if (!accessTokenObject) {
-    accessTokenObject = await sdk.tokenManager.get(ACCESS_TOKEN_STORAGE_KEY);
+    accessTokenObject = await sdk.tokenManager.get(sdk.options.storageKeys.accessToken);
   }
   if (!idTokenObject) {
-    idTokenObject = await sdk.tokenManager.get(ID_TOKEN_STORAGE_KEY);
+    idTokenObject = await sdk.tokenManager.get(sdk.options.storageKeys.idToken);
   }
 
   if (!accessTokenObject ||

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -36,6 +36,11 @@ export interface CustomUrls {
   logoutUrl?: string;
 }
 
+export interface StorageKeysOptions {
+  idToken?: string;
+  accessToken?: string;
+}
+
 export interface OktaAuthOptions extends CustomUrls {
   pkce?: boolean;
   clientId?: string;
@@ -54,4 +59,5 @@ export interface OktaAuthOptions extends CustomUrls {
   transformErrorXHR?: (xhr: object) => any;
   headers?: object;
   maxClockSkew?: number;
+  storageKeys?: StorageKeysOptions;
 }


### PR DESCRIPTION
In this PR:
* adds `storageKeys` to the sdk options
* keeps this option in root level, as it can include all custom keys (not only token storage keys).
* fixes broken configuration table with HTML list