### PR TITLE
refactor browser public methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@
   - Supports browser-based OpenID Connect flows in `sdk.signIn` method (browser bundle only).
   - Accepts new custom callbacks [options](README.md#configuration-options)
     - `isAuthenticated`
-    - `onAuthRequired`
     - `autoRemove`
     - `devMode`
 - [#469](https://github.com/okta/okta-auth-js/pull/469) Adds "rate limiting" logic to token autoRenew process to prevent too many requests be sent out which may cause application rate limit issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,22 @@
     - `authStateManager.updateAuthState`
     - `authStateManager.subscribe`
     - `authStateManager.unsubscribe`
-  - Adds new methods in sdk scope:
-    - `sdk.loginRedirect`
+  - Adds new methods in sdk browser scope:
+    - `sdk.signInWithCredentials`
+    - `sdk.signInWithRedirect`
     - `sdk.getUser`
     - `sdk.getIdToken`
     - `sdk.getAccessToken`
-    - `sdk.handleAuthentication`
+    - `sdk.parseAndStoreTokensFromUrl`
     - `sdk.setFromUri`
     - `sdk.getFromUri`
+  - Deprecates method in sdk browser scope:
+    - `sdk.signIn`
   - Adds new methods in `sdk.tokenManager`:
     - `tokenManager.getTokens`
     - `tokenManager.setTokens`
-  - Supports browser-based OpenID Connect flows in `sdk.signIn` method (browser bundle only).
-  - Accepts new custom callbacks [options](README.md#configuration-options)
-    - `isAuthenticated`
+  - Accepts new [options](README.md#configuration-options)
+    - `transformAuthState`
     - `autoRemove`
     - `devMode`
 - [#469](https://github.com/okta/okta-auth-js/pull/469) Adds "rate limiting" logic to token autoRenew process to prevent too many requests be sent out which may cause application rate limit issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
     - `sdk.getUser`
     - `sdk.getIdToken`
     - `sdk.getAccessToken`
-    - `sdk.parseAndStoreTokensFromUrl`
+    - `sdk.storeTokensFromRedirect`
     - `sdk.setFromUri`
     - `sdk.getFromUri`
   - Deprecates method in sdk browser scope:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     - `sdk.storeTokensFromRedirect`
     - `sdk.setFromUri`
     - `sdk.getFromUri`
+    - `sdk.removeFromUri`
   - Deprecates method in sdk browser scope:
     - `sdk.signIn`
   - Adds new methods in `sdk.tokenManager`:

--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ var config = {
 
 ### `signIn(options)`
 
-> :warning: This method will be deprecated in the next major release, use [signInWithCredentials](#signinwithcredentialsoptions) instead.
+> :warning: Deprecated, this method will be removed in next major release, use [signInWithCredentials](#signinwithcredentialsoptions) instead.
 > :hourglass: async
 
 The goal of this authentication flow is to [set an Okta session cookie on the user's browser](https://developer.okta.com/use_cases/authentication/session_cookie#retrieving-a-session-cookie-by-visiting-a-session-redirect-link) or [retrieve an `id_token` or `access_token`](https://developer.okta.com/use_cases/authentication/session_cookie#retrieving-a-session-cookie-via-openid-connect-authorization-endpoint). The flow is started using `signIn`.

--- a/README.md
+++ b/README.md
@@ -444,7 +444,9 @@ Callback function. By default, the SDK will consider a user authenticated if bot
 authClient.authStateManager.updateAuthState();
 ```
 
-This callback function receives the sdk instance as the first function parameter and [isPending](#authstatemanager) state as the second parameter.
+This callback function receives the sdk instance as the first function parameter and additionalParams object as the second parameter, which includes:
+
+* [isPending](#authstatemanager): pre-evaluated `authState.isPending` which is passed back from [authStateManager.updateAuthState](#authstatemanagerupdateauthstate).
 
 ##### `devMode`
 

--- a/README.md
+++ b/README.md
@@ -446,14 +446,6 @@ authClient.authStateManager.updateAuthState();
 
 This callback function receives the sdk instance as the first function parameter and [isPending](#authstatemanager) state as the second parameter.
 
-##### `onAuthRequired`
-
-> :warning: DO NOT trigger `authClient.signInWithRedirect()` in this callback. This callback is used inside the `signInWithRedirect` method, call it again will trigger the protection logic to end the function.
-
-Callback function. Called when authentication is required. When this callback is avaliable, the provided flow is executed as an alternative of the default redirect signIn flow.
-
-This callback function receives the sdk instance as the first function parameter.
-
 ##### `devMode`
 
 Default to `false`. It enables debugging logs when set to `true`.
@@ -634,7 +626,7 @@ Alias method of [signIn method](#signinoptions).
 
 ### `signInWithRedirect(options)`
 
-This method Calls `onAuthRequired` function if it was set on the initial configuration. Otherwise, it will start the default full-page redirect to Okta with [optional request parameters](#authorize-options). In this flow, there is a fromUri parameter in options to track the route before the user signIn, and the addtional params are mapped to the [Authorize options](#authorize-options).
+Starts the full-page redirect to Okta with [optional request parameters](#authorize-options). In this flow, there is a fromUri parameter in options to track the route before the user signIn, and the addtional params are mapped to the [Authorize options](#authorize-options).
 You can use [handleAuthentication method](#handleauthentication) to store tokens and clear the intermediate state (the fromUri) after successful authentication.
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -435,20 +435,16 @@ Defaults to `true`, unless the application origin is `http://localhost`, in whic
 
 Defaults to `none` if the `secure` option is `true`, or `lax` if the `secure` option is false. Allows fine-grained control over the same-site cookie setting. A value of `none` allows embedding within an iframe. A value of `lax` will avoid being blocked by user "3rd party" cookie settings. A value of `strict` will block all cookies when redirecting from Okta and is not recommended.
 
-##### `isAuthenticated`
+##### `transformAuthState`
 
-Callback function. By default, the SDK will consider a user authenticated if both valid idToken and accessToken are available from `tokenManager`. Setting a `isAuthenticated` function on the config will skip the default logic and call the supplied function instead. The function should return a Promise and resolve to either true or false. This callback is only evaluated when the `auth` code has reason to think the authentication state has changed, by default it's been triggered when token state changes.
+Callback function. By default, the SDK will consider a user authenticated if both valid idToken and accessToken are available from `tokenManager`. Setting a `transformAuthState` function on the config will emit a new transformed `authState` based on the evaludated authState from the default logic. The function should return a Promise and resolve to an [AuthState](#authstatemanager). This callback is only evaluated when the `auth` code has reason to think the authentication state has changed, by default it's been triggered when token state changes.
 
 ```javascript
 // Trigger a re-evaluation outside of the default token driven flow
 authClient.authStateManager.updateAuthState();
 ```
 
-This callback function receives the sdk instance as the first function parameter and evaluatedAuthState object as the second parameter, which includes:
-
-* [isPending]: evaluated [authState.isPending](#authstatemanager) from the current [updateAuthState](#authstatemanagerupdateauthstate) evaluation process.
-* [accessToken]: evaluated [authState.accessToken](#authstatemanager) from the current [updateAuthState](#authstatemanagerupdateauthstate) evaluation process.
-* [idToken]: evaluated [authState.idToken](#authstatemanager) from the current [updateAuthState](#authstatemanagerupdateauthstate) evaluation process.
+This callback function receives the sdk instance as the first function parameter and an [authState](#authstatemanager) object as the second parameter.
 
 ##### `devMode`
 

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ Callback function. By default, the SDK will consider a user authenticated if bot
 authClient.authStateManager.updateAuthState();
 ```
 
-This callback function receives the sdk instance as the first function parameter and additionalParams object as the second parameter, which includes:
+This callback function receives the sdk instance as the first function parameter and evaluatedAuthState object as the second parameter, which includes:
 
 * [isPending]: evaluated [authState.isPending](#authstatemanager) from the current [updateAuthState](#authstatemanagerupdateauthstate) evaluation process.
 * [accessToken]: evaluated [authState.accessToken](#authstatemanager) from the current [updateAuthState](#authstatemanagerupdateauthstate) evaluation process.

--- a/README.md
+++ b/README.md
@@ -651,6 +651,7 @@ if (authClient.token.isLoginRedirect()) {
   authClient.storeTokensFromRedirect();
   // Get and clear fromUri from storage
   const fromUri = authClient.getFromUri();
+  authClient.removeFromUri();
   // Redirect to fromUri
   history.replaceState(null, '', fromUri);
 } else if (!authClient.authStateManager.getAuthState().isAuthenticated) {

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ Defaults to `none` if the `secure` option is `true`, or `lax` if the `secure` op
 
 ##### `transformAuthState`
 
-Callback function. By default, the SDK will consider a user authenticated if both valid idToken and accessToken are available from `tokenManager`. Setting a `transformAuthState` function on the config will emit a new transformed `authState` based on the evaludated authState from the default logic. The function should return a Promise and resolve to an [AuthState](#authstatemanager). This callback is only evaluated when the `auth` code has reason to think the authentication state has changed, by default it's been triggered when token state changes.
+Callback function. By default, the SDK will consider a user authenticated if both valid idToken and accessToken are available from `tokenManager`. Setting a `transformAuthState` function on the config will emit a new transformed `authState` based on the evaluated authState from the default logic. The function should return a Promise and resolve to an [AuthState](#authstatemanager). This callback is only evaluated when the `auth` code has reason to think the authentication state has changed, by default it's been triggered when token state changes.
 
 ```javascript
 // Trigger a re-evaluation outside of the default token driven flow
@@ -544,7 +544,7 @@ var config = {
 * [getUser](#getuser)
 * [getIdToken](#getidtoken)
 * [getAccessToken](#getaccesstoken)
-* [parseAndStoreTokensFromUrl](#parseandstoretokensfromurl)
+* [storeTokensFromRedirect](#storetokensfromredirect)
 * [setFromUri](#setfromurifromuri)
 * [getFromUri](#getfromuri)
 * [tx.resume](#txresume)
@@ -628,12 +628,12 @@ authClient.signInWithCredentials({
 ### `signInWithRedirect(options)`
 
 Starts the full-page redirect to Okta with [optional request parameters](#authorize-options). In this flow, there is a fromUri parameter in options to track the route before the user signIn, and the addtional params are mapped to the [Authorize options](#authorize-options).
-You can use [parseAndStoreTokensFromUrl](#parseandstoretokensfromurl) to store tokens and [getFromUri](#getfromuri) to clear the intermediate state (the fromUri) after successful authentication.
+You can use [storeTokensFromRedirect](#storetokensfromredirect) to store tokens and [getFromUri](#getfromuri) to clear the intermediate state (the fromUri) after successful authentication.
 
 ```javascript
 if (authClient.token.isLoginRedirect()) {
   // Call handleAuthentication to store tokens when redirect back from OKTA
-  authClient.parseAndStoreTokensFromUrl();
+  authClient.storeTokensFromRedirect();
   // Get and clear fromUri from storage
   const fromUri = authClient.getFromUri();
   // Redirect to fromUri
@@ -871,7 +871,7 @@ Resolves with the id token string retrieved from storage if it exists. Devs shou
 
 Resolves with the access token string retrieved from storage if it exists. Devs should prefer to consult the synchronous results emitted from subscribing to the [authStateManager.subscribe](#authstatemanagersubscribehandler).
 
-### `parseAndStoreTokensFromUrl()`
+### `storeTokensFromRedirect()`
 
 > :hourglass: async
 

--- a/lib/AuthStateManager.ts
+++ b/lib/AuthStateManager.ts
@@ -131,7 +131,7 @@ class AuthStateManager {
             isPending = shouldEvaluateIsPending();
           }
           let promise = isAuthenticated 
-            ? isAuthenticated(this._sdk)
+            ? isAuthenticated(this._sdk, isPending)
             : Promise.resolve(!!(accessToken && idToken));
 
           promise

--- a/lib/AuthStateManager.ts
+++ b/lib/AuthStateManager.ts
@@ -1,6 +1,7 @@
 import { AuthSdkError } from './errors';
 import { AuthState, UpdateAuthStateOptions } from './types';
 import { OktaAuth } from './browser';
+import { getConsole, warn } from './util';
 const PCancelable = require('p-cancelable');
 
 export const DEFAULT_AUTH_STATE = { 
@@ -57,14 +58,22 @@ class AuthStateManager {
   }
 
   updateAuthState({ event, key, token }: UpdateAuthStateOptions = {}): void {
+    if (!this._sdk.emitter.e 
+        || !this._sdk.emitter.e[EVENT_AUTH_STATE_CHANGE] 
+        || !this._sdk.emitter.e[EVENT_AUTH_STATE_CHANGE].length) {
+      warn('updateAuthState is an asynchronous method with no return, ' + 
+        'please subscribe to the latest authState update with ' + 
+        'authStateManager.subscribe(handler) method before calling updateAuthState.');
+    }
+
     const { isAuthenticated, devMode } = this._sdk.options;
     const { autoRenew, autoRemove } = this._sdk.tokenManager._getOptions();
 
     const logger = (status) => {
-      console.group(`OKTA-AUTH-JS:updateAuthState: Event:${event} Status:${status}`);
-      console.log(key, token);
-      console.log('Current authState', this._authState);
-      console.groupEnd();
+      getConsole().group(`OKTA-AUTH-JS:updateAuthState: Event:${event} Status:${status}`);
+      getConsole().log(key, token);
+      getConsole().log('Current authState', this._authState);
+      getConsole().groupEnd();
     };
 
     const emitAuthStateChange = (authState) => {

--- a/lib/AuthStateManager.ts
+++ b/lib/AuthStateManager.ts
@@ -140,7 +140,7 @@ class AuthStateManager {
             isPending = shouldEvaluateIsPending();
           }
           let promise = isAuthenticated 
-            ? isAuthenticated(this._sdk, { isPending })
+            ? isAuthenticated(this._sdk, { isPending, accessToken, idToken })
             : Promise.resolve(!!(accessToken && idToken));
 
           promise

--- a/lib/AuthStateManager.ts
+++ b/lib/AuthStateManager.ts
@@ -140,7 +140,7 @@ class AuthStateManager {
             isPending = shouldEvaluateIsPending();
           }
           let promise = isAuthenticated 
-            ? isAuthenticated(this._sdk, isPending)
+            ? isAuthenticated(this._sdk, { isPending })
             : Promise.resolve(!!(accessToken && idToken));
 
           promise

--- a/lib/OktaAuthBase.ts
+++ b/lib/OktaAuthBase.ts
@@ -23,7 +23,6 @@ import {
   OktaAuth,
   OktaAuthOptions,
   SignInWithCredentialsOptions,
-  SigninWithRedirectOptions,
   ForgotPasswordOptions,
   VerifyRecoveryTokenOptions,
   TransactionAPI,
@@ -63,7 +62,7 @@ export default class OktaAuthBase implements OktaAuth, SigninAPI {
   }
 
   // { username, password, (relayState), (context) }
-  signIn(opts: SignInWithCredentialsOptions | SigninWithRedirectOptions): Promise<AuthTransaction> | Promise<void> {
+  signIn(opts: SignInWithCredentialsOptions): Promise<AuthTransaction> {
     return postToTransaction(this, '/api/v1/authn', opts);
   }
 

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -208,9 +208,9 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
     this.authStateManager = new AuthStateManager(this);
   }
 
-  // TODO: deprecate in 5.0
+  // TODO: This method is deprecated. Remove it in 5.0
   signIn(opts) {
-    deprecate('This method will be deprecated in v5.0, please use signInWithCredentials() instead.');
+    deprecate('This method has been deprecated, please use signInWithCredentials() instead.');
 
     opts = clone(opts || {});
     const _postToTransaction = (options?) => {
@@ -359,7 +359,7 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
   }
 
   //
-  // Common Methods from dowstream SDKs
+  // Common Methods from downstream SDKs
   //
 
   async getUser(): Promise<UserClaims> {

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -122,8 +122,7 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
       transformErrorXHR: args.transformErrorXHR,
       cookies: cookieSettings,
       scopes: args.scopes,
-      isAuthenticated: args.isAuthenticated,
-      onAuthRequired: args.onAuthRequired
+      isAuthenticated: args.isAuthenticated
     });
   
     this.userAgent = getUserAgent(args, `okta-auth-js/${SDK_VERSION}`);
@@ -243,12 +242,8 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
     }
 
     this._pending.handleLogin = true;
-    const { onAuthRequired, scopes, responseType } = this.options;
+    const { scopes, responseType } = this.options;
     try {
-      if (onAuthRequired) {
-        return await onAuthRequired(this);
-      }
-
       // Trigger default signIn redirect flow
       if (fromUri) {
         sessionStorage.setItem(REFERRER_PATH_STORAGE_KEY, fromUri);

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -389,7 +389,7 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
   /**
    * Store parsed tokens from redirect url
    */
-  async parseAndStoreTokensFromUrl(): Promise<void> {
+  async storeTokensFromRedirect(): Promise<void> {
     const { tokens } = await this.token.parseFromUrl();
     this.tokenManager.setTokens(tokens);
   }

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -210,7 +210,7 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
 
   // TODO: deprecate in 5.0
   signIn(opts) {
-    console.warn('AuthSdkWarn: this method will be deprecated in v5.0, please use signInWithCredentials() instead.');
+    console.warn('This method will be deprecated in v5.0, please use signInWithCredentials() instead.');
 
     opts = clone(opts || {});
     const _postToTransaction = (options?) => {
@@ -230,7 +230,9 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
     });
   }
 
-  // Alias method of signIn()
+  /**
+   * Alias method of signIn()
+   */ 
   signInWithCredentials(opts: SignInWithCredentialsOptions) {
     return this.signIn(opts);
   }
@@ -246,15 +248,15 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
     try {
       // Trigger default signIn redirect flow
       if (fromUri) {
-        sessionStorage.setItem(REFERRER_PATH_STORAGE_KEY, fromUri);
+        browserStorage.getSessionStorage().setItem(REFERRER_PATH_STORAGE_KEY, fromUri);
       }
       const params = Object.assign({
         scopes: scopes || ['openid', 'email', 'profile'],
         responseType: responseType || ['id_token', 'token']
       }, additionalParams);
-      return this.token.getWithRedirect(params);
+      await this.token.getWithRedirect(params);
     } finally {
-      this._pending.handleLogin = null;
+      this._pending.handleLogin = false;
     }
   }
   
@@ -388,8 +390,9 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
   async handleAuthentication(): Promise<string | null> {
     const { tokens } = await this.token.parseFromUrl();
     this.tokenManager.setTokens(tokens);
-    const fromUri = sessionStorage.getItem(REFERRER_PATH_STORAGE_KEY);
-    sessionStorage.removeItem(REFERRER_PATH_STORAGE_KEY);
+    const storage = browserStorage.getSessionStorage();
+    const fromUri = storage.getItem(REFERRER_PATH_STORAGE_KEY);
+    storage.removeItem(REFERRER_PATH_STORAGE_KEY);
     return fromUri;
   }
 }

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -18,7 +18,7 @@ import OktaAuthBase from '../OktaAuthBase';
 import * as features from './features';
 import fetchRequest from '../fetch/fetchRequest';
 import browserStorage from './browserStorage';
-import { removeTrailingSlash, toQueryString, clone, getUrlParts, warn, deprecate } from '../util';
+import { removeTrailingSlash, toQueryString, clone, warn, deprecate } from '../util';
 import { getUserAgent } from '../builderUtil';
 import { 
   DEFAULT_MAX_CLOCK_SKEW, 

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -122,7 +122,7 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
       transformErrorXHR: args.transformErrorXHR,
       cookies: cookieSettings,
       scopes: args.scopes,
-      isAuthenticated: args.isAuthenticated
+      transformAuthState: args.transformAuthState
     });
   
     this.userAgent = getUserAgent(args, `okta-auth-js/${SDK_VERSION}`);

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -18,7 +18,7 @@ import OktaAuthBase from '../OktaAuthBase';
 import * as features from './features';
 import fetchRequest from '../fetch/fetchRequest';
 import browserStorage from './browserStorage';
-import { removeTrailingSlash, toQueryString, clone, getUrlParts } from '../util';
+import { removeTrailingSlash, toQueryString, clone, getUrlParts, warn, deprecate } from '../util';
 import { getUserAgent } from '../builderUtil';
 import { 
   DEFAULT_MAX_CLOCK_SKEW, 
@@ -100,7 +100,7 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
     }
     if (cookieSettings.secure && !this.features.isHTTPS()) {
       // eslint-disable-next-line no-console
-      console.warn(
+      warn(
         'The current page is not being served with the HTTPS protocol.\n' +
         'For security reasons, we strongly recommend using HTTPS.\n' +
         'If you cannot use HTTPS, set "cookies.secure" option to false.'
@@ -210,7 +210,7 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
 
   // TODO: deprecate in 5.0
   signIn(opts) {
-    console.warn('This method will be deprecated in v5.0, please use signInWithCredentials() instead.');
+    deprecate('This method will be deprecated in v5.0, please use signInWithCredentials() instead.');
 
     opts = clone(opts || {});
     const _postToTransaction = (options?) => {

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -405,8 +405,12 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
   getFromUri(): string {
     const storage = browserStorage.getSessionStorage();
     const fromUri = storage.getItem(REFERRER_PATH_STORAGE_KEY) || window.location.origin;
-    storage.removeItem(REFERRER_PATH_STORAGE_KEY);
     return fromUri;
+  }
+
+  removeFromUri(): void {
+    const storage = browserStorage.getSessionStorage();
+    storage.removeItem(REFERRER_PATH_STORAGE_KEY);
   }
 }
 

--- a/lib/server/server.ts
+++ b/lib/server/server.ts
@@ -16,8 +16,6 @@ import OktaAuthBase from '../OktaAuthBase';
 import fetchRequest from '../fetch/fetchRequest';
 import { getUserAgent } from '../builderUtil';
 import serverStorage from './serverStorage';
-import { isSignInWithCredentialsOptions } from '../types';
-import { AuthSdkError } from '../errors';
 const PACKAGE_JSON = require('../../package.json');
 
 const SDK_VERSION = PACKAGE_JSON.version;
@@ -31,12 +29,5 @@ export default class OktaAuthNode extends OktaAuthBase {
     super(args);
 
     this.userAgent = getUserAgent(args, `okta-auth-js-server/${SDK_VERSION}`);
-  }
-
-  signIn(opts) {
-    if (!isSignInWithCredentialsOptions(opts)) {
-      throw new AuthSdkError('Invalid signinOptions are provided.');
-    }
-    return super.signIn(opts);
   }
 }

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -56,7 +56,7 @@ export interface OktaAuthOptions extends CustomUrls {
   transformErrorXHR?: (xhr: object) => any;
   headers?: object;
   maxClockSkew?: number;
-  isAuthenticated?: (oktaAuth: OktaAuth) => Promise<boolean>;
+  isAuthenticated?: (oktaAuth: OktaAuth, isPending: boolean) => Promise<boolean>;
   onAuthRequired?: (oktaAuth: OktaAuth) => void;
   devMode?: boolean; 
 }

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -38,7 +38,7 @@ export interface CustomUrls {
   logoutUrl?: string;
 }
 
-export interface IsAuthenticatedOptions {
+export interface IsAuthenticatedParams {
   isPending: boolean;
 }
 
@@ -60,6 +60,6 @@ export interface OktaAuthOptions extends CustomUrls {
   transformErrorXHR?: (xhr: object) => any;
   headers?: object;
   maxClockSkew?: number;
-  isAuthenticated?: (oktaAuth: OktaAuth, options: IsAuthenticatedOptions) => Promise<boolean>;
+  isAuthenticated?: (oktaAuth: OktaAuth, params: IsAuthenticatedParams) => Promise<boolean>;
   devMode?: boolean; 
 }

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -38,6 +38,10 @@ export interface CustomUrls {
   logoutUrl?: string;
 }
 
+export interface IsAuthenticatedOptions {
+  isPending: boolean;
+}
+
 export interface OktaAuthOptions extends CustomUrls {
   pkce?: boolean;
   clientId?: string;
@@ -56,6 +60,6 @@ export interface OktaAuthOptions extends CustomUrls {
   transformErrorXHR?: (xhr: object) => any;
   headers?: object;
   maxClockSkew?: number;
-  isAuthenticated?: (oktaAuth: OktaAuth, isPending: boolean) => Promise<boolean>;
+  isAuthenticated?: (oktaAuth: OktaAuth, options: IsAuthenticatedOptions) => Promise<boolean>;
   devMode?: boolean; 
 }

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -57,6 +57,5 @@ export interface OktaAuthOptions extends CustomUrls {
   headers?: object;
   maxClockSkew?: number;
   isAuthenticated?: (oktaAuth: OktaAuth, isPending: boolean) => Promise<boolean>;
-  onAuthRequired?: (oktaAuth: OktaAuth) => void;
   devMode?: boolean; 
 }

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -14,6 +14,7 @@ import { StorageUtil } from './Storage';
 import { CookieOptions } from './Cookies';
 import { HttpRequestClient } from './http';
 import { OktaAuth } from './';
+import { AccessToken, IDToken } from './Token';
 
 export interface TokenManagerOptions {
   autoRenew?: boolean;
@@ -40,6 +41,8 @@ export interface CustomUrls {
 
 export interface IsAuthenticatedParams {
   isPending: boolean;
+  accessToken: AccessToken;
+  idToken: IDToken;
 }
 
 export interface OktaAuthOptions extends CustomUrls {

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -14,7 +14,7 @@ import { StorageUtil } from './Storage';
 import { CookieOptions } from './Cookies';
 import { HttpRequestClient } from './http';
 import { OktaAuth } from './';
-import { AccessToken, IDToken } from './Token';
+import { AuthState } from './AuthState';
 
 export interface TokenManagerOptions {
   autoRenew?: boolean;
@@ -39,12 +39,6 @@ export interface CustomUrls {
   logoutUrl?: string;
 }
 
-export interface IsAuthenticatedParams {
-  isPending: boolean;
-  accessToken: AccessToken;
-  idToken: IDToken;
-}
-
 export interface OktaAuthOptions extends CustomUrls {
   pkce?: boolean;
   clientId?: string;
@@ -63,6 +57,6 @@ export interface OktaAuthOptions extends CustomUrls {
   transformErrorXHR?: (xhr: object) => any;
   headers?: object;
   maxClockSkew?: number;
-  isAuthenticated?: (oktaAuth: OktaAuth, params: IsAuthenticatedParams) => Promise<boolean>;
+  transformAuthState?: (oktaAuth: OktaAuth, authState: AuthState) => Promise<AuthState>;
   devMode?: boolean; 
 }

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -170,6 +170,7 @@ export interface SignInWithCredentialsOptions {
   password: string;
   relayState?: string;
   context?: string;
+  sendFingerprint?: boolean;
 }
 
 export function isSignInWithCredentialsOptions(obj: any): obj is SignInWithCredentialsOptions {

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -226,19 +226,22 @@ export function getConsole() {
     return nativeConsole;
   }
   return {
-    log: function() {}
+    log: function() {},
+    warn: function() {},
+    group: function() {},
+    groupEnd: function() {}
   };
 }
 
 export function warn(text) {
   /* eslint-disable no-console */
-  getConsole().log('[okta-auth-sdk] WARN: ' + text);
+  getConsole().warn('[okta-auth-sdk] WARN: ' + text);
   /* eslint-enable */
 }
 
 export function deprecate(text) {
   /* eslint-disable no-console */
-  getConsole().log('[okta-auth-sdk] DEPRECATION: ' + text);
+  getConsole().warn('[okta-auth-sdk] DEPRECATION: ' + text);
   /* eslint-enable */
 }
 

--- a/test/karma/spec/renewToken.js
+++ b/test/karma/spec/renewToken.js
@@ -185,7 +185,7 @@ describe('Renew token', function() {
       expect(url.pathname).toBe('/oauth2/v1/authorize');
       expect(url.searchParams.get('client_id')).toBe(CLIENT_ID);
       expect(url.searchParams.get('redirect_uri')).toBe(REDIRECT_URI);
-      expect(url.searchParams.get('response_type')).toBe('token');
+      expect(url.searchParams.get('response_type')).toBe('token id_token');
       expect(url.searchParams.get('response_mode')).toBe('okta_post_message');
       expect(url.searchParams.get('scope')).toBe('openid email');
       expect(url.searchParams.get('state')).toBeTruthy();
@@ -195,6 +195,7 @@ describe('Renew token', function() {
       const scope = url.searchParams.get('scope');
       var response = {
         access_token: ACCESS_TOKEN_STR,
+        id_token: ID_TOKEN_STR,
         expires_in: 3600,
         scope,
         state,
@@ -208,6 +209,7 @@ describe('Renew token', function() {
       window.dispatchEvent(event);
     });
     
+    mockNonce(NONCE);
     return bootstrap({
       pkce: false
     })

--- a/test/spec/AuthStateManager.js
+++ b/test/spec/AuthStateManager.js
@@ -81,6 +81,20 @@ describe('AuthStateManager', () => {
       sdkMock.tokenManager.hasExpired = jest.fn().mockReturnValue(false);
     });
 
+    it('should log console warning if no listener is registered for authStateChange', () => {
+      jest.spyOn(console, 'warn').mockReturnValue(null);
+      const instance = new AuthStateManager(sdkMock);
+      instance.updateAuthState();
+      expect(console.warn).toHaveBeenCalledWith('[okta-auth-sdk] WARN: updateAuthState is an asynchronous method with no return, please subscribe to the latest authState update with authStateManager.subscribe(handler) method before calling updateAuthState.');
+    });
+    it('should not log console warning if listener is registered for authStateChange', () => {
+      jest.spyOn(console, 'warn').mockReturnValue(null);
+      const instance = new AuthStateManager(sdkMock);
+      instance.subscribe(() => {});
+      instance.updateAuthState();
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
     it('should emit an authState with isAuthenticated === true', () => {
       expect.assertions(2);
       return new Promise(resolve => {

--- a/test/spec/AuthStateManager.js
+++ b/test/spec/AuthStateManager.js
@@ -168,8 +168,14 @@ describe('AuthStateManager', () => {
       });
     });
 
-    it('should evaluate authState.isAuthenticated based on "isAuthenticated" callback if it\'s provided', () => {
-      sdkMock.options.isAuthenticated = jest.fn().mockResolvedValue(false);
+    it('should evaluate authState based on "transformAuthState" callback if it\'s provided', () => {
+      const fakeAuthState = {
+        accessToken: 'fakeAccessToken0',
+        idToken: 'fakeIdToken0',
+        isAuthenticated: false,
+        isPending: false,
+      };
+      sdkMock.options.transformAuthState = jest.fn().mockResolvedValue(fakeAuthState);
       expect.assertions(3);
       return new Promise(resolve => {
         const instance = new AuthStateManager(sdkMock);
@@ -178,14 +184,9 @@ describe('AuthStateManager', () => {
         instance.subscribe(handler);
 
         setTimeout(() => {
-          expect(sdkMock.options.isAuthenticated).toHaveBeenCalledTimes(1);
+          expect(sdkMock.options.transformAuthState).toHaveBeenCalledTimes(1);
           expect(handler).toHaveBeenCalledTimes(1);
-          expect(handler).toHaveBeenCalledWith({
-            accessToken: 'fakeAccessToken0',
-            idToken: 'fakeIdToken0',
-            isAuthenticated: false,
-            isPending: false,
-          });
+          expect(handler).toHaveBeenCalledWith(fakeAuthState);
           resolve();
         }, 100);
       });
@@ -243,10 +244,17 @@ describe('AuthStateManager', () => {
       });
     });
 
-    it('should emit error in authState if isAuthenticated throws error', () => {
+    it('should emit error in authState if transformAuthState throws error', () => {
       expect.assertions(2);
       const error = new Error('fake error');
-      sdkMock.options.isAuthenticated = jest.fn().mockRejectedValue(error);
+      const fakeAuthState = {
+        accessToken: 'fakeAccessToken0',
+        idToken: 'fakeIdToken0',
+        isAuthenticated: false,
+        isPending: false,
+        error
+      };
+      sdkMock.options.transformAuthState = jest.fn().mockRejectedValue(error);
       return new Promise(resolve => {
         const instance = new AuthStateManager(sdkMock);
         instance.updateAuthState();
@@ -255,13 +263,7 @@ describe('AuthStateManager', () => {
 
         setTimeout(() => {
           expect(handler).toHaveBeenCalledTimes(1);
-          expect(handler).toHaveBeenCalledWith({
-            accessToken: 'fakeAccessToken0',
-            idToken: 'fakeIdToken0',
-            isAuthenticated: false,
-            isPending: false,
-            error
-          });
+          expect(handler).toHaveBeenCalledWith(fakeAuthState);
           resolve();
         }, 100);
       });

--- a/test/spec/browser.js
+++ b/test/spec/browser.js
@@ -113,13 +113,6 @@ describe('Browser', function() {
         expect(auth.loginRedirect).toHaveBeenCalled();
       });
   
-      it('calls onAuthRequired, if provided, instead of loginRedirect', async () => {
-        auth.options.onAuthRequired = jest.fn().mockResolvedValue();
-        await auth.signIn();
-        expect(auth.loginRedirect).not.toHaveBeenCalled();
-        expect(auth.options.onAuthRequired).toHaveBeenCalledWith(auth);
-      });
-  
       it('Calls setFromUri with fromUri, if provided', () => {
         const fromUri = 'notrandom';
         auth.signIn({ fromUri });

--- a/test/spec/browser.js
+++ b/test/spec/browser.js
@@ -70,7 +70,7 @@ describe('Browser', function() {
         
         // eslint-disable-next-line no-console
         expect(console.warn).toHaveBeenCalledWith(
-          'The current page is not being served with the HTTPS protocol.\n' +
+          '[okta-auth-sdk] WARN: The current page is not being served with the HTTPS protocol.\n' +
           'For security reasons, we strongly recommend using HTTPS.\n' +
           'If you cannot use HTTPS, set "cookies.secure" option to false.'
         );
@@ -111,7 +111,7 @@ describe('Browser', function() {
     it('should console warning for deprecation', async () => {
       jest.spyOn(console, 'warn').mockReturnValue(null);
       await auth.signIn(options);
-      expect(console.warn).toHaveBeenCalledWith('This method will be deprecated in v5.0, please use signInWithCredentials() instead.');
+      expect(console.warn).toHaveBeenCalledWith('[okta-auth-sdk] DEPRECATION: This method will be deprecated in v5.0, please use signInWithCredentials() instead.');
     });
     it('should call "/api/v1/authn" endpoint with default options', async () => {
       await auth.signIn(options);

--- a/test/spec/browser.js
+++ b/test/spec/browser.js
@@ -111,7 +111,7 @@ describe('Browser', function() {
     it('should console warning for deprecation', async () => {
       jest.spyOn(console, 'warn').mockReturnValue(null);
       await auth.signIn(options);
-      expect(console.warn).toHaveBeenCalledWith('[okta-auth-sdk] DEPRECATION: This method will be deprecated in v5.0, please use signInWithCredentials() instead.');
+      expect(console.warn).toHaveBeenCalledWith('[okta-auth-sdk] DEPRECATION: This method has been deprecated, please use signInWithCredentials() instead.');
     });
     it('should call "/api/v1/authn" endpoint with default options', async () => {
       await auth.signIn(options);

--- a/test/spec/browser.js
+++ b/test/spec/browser.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-new */
-/* global window, sessionStorage */
+/* global window */
 jest.mock('cross-fetch');
 jest.mock('../../lib/tx');
 
@@ -153,7 +153,7 @@ describe('Browser', function() {
     it('should add fromUri to sessionStorage if provided in options', async () => {
       const fromUri = 'notrandom';
       await auth.signInWithRedirect({ fromUri });
-      expect(setItemMock).toHaveBeenCalledWith('referrerPath', fromUri);
+      expect(setItemMock).toHaveBeenCalledWith(REFERRER_PATH_STORAGE_KEY, fromUri);
     });
 
     it('should not add fromUri to sessionStorage if no fromUri in options', async () => {

--- a/test/spec/browser.js
+++ b/test/spec/browser.js
@@ -629,16 +629,28 @@ describe('Browser', function() {
         removeItem: removeItemMock
       }));
     });
-    it('should get and cleare referrer from localStorage', () => {
+    it('should get and cleare referrer from storage', () => {
       const res = auth.getFromUri();
       expect(res).toBe('fakeFromUri');
-      expect(removeItemMock).toHaveBeenCalled();
     });
     it('returns window.location.origin if nothing was set', () => {
       getItemMock = jest.fn().mockReturnValue(null);
       const res = auth.getFromUri();
       expect(res).toBe(window.location.origin);
-      expect(removeItemMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('removeFromUri', () => {
+    let removeItemMock;
+    beforeEach(() => {
+      removeItemMock = jest.fn();
+      storageUtil.getSessionStorage = jest.fn().mockImplementation(() => ({
+        removeItem: removeItemMock
+      }));
+    });
+    it('should cleare referrer from localStorage', () => {
+      const res = auth.removeFromUri();
+      expect(removeItemMock).toHaveBeenCalledWith(REFERRER_PATH_STORAGE_KEY);
     });
   });
 });

--- a/test/spec/browser.js
+++ b/test/spec/browser.js
@@ -577,7 +577,7 @@ describe('Browser', function() {
     });
   });
 
-  describe('parseAndStoreTokensFromUrl', () => {
+  describe('storeTokensFromRedirect', () => {
     beforeEach(() => {
       auth.token.parseFromUrl = jest.fn().mockResolvedValue({ 
         tokens: { idToken: 'fakeIdToken', accessToken: 'fakeAccessToken' }
@@ -585,7 +585,7 @@ describe('Browser', function() {
       auth.tokenManager.setTokens = jest.fn();
     });
     it('calls parseFromUrl', async () => {
-      await auth.parseAndStoreTokensFromUrl();
+      await auth.storeTokensFromRedirect();
       expect(auth.token.parseFromUrl).toHaveBeenCalled();
     });
     it('stores tokens', async () => {
@@ -594,7 +594,7 @@ describe('Browser', function() {
       auth.token.parseFromUrl = jest.fn().mockResolvedValue({ 
         tokens: { accessToken, idToken }
       });
-      await auth.parseAndStoreTokensFromUrl();
+      await auth.storeTokensFromRedirect();
       expect(auth.tokenManager.setTokens).toHaveBeenCalledWith({ accessToken, idToken });
     });
   });

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -186,10 +186,10 @@ describe('TokenManager', function() {
       });
     });
     it('defaults to sessionStorage if localStorage isn\'t available', function() {
-      jest.spyOn(window.console, 'log');
+      jest.spyOn(window.console, 'warn');
       oauthUtil.mockLocalStorageError();
       setupSync();
-      expect(window.console.log).toHaveBeenCalledWith(
+      expect(window.console.warn).toHaveBeenCalledWith(
         '[okta-auth-sdk] WARN: This browser doesn\'t ' +
         'support localStorage. Switching to sessionStorage.'
       );
@@ -199,10 +199,10 @@ describe('TokenManager', function() {
       });
     });
     it('defaults to sessionStorage if localStorage cannot be written to', function() {
-      jest.spyOn(window.console, 'log');
+      jest.spyOn(window.console, 'warn');
       oauthUtil.mockStorageSetItemError();
       setupSync();
-      expect(window.console.log).toHaveBeenCalledWith(
+      expect(window.console.warn).toHaveBeenCalledWith(
         '[okta-auth-sdk] WARN: This browser doesn\'t ' +
         'support localStorage. Switching to sessionStorage.'
       );
@@ -212,11 +212,11 @@ describe('TokenManager', function() {
       });
     });
     it('defaults to cookie-based storage if localStorage and sessionStorage are not available', function() {
-      jest.spyOn(window.console, 'log');
+      jest.spyOn(window.console, 'warn');
       oauthUtil.mockLocalStorageError();
       oauthUtil.mockSessionStorageError();
       setupSync();
-      expect(window.console.log).toHaveBeenCalledWith(
+      expect(window.console.warn).toHaveBeenCalledWith(
         '[okta-auth-sdk] WARN: This browser doesn\'t ' +
         'support sessionStorage. Switching to cookie-based storage.'
       );
@@ -230,7 +230,7 @@ describe('TokenManager', function() {
       );
     });
     it('defaults to cookie-based storage if sessionStorage cannot be written to', function() {
-      jest.spyOn(window.console, 'log');
+      jest.spyOn(window.console, 'warn');
       oauthUtil.mockLocalStorageError();
       oauthUtil.mockStorageSetItemError();
       setupSync({
@@ -238,7 +238,7 @@ describe('TokenManager', function() {
           storage: 'sessionStorage'
         }
       });
-      expect(window.console.log).toHaveBeenCalledWith(
+      expect(window.console.warn).toHaveBeenCalledWith(
         '[okta-auth-sdk] WARN: This browser doesn\'t ' +
         'support sessionStorage. Switching to cookie-based storage.'
       );

--- a/test/spec/util.js
+++ b/test/spec/util.js
@@ -4,19 +4,20 @@ import * as util from '../../lib/util';
 describe('util', function() {
   beforeEach(function() {
     jest.spyOn(window.console, 'log');
+    jest.spyOn(window.console, 'warn');
   });
 
   describe('warn', function() {
     it('writes warning to console', function() {
       util.warn('sample warning');
-      expect(window.console.log).toHaveBeenCalledWith('[okta-auth-sdk] WARN: sample warning');
+      expect(window.console.warn).toHaveBeenCalledWith('[okta-auth-sdk] WARN: sample warning');
     });
   });
 
   describe('deprecate', function() {
     it('writes deprecation to console', function() {
       util.deprecate('sample deprecation');
-      expect(window.console.log).toHaveBeenCalledWith('[okta-auth-sdk] DEPRECATION: sample deprecation');
+      expect(window.console.warn).toHaveBeenCalledWith('[okta-auth-sdk] DEPRECATION: sample deprecation');
     });
   });
 


### PR DESCRIPTION
This PR changes public methods based on `dev-4.1`, the changes include:
- keeps `signIn` for signIn with credential only, and mark this method with deprecate soon.
- adds new alias method `signInWithCredential` as future replacement of `signIn`
- adds new method `signInWithRedirect` for browser redirect signIn flow
- removes `onAuthRequired` callback as there is no callback logic for it in authJs internal flow, move to downstream SDKs to handle
- removes `setFromUri` and `getFromUri` and internal relative <-> absolute uri transform logic, since without proper baseUri, the logic is error prone, users should be able to get whatever they set.
- removes and resolves `fromUri` (if has been set) in `handleAuthentication`