### PR TITLE
Sw fix oauth params 3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 dist
 target
 node_modules
+build
 build2
+samples
 test/SpecRunner.html
 npm-debug.log
 testenv

--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -618,7 +618,7 @@ function prepareOauthParams(sdk, options) {
     });
 }
 
-function addOAuthParamsToStorage(sdk, tokenParams, urls) {
+function _addOAuthParamsToStorage(sdk, tokenParams, urls) {
   const { responseType, state, nonce, scopes, clientId, ignoreSignature } = tokenParams;
   const tokenParamsStr = JSON.stringify({
     responseType,
@@ -629,10 +629,10 @@ function addOAuthParamsToStorage(sdk, tokenParams, urls) {
     urls,
     ignoreSignature
   });
+  // Add oauth_params to both cookies and sessionStorage for broader support
+  cookies.set(constants.REDIRECT_OAUTH_PARAMS_NAME, tokenParamsStr, null, sdk.options.cookies);
   if (browserStorage.browserHasSessionStorage()) {
     browserStorage.getSessionStorage().setItem(constants.REDIRECT_OAUTH_PARAMS_NAME, tokenParamsStr);
-  } else {
-    cookies.set(constants.REDIRECT_OAUTH_PARAMS_NAME, tokenParamsStr, null, sdk.options.cookies);
   }
 }
 
@@ -647,7 +647,7 @@ function getWithRedirect(sdk, options) {
       var urls = oauthUtil.getOAuthUrls(sdk, options);
       var requestUrl = urls.authorizeUrl + buildAuthorizeParams(oauthParams);
 
-      addOAuthParamsToStorage(sdk, oauthParams, urls);
+      _addOAuthParamsToStorage(sdk, tokenParams, urls);
 
       // Set nonce cookie for servers to validate nonce in id_token
       cookies.set(constants.REDIRECT_NONCE_COOKIE_NAME, oauthParams.nonce, null, sdk.options.cookies);
@@ -710,7 +710,7 @@ function removeSearch(sdk) {
   }
 }
 
-function getOAuthParamsStrFromStorage() {
+function _getOAuthParamsStrFromStorage() {
   // try to read OAuth params from cookie first. This is for backward compatibility
   let oauthParamsStr = cookies.get(constants.REDIRECT_OAUTH_PARAMS_NAME);
   cookies.delete(constants.REDIRECT_OAUTH_PARAMS_NAME);
@@ -721,6 +721,7 @@ function getOAuthParamsStrFromStorage() {
     oauthParamsStr = storage.getItem(constants.REDIRECT_OAUTH_PARAMS_NAME);
     storage.removeItem(constants.REDIRECT_OAUTH_PARAMS_NAME);
   }
+
   return oauthParamsStr;
 }
 
@@ -748,7 +749,7 @@ function parseFromUrl(sdk, options) {
     return Promise.reject(new AuthSdkError('Unable to parse a token from the url'));
   }
 
-  const oauthParamsStr = getOAuthParamsStrFromStorage();  
+  const oauthParamsStr = _getOAuthParamsStrFromStorage();  
   if (!oauthParamsStr) {
     return Promise.reject(new AuthSdkError('Unable to retrieve OAuth redirect params from storage'));
   }
@@ -837,5 +838,7 @@ module.exports = {
   getUserInfo: getUserInfo,
   verifyToken: verifyToken,
   handleOAuthResponse: handleOAuthResponse,
-  prepareOauthParams: prepareOauthParams
+  prepareOauthParams: prepareOauthParams,
+  _addOAuthParamsToStorage, // export for testing purpose
+  _getOAuthParamsStrFromStorage // export for testing purpose
 };

--- a/packages/okta-auth-js/lib/token.js
+++ b/packages/okta-auth-js/lib/token.js
@@ -647,7 +647,7 @@ function getWithRedirect(sdk, options) {
       var urls = oauthUtil.getOAuthUrls(sdk, options);
       var requestUrl = urls.authorizeUrl + buildAuthorizeParams(oauthParams);
 
-      _addOAuthParamsToStorage(sdk, tokenParams, urls);
+      _addOAuthParamsToStorage(sdk, oauthParams, urls);
 
       // Set nonce cookie for servers to validate nonce in id_token
       cookies.set(constants.REDIRECT_NONCE_COOKIE_NAME, oauthParams.nonce, null, sdk.options.cookies);

--- a/packages/okta-auth-js/test/spec/.eslintrc.json
+++ b/packages/okta-auth-js/test/spec/.eslintrc.json
@@ -15,7 +15,7 @@
   },
   "parserOptions": {
     "sourceType": "module",
-    "ecmaVersion": 2017
+    "ecmaVersion": 2018
   },
   "rules": {
     "jasmine/no-unsafe-spy": 0,

--- a/packages/okta-auth-js/test/spec/token.js
+++ b/packages/okta-auth-js/test/spec/token.js
@@ -14,6 +14,7 @@ var sdkUtil = require('../../lib/oauthUtil');
 var pkce = require('../../lib/pkce');
 var http = require('../../lib/http');
 var sdkCrypto = require('../../lib/crypto');
+var token = require('../../lib/token');
 var AuthSdkError = require('../../lib/errors/AuthSdkError');
 
 function setupSync(options) {
@@ -3269,6 +3270,107 @@ describe('token.verify', function() {
     it('expired before issued', function() {
       return expectError([tokens.expiredBeforeIssuedIdTokenParsed, validationParams],
         'The JWT expired before it was issued');
+    });
+  });
+});
+
+describe('token._addOAuthParamsToStorage', () => {
+  let sdkMock;
+  let setCookieMock;
+  let sessionStorageSetItemMock;
+  let fakeTokenParams;
+  let fakeUrls;
+  beforeEach(() => {
+    sdkMock = {
+      options: { cookies: { secure: true, sameSite: 'none' } }
+    };
+    setCookieMock = util.mockSetCookie();
+    sessionStorageSetItemMock = jest.fn();
+    fakeTokenParams = { responseType: 'fake response type' };
+    fakeUrls = ['http://fake.com'];
+  });
+
+  it('should store in both cookies and sessionStorage when sessionStorage is available', () => {
+    util.mockSessionStorage({
+      enabled: true,
+      setItemMock: sessionStorageSetItemMock
+    });
+    token._addOAuthParamsToStorage(sdkMock, fakeTokenParams, fakeUrls);
+    const expectedParamStr = JSON.stringify({ ...fakeTokenParams, urls: fakeUrls });
+    expect(setCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params', expectedParamStr, null, { secure: true, sameSite: 'none' });
+    expect(sessionStorageSetItemMock).toHaveBeenCalledWith('okta-oauth-redirect-params', expectedParamStr);
+  });
+
+  it('should only  store in cookies when sessionStorage is not available', () => {
+    util.mockSessionStorage({
+      enabled: false,
+      setItemMock: sessionStorageSetItemMock
+    });
+    token._addOAuthParamsToStorage(sdkMock, fakeTokenParams, fakeUrls);
+    const expectedParamStr = JSON.stringify({ ...fakeTokenParams, urls: fakeUrls });
+    expect(setCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params', expectedParamStr, null, { secure: true, sameSite: 'none' });
+    expect(sessionStorageSetItemMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('token._getOAuthParamsStrFromStorage', () => {
+  let fakeParams;
+  let getCookieMock;
+  let deleteCookieMock;
+  let sessionStorageGetItemMock;
+  let sessionStorageRemoveItemMock;
+  beforeEach(() => {
+    fakeParams = { fake: 'fake' };
+    getCookieMock = util.mockGetCookie(JSON.stringify(fakeParams));
+    deleteCookieMock = util.mockDeleteCookie();
+    sessionStorageRemoveItemMock = jest.fn();
+  });
+
+  describe('has sessionStorage', () => {
+    it('should read from sessionStorage and clear both storages', () => {
+      sessionStorageGetItemMock = jest.fn().mockReturnValue(JSON.stringify(fakeParams));
+      util.mockSessionStorage({
+        enabled: true,
+        getItemMock: sessionStorageGetItemMock,
+        removeItemMock: sessionStorageRemoveItemMock
+      });
+      const paramsStr = token._getOAuthParamsStrFromStorage();
+      expect(sessionStorageGetItemMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
+      expect(sessionStorageRemoveItemMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
+      expect(getCookieMock).not.toHaveBeenCalled();
+      expect(deleteCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
+      expect(paramsStr).toEqual(JSON.stringify(fakeParams));
+    });
+    it('should read from cookies and clear both storages when no data in sessinStorage', () => {
+      sessionStorageGetItemMock = jest.fn().mockReturnValue(undefined);
+      util.mockSessionStorage({
+        enabled: true,
+        getItemMock: sessionStorageGetItemMock,
+        removeItemMock: sessionStorageRemoveItemMock
+      });
+      const paramsStr = token._getOAuthParamsStrFromStorage();
+      expect(sessionStorageGetItemMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
+      expect(sessionStorageRemoveItemMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
+      expect(getCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
+      expect(deleteCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
+      expect(paramsStr).toEqual(JSON.stringify(fakeParams));
+    });
+  });
+
+  describe('not has sessionStorage', () => {
+    it('should read from cookies and clear cookies', () => {
+      sessionStorageGetItemMock = jest.fn();
+      util.mockSessionStorage({
+        enabled: false,
+        getItemMock: sessionStorageGetItemMock,
+        removeItemMock: sessionStorageRemoveItemMock
+      });
+      const paramsStr = token._getOAuthParamsStrFromStorage();
+      expect(sessionStorageGetItemMock).not.toHaveBeenCalled();
+      expect(sessionStorageRemoveItemMock).not.toHaveBeenCalled();
+      expect(getCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
+      expect(deleteCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
+      expect(paramsStr).toEqual(JSON.stringify(fakeParams));
     });
   });
 });

--- a/packages/okta-auth-js/test/spec/token.js
+++ b/packages/okta-auth-js/test/spec/token.js
@@ -3348,7 +3348,7 @@ describe('token._getOAuthParamsStrFromStorage', () => {
     it('should read from sessionStorage and clear both storages when no data in cookies', () => {
       getCookieMock = util.mockGetCookie('');
       deleteCookieMock = util.mockDeleteCookie();
-      const paramsStr = token._getOAuthParamsStrFromStorage();
+      token._getOAuthParamsStrFromStorage();
       expect(getCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
       expect(deleteCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
       expect(sessionStorageGetItemMock).toHaveBeenCalledWith('okta-oauth-redirect-params');

--- a/packages/okta-auth-js/test/spec/token.js
+++ b/packages/okta-auth-js/test/spec/token.js
@@ -3321,55 +3321,55 @@ describe('token._getOAuthParamsStrFromStorage', () => {
   let sessionStorageRemoveItemMock;
   beforeEach(() => {
     fakeParams = { fake: 'fake' };
-    getCookieMock = util.mockGetCookie(JSON.stringify(fakeParams));
-    deleteCookieMock = util.mockDeleteCookie();
+    sessionStorageGetItemMock = jest.fn();
     sessionStorageRemoveItemMock = jest.fn();
+    util.mockSessionStorage({
+      enabled: true,
+      getItemMock: sessionStorageGetItemMock,
+      removeItemMock: sessionStorageRemoveItemMock
+    });
+  });
+  afterEach(() => {
+    getCookieMock = null;
+    deleteCookieMock = null;
   });
 
   describe('has sessionStorage', () => {
-    it('should read from sessionStorage and clear both storages', () => {
-      sessionStorageGetItemMock = jest.fn().mockReturnValue(JSON.stringify(fakeParams));
-      util.mockSessionStorage({
-        enabled: true,
-        getItemMock: sessionStorageGetItemMock,
-        removeItemMock: sessionStorageRemoveItemMock
-      });
+    it('should read from cookies and clear cookies storages', () => {
+      getCookieMock = util.mockGetCookie(JSON.stringify(fakeParams));
+      deleteCookieMock = util.mockDeleteCookie();
       const paramsStr = token._getOAuthParamsStrFromStorage();
-      expect(sessionStorageGetItemMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
-      expect(sessionStorageRemoveItemMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
-      expect(getCookieMock).not.toHaveBeenCalled();
+      expect(getCookieMock).toHaveBeenCalled();
       expect(deleteCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
+      expect(sessionStorageGetItemMock).not.toHaveBeenCalled();
+      expect(sessionStorageRemoveItemMock).not.toHaveBeenCalled();
       expect(paramsStr).toEqual(JSON.stringify(fakeParams));
     });
-    it('should read from cookies and clear both storages when no data in sessinStorage', () => {
-      sessionStorageGetItemMock = jest.fn().mockReturnValue(undefined);
-      util.mockSessionStorage({
-        enabled: true,
-        getItemMock: sessionStorageGetItemMock,
-        removeItemMock: sessionStorageRemoveItemMock
-      });
+    it('should read from sessionStorage and clear both storages when no data in cookies', () => {
+      getCookieMock = util.mockGetCookie('');
+      deleteCookieMock = util.mockDeleteCookie();
       const paramsStr = token._getOAuthParamsStrFromStorage();
-      expect(sessionStorageGetItemMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
-      expect(sessionStorageRemoveItemMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
       expect(getCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
       expect(deleteCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
-      expect(paramsStr).toEqual(JSON.stringify(fakeParams));
+      expect(sessionStorageGetItemMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
+      expect(sessionStorageRemoveItemMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
     });
   });
 
   describe('not has sessionStorage', () => {
     it('should read from cookies and clear cookies', () => {
-      sessionStorageGetItemMock = jest.fn();
+      getCookieMock = util.mockGetCookie(JSON.stringify(fakeParams));
+      deleteCookieMock = util.mockDeleteCookie();
       util.mockSessionStorage({
         enabled: false,
         getItemMock: sessionStorageGetItemMock,
         removeItemMock: sessionStorageRemoveItemMock
       });
       const paramsStr = token._getOAuthParamsStrFromStorage();
-      expect(sessionStorageGetItemMock).not.toHaveBeenCalled();
-      expect(sessionStorageRemoveItemMock).not.toHaveBeenCalled();
       expect(getCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
       expect(deleteCookieMock).toHaveBeenCalledWith('okta-oauth-redirect-params');
+      expect(sessionStorageGetItemMock).not.toHaveBeenCalled();
+      expect(sessionStorageRemoveItemMock).not.toHaveBeenCalled();
       expect(paramsStr).toEqual(JSON.stringify(fakeParams));
     });
   });

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -20,7 +20,7 @@
     "@wdio/mocha-framework": "^6.4.0",
     "@wdio/sauce-service": "^6.4.0",
     "@wdio/spec-reporter": "^5.15.1",
-    "chromedriver": "^84.0.1",
+    "chromedriver": "^85.0.0",
     "eslint": "5.6.1",
     "eslint-plugin-jasmine": "^2.10.1",
     "wait-on": "^3.3.0",

--- a/test/support/oauthUtil.js
+++ b/test/support/oauthUtil.js
@@ -448,12 +448,14 @@ oauthUtil.setupParseUrl = function(opts) {
   util.mockGetCookie(opts.oauthParams);
   var deleteCookieMock = util.mockDeleteCookie();
 
-  storageUtil.getSessionStorage = jest.fn().mockReturnValue({
-    getItem: jest.fn().mockReturnValue(opts.oauthParams || ''),
-    removeItem: jest.fn()
-  });
-  storageUtil.browserHasSessionStorage = jest.fn().mockReturnValue(!!opts.hasSessionStorage);
-
+  jest.spyOn(storageUtil, 'getSessionStorage')
+    .mockImplementation(() => ({
+      getItem: jest.fn().mockReturnValue(opts.oauthParams || ''),
+      removeItem: jest.fn()
+    }));
+  jest.spyOn(storageUtil, 'browserHasSessionStorage')
+    .mockImplementation(() => !!opts.hasSessionStorage);
+  
   return client.token.parseFromUrl(opts.parseFromUrlArgs)
     .then(function(res) {
       var expectedResp = opts.expectedResp;

--- a/test/support/oauthUtil.js
+++ b/test/support/oauthUtil.js
@@ -449,12 +449,16 @@ oauthUtil.setupParseUrl = function(opts) {
   var deleteCookieMock = util.mockDeleteCookie();
 
   jest.spyOn(storageUtil, 'getSessionStorage')
-    .mockImplementation(() => ({
-      getItem: jest.fn().mockReturnValue(opts.oauthParams || ''),
-      removeItem: jest.fn()
-    }));
+    .mockImplementation(function() {
+      return {
+        getItem: jest.fn().mockReturnValue(opts.oauthParams || ''),
+        removeItem: jest.fn()
+      };
+    });
   jest.spyOn(storageUtil, 'browserHasSessionStorage')
-    .mockImplementation(() => !!opts.hasSessionStorage);
+    .mockImplementation(function() {
+      return !!opts.hasSessionStorage;
+    });
   
   return client.token.parseFromUrl(opts.parseFromUrlArgs)
     .then(function(res) {

--- a/test/support/util.js
+++ b/test/support/util.js
@@ -3,8 +3,9 @@
 
 var _ = require('lodash'),
     OktaAuth = require('OktaAuth'),
-    cookies = require('@okta/okta-auth-js/lib/browser/browserStorage').storage,
-    fetch = require('cross-fetch');
+    browserStorage = require('@okta/okta-auth-js/lib/browser/browserStorage'),
+    fetch = require('cross-fetch'),
+    cookies = browserStorage.storage;
 
 var util = {};
 

--- a/test/support/util.js
+++ b/test/support/util.js
@@ -356,6 +356,17 @@ util.mockUserAgent = function (client, mockUserAgent) {
   jest.spyOn(client.fingerprint, '_getUserAgent').mockReturnValue(mockUserAgent);
 };
 
+util.mockSessionStorage = function ({ enabled, getItemMock, setItemMock, removeItemMock }) {
+  jest.spyOn(browserStorage, 'browserHasSessionStorage')
+    .mockImplementation(() => !!enabled);
+  jest.spyOn(browserStorage, 'getSessionStorage')
+    .mockImplementation(() => ({
+      setItem: setItemMock,
+      getItem: getItemMock,
+      removeItem: removeItemMock
+    }));
+};
+
 util.expectErrorToEqual = function (actual, expected) {
   expect(actual.name).toEqual(expected.name);
   expect(actual.message).toEqual(expected.message);

--- a/test/support/util.js
+++ b/test/support/util.js
@@ -357,15 +357,19 @@ util.mockUserAgent = function (client, mockUserAgent) {
   jest.spyOn(client.fingerprint, '_getUserAgent').mockReturnValue(mockUserAgent);
 };
 
-util.mockSessionStorage = function ({ enabled, getItemMock, setItemMock, removeItemMock }) {
+util.mockSessionStorage = function (opts) {
   jest.spyOn(browserStorage, 'browserHasSessionStorage')
-    .mockImplementation(() => !!enabled);
+    .mockImplementation(function() { 
+      return !!opts.enabled;
+    });
   jest.spyOn(browserStorage, 'getSessionStorage')
-    .mockImplementation(() => ({
-      setItem: setItemMock,
-      getItem: getItemMock,
-      removeItem: removeItemMock
-    }));
+    .mockImplementation(function() {
+      return {
+        setItem: opts.setItemMock,
+        getItem: opts.getItemMock,
+        removeItem: opts.removeItemMock
+      };
+    });
 };
 
 util.expectErrorToEqual = function (actual, expected) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2942,10 +2942,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^84.0.1:
-  version "84.0.1"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-84.0.1.tgz#eaca7723f1a58c262a5c521b8596769af40b0d4f"
-  integrity sha512-iJ6Y680yp58+KlAPS5YgYe3oePVFf8jY5k4YoczhXkT0p/mQZKfGNkGG/Xc0LjGWDQRTgZwXg66hOXoApIQecg==
+chromedriver@^85.0.0:
+  version "85.0.1"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-85.0.1.tgz#2e1b571845253368fcd112108f23eb9c778f7982"
+  integrity sha512-z8je3U4tXFZnx7AloRabM4Ep1lpFJvHxLoGuRvLg33Qy0UKk/z6OXmHUO2z6DKE0Oe6CFpjj/bdhuQ8dfvq9ug==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.19.2"


### PR DESCRIPTION
Write: add OAuth params into both sessionStorage and cookies
Read: favor cookies first, then try sessionStorage to compatible with old versions of SIW.

https://github.com/okta/okta-auth-js/pull/514#issuecomment-712494247