### PR TITLE
ID token expiry time based on local clock

### DIFF
--- a/lib/token.ts
+++ b/lib/token.ts
@@ -261,12 +261,13 @@ function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res: OAuth
     var tokenType = res.token_type;
     var accessToken = res.access_token;
     var idToken = res.id_token;
+    var now = Math.floor(Date.now()/1000);
     
     if (accessToken) {
       tokenDict.accessToken = {
         value: accessToken,
         accessToken: accessToken,
-        expiresAt: Number(expiresIn) + Math.floor(Date.now()/1000),
+        expiresAt: Number(expiresIn) + now,
         tokenType: tokenType,
         scopes: scopes,
         authorizeUrl: urls.authorizeUrl,
@@ -281,7 +282,7 @@ function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res: OAuth
         value: idToken,
         idToken: idToken,
         claims: jwt.payload,
-        expiresAt: jwt.payload.exp,
+        expiresAt: jwt.payload.exp - jwt.payload.iat + now,
         scopes: scopes,
         authorizeUrl: urls.authorizeUrl,
         issuer: urls.issuer,


### PR DESCRIPTION
This is just one way to address the root cause of https://github.com/okta/okta-oidc-js/issues/894. The ID token `expiresAt` value is based on the `exp` claim in the JWT payload segment. This is populated server side, so obviously can be skewed against the local clock. Setting your local clock ahead by 1 hour means the `expiresAt` value is essentially _now_. `setExpireEventTimeout` then calls `setTimeout` with a zero or negative value, which results in an `expired` event being emitted. A subscriber to that event then triggers a renew. This loops forever.

This PR presents just one way to address the issue, see the commit message for more details.

I also note that `SdkClock` has had some work started to make it deal with local clock drift, but it is not complete. This would be another suitable way to address the issue, though I don't really have the means to do this work, as it would likely require something Okta API side to help calculate the drift. So if there is a concensus that is the correct way forward, feel free to close this PR.