### PR TITLE
fixes issue with oauth params cookie

### DIFF
--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -711,14 +711,15 @@ function removeSearch(sdk) {
 }
 
 function getOAuthParamsStrFromStorage() {
-  let oauthParamsStr;
-  if (browserStorage.browserHasSessionStorage()) {
+  // try to read OAuth params from cookie first. This is for backward compatibility
+  let oauthParamsStr = cookies.get(constants.REDIRECT_OAUTH_PARAMS_NAME);
+  cookies.delete(constants.REDIRECT_OAUTH_PARAMS_NAME);
+
+  // latest version of auth-js will store params in session storage
+  if (!oauthParamsStr && browserStorage.browserHasSessionStorage()) {
     const storage = browserStorage.getSessionStorage();
     oauthParamsStr = storage.getItem(constants.REDIRECT_OAUTH_PARAMS_NAME);
     storage.removeItem(constants.REDIRECT_OAUTH_PARAMS_NAME);
-  } else {
-    oauthParamsStr = cookies.get(constants.REDIRECT_OAUTH_PARAMS_NAME);
-    cookies.delete(constants.REDIRECT_OAUTH_PARAMS_NAME);
   }
   return oauthParamsStr;
 }

--- a/test/app/src/testApp.js
+++ b/test/app/src/testApp.js
@@ -179,6 +179,7 @@ Object.assign(TestApp.prototype, {
     this._afterRender('with-error');
   },
   loginWidget: function() {
+    saveConfigToStorage(this.config);
     document.getElementById('modal').style.display = 'block';
     var config = window.getWidgetConfig();
 

--- a/test/app/src/webpackEntry.js
+++ b/test/app/src/webpackEntry.js
@@ -35,7 +35,8 @@ window.getWidgetConfig = function() {
     baseUrl: config.issuer.split('/oauth2')[0],
     el: '#widget',
     authParams: {
-      display: 'page'
+      display: 'page',
+      pkce: config.pkce
     }
   });
   return siwConfig;

--- a/test/e2e/pageobjects/TestApp.js
+++ b/test/e2e/pageobjects/TestApp.js
@@ -24,6 +24,7 @@ class TestApp {
   get tokenMsg() { return $('#token-msg'); }
   
   // Unauthenticated landing
+  get loginWidgetBtn() { return $('#login-widget'); }
   get loginRedirectBtn() { return $('#login-redirect'); }
   get loginPopupBtn() { return $('#login-popup'); }
   get loginDirectBtn() { return $('#login-direct'); }
@@ -54,6 +55,11 @@ class TestApp {
   async open(queryObj) {
     await browser.url(toQueryParams(queryObj));
     await browser.waitUntil(async () => this.readySelector.then(el => el.isExisting()), 5000, 'wait for ready selector');
+  }
+
+  async showLoginWidget() {
+    await this.waitForLoginBtn();
+    await this.loginWidgetBtn.then(el => el.click());
   }
 
   async loginRedirect() {

--- a/test/e2e/specs/login.js
+++ b/test/e2e/specs/login.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import TestApp from '../pageobjects/TestApp';
 import { flows, openImplicit, openPKCE } from '../util/appUtils';
-import { loginRedirect, loginPopup, loginDirect } from '../util/loginUtils';
+import { loginWidget, loginRedirect, loginPopup, loginDirect } from '../util/loginUtils';
 
 describe('E2E login', () => {
 
@@ -21,6 +21,13 @@ describe('E2E login', () => {
     describe(flow + ' flow', () => {
       beforeEach(async () => {
         (flow === 'pkce') ? await openPKCE() : await openImplicit();
+      });
+
+      it('can login using signin widget', async () => {
+        await loginWidget(flow);
+        await TestApp.getUserInfo();
+        await TestApp.assertUserInfo();
+        await TestApp.logoutRedirect();
       });
 
       it('can login using redirect', async () => {

--- a/test/e2e/util/loginUtils.js
+++ b/test/e2e/util/loginUtils.js
@@ -48,4 +48,11 @@ async function loginDirect(flow) {
   await TestApp.loginDirect();
   return handleCallback(flow);
 }
-export { loginDirect, loginPopup, loginRedirect };
+
+async function loginWidget(flow) {
+  await TestApp.showLoginWidget();
+  await OktaLogin.signin(USERNAME, PASSWORD);
+  return handleCallback(flow);
+}
+
+export { loginWidget, loginDirect, loginPopup, loginRedirect };


### PR DESCRIPTION
- maintains compatibility with older widget / authJS versions by reading from cookie before sessionStorage
- adds E2E tests for siginin widget (problem was reproduced using this test before fix was added)

This PR is for 3.2 branch. Change will be cherry-picked and added to a PR for 4.0 branch