### PR TITLE
fix: export naming conflict

### DIFF
--- a/lib/browser/index.ts
+++ b/lib/browser/index.ts
@@ -11,9 +11,11 @@
  *
  */
 
-export { default as OktaAuth } from './browser';
 export * from '../constants';
 export * from '../types';
 export * from '../tx';
 export * from '../errors';
 export * from '../TokenManager';
+
+// Keep the OktaAuth at the bottom of export to prevent from export name overriding
+export { default as OktaAuth } from './browser';


### PR DESCRIPTION
Fixes Travis error
```
$ /home/travis/build/okta/okta-auth-js/node_modules/.bin/tsc --noEmit
src/testApp.ts(220,6): error TS2349: This expression is not callable.
  Each member of the union type '(<TResult1 = void, TResult2 = never>(onfulfilled?: (value: void) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<...>) | (<TResult1 = AuthTransaction, TResult2 = never>(onfulfilled?: (value: AuthTransaction) => TResult1 | PromiseLike<...>, onrejected?: ...' has signatures, but none of those signatures are compatible with each other.
error Command failed with exit code 1.
```