### PR TITLE
feat: Support custom claims in AccessToken - OKTA-326437

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.3.0
+
+### Features
+- [#518](https://github.com/okta/okta-auth-js/pull/518) Added `claims` to `AccessToken`
+
 ## 4.2.0
 
 ### Features

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -271,9 +271,11 @@ function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res: OAuth
       var refreshToken = res.refresh_token;
 
       if (accessToken) {
+        var accessJwt = sdk.token.decode(accessToken);
         tokenDict.accessToken = {
           value: accessToken, 
           accessToken: accessToken,
+          claims: accessJwt.payload,
           expiresAt: Number(expiresIn) + Math.floor(Date.now() / 1000),
           tokenType: tokenType,
           scopes: scopes,
@@ -295,13 +297,13 @@ function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res: OAuth
       }
 
       if (idToken) {
-        var jwt = sdk.token.decode(idToken);
+        var idJwt = sdk.token.decode(idToken);
 
         var idTokenObj: IDToken = {
           value: idToken,
           idToken: idToken,
-          claims: jwt.payload,
-          expiresAt: jwt.payload.exp,
+          claims: idJwt.payload,
+          expiresAt: idJwt.payload.exp,
           scopes: scopes,
           authorizeUrl: urls.authorizeUrl,
           issuer: urls.issuer,

--- a/lib/types/Token.ts
+++ b/lib/types/Token.ts
@@ -21,6 +21,7 @@ export interface AbstractToken {
 
 export interface AccessToken extends AbstractToken {
   accessToken: string;
+  claims: UserClaims;
   tokenType: string;
   userinfoUrl: string;
 }

--- a/test/karma/spec/renewToken.js
+++ b/test/karma/spec/renewToken.js
@@ -19,7 +19,7 @@ describe('Renew token', function() {
     redirectUri: REDIRECT_URI,
   };
 
-  const ACCESS_TOKEN_STR = 'fakeytoken'; // will not be verified in this flow
+  const ACCESS_TOKEN_STR = tokens.standardAccessToken;
   const ID_TOKEN_STR = tokens.standardIdToken;
   const ACCCESS_TOKEN_PARSED = tokens.standardAccessTokenParsed;
   const NONCE = tokens.standardIdTokenClaims.nonce;

--- a/test/spec/token.ts
+++ b/test/spec/token.ts
@@ -25,6 +25,9 @@ function setupSync(options?) {
 function createAccessToken(strValue): AccessToken {
   return {
     accessToken: strValue,
+    claims: {
+      sub: ''
+    },
     value: strValue,
     userinfoUrl: '',
     authorizeUrl: '',

--- a/test/support/tokens.js
+++ b/test/support/tokens.js
@@ -247,9 +247,26 @@ tokens.standardAccessToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOj' +
                               'JOEhR6vs11qVmIgbwZ4--MqUIRU3WoFEsr0muLl039QrUa1' +
                               'EQ9-Ua9rPOMaO0pFC6h2lfB_HfzGifXATKsN-wLdxk6cgA';
 
+tokens.standardAccessTokenClaims = {
+  'aud': 'https://lboyette.trexcloud.com/as/ors1rg3zyc8mvVTJO0g7',
+  'cid': 'Pf0aifrhYZu1v0P1bFFz',
+  'exp': 1468471247,
+  'iat': 1468467647,
+  'iss': 'https://lboyette.trexcloud.com/as/ors1rg3zyc8mvVTJO0g7',
+  'jti': 'AT.rvbnS4iWu2aDNca3bwTf0H9eWcWllKQeiNY_VeImMZA',
+  'scp': [
+    'openid',
+    'email',
+  ],
+  'sub': '00u1pcla5qYIREDLWCQV',
+  'uid': '00u1pcla5qYIREDLWCQV',
+  'ver': 1,
+};
+
 tokens.standardAccessTokenParsed = {
   value: tokens.standardAccessToken,
   accessToken: tokens.standardAccessToken,
+  claims: tokens.standardAccessTokenClaims,
   expiresAt: 1449703529, // assuming time = 1449699929
   scopes: ['openid', 'email'],
   tokenType: 'Bearer',
@@ -270,9 +287,26 @@ tokens.authServerAccessToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjE
                                 'EE8wXbgYjzGH5T6dazwgGfGmVf2PTa1pKfPew7f_XKE_t1O_tJ9C' +
                                 'h9gY9Z3xd92ac407ZIOHkabLvZ0-45ANM3Gm0LC0c';
 
+tokens.authServerAccessTokenClaims = {
+  'ver': 1,
+  'jti': 'AT._0Y3BbEy_f42ScS2VOwksTp8B8QojYS3bMtXCDFrxh8',
+  'iss': 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
+  'aud': 'http://example.com',
+  'sub': 'samljackson@okta.com',
+  'iat': 1449699929,
+  'exp': 1449703529,
+  'cid': 'gLzF0DhjQIGCT4qO0SMB',
+  'uid': '00ukoeEqIogiFHpDe0g3',
+  'scp': [
+    'openid',
+    'email',
+  ],
+};
+
 tokens.authServerAccessTokenParsed = {
   value: tokens.authServerAccessToken,
   accessToken: tokens.authServerAccessToken,
+  claims: tokens.authServerAccessTokenClaims,
   expiresAt: 1449703529, // assuming time = 1449699929
   scopes: ['openid', 'email'],
   tokenType: 'Bearer',


### PR DESCRIPTION
Changes:
- Add `claims` object to `accessToken`

This will allow retrieving custom claims from access token.

Resolves: https://github.com/okta/okta-auth-js/issues/458
Internal ref: https://oktainc.atlassian.net/browse/OKTA-326437