### PR TITLE
Check redirect URI in token.isLoginRedirect()

### DIFF
--- a/lib/oauthUtil.ts
+++ b/lib/oauthUtil.ts
@@ -231,6 +231,11 @@ function hasCodeInUrl(hashOrSearch: string): boolean {
   return /(code=)/i.test(hashOrSearch);
 }
 
+function isRedirectUri(uri: string, sdk: OktaAuth): boolean {
+  var authParams = sdk.options;
+  return uri && uri.indexOf(authParams.redirectUri) == 0;
+}
+
 /**
  * Check if tokens or a code have been passed back into the url, which happens in
  * the social auth IDP redirect flow.
@@ -239,9 +244,10 @@ function isLoginRedirect (sdk: OktaAuth) {
   var authParams = sdk.options;
   if (authParams.pkce || authParams.responseType === 'code' || authParams.responseMode === 'query') {
     // Look for code
-    return authParams.responseMode === 'fragment' ?
+    var hasCode = authParams.responseMode === 'fragment' ?
       hasCodeInUrl(window.location.hash) :
       hasCodeInUrl(window.location.search);
+    return isRedirectUri(window.location.href, sdk) && hasCode;
   }
   // Look for tokens (Implicit OIDC flow)
   return hasTokensInHash(window.location.hash);

--- a/test/spec/oauthUtil.js
+++ b/test/spec/oauthUtil.js
@@ -963,13 +963,15 @@ describe('isLoginRedirect', function() {
     it('there should be code in hash when responseMode is fragment', () => {
       delete window.location;
       window.location = {
-        hash: '#code=fakecode'
+        hash: '#code=fakecode',
+        href: 'https://exmple.com/implicit/callback#code=fakecode'
       };
       sdk = new OktaAuth({
         pkce: true,
         responseMode: 'fragment',
         issuer: 'https://auth-js-test.okta.com',
-        clientId: 'foo'
+        clientId: 'foo',
+        redirectUri: 'https://exmple.com/implicit/callback'
       });
       const result = oauthUtil.isLoginRedirect(sdk);
       expect(result).toBe(true);
@@ -978,12 +980,14 @@ describe('isLoginRedirect', function() {
     it('there should be code in query when use default responseMode', () => {
       delete window.location;
       window.location = {
-        search: '?code=fakecode'
+        search: '?code=fakecode',
+        href: 'https://exmple.com/implicit/callback?code=fakecode'
       };
       sdk = new OktaAuth({
         pkce: true,
         issuer: 'https://auth-js-test.okta.com',
-        clientId: 'foo'
+        clientId: 'foo',
+        redirectUri: 'https://exmple.com/implicit/callback'
       });
       const result = oauthUtil.isLoginRedirect(sdk);
       expect(result).toBe(true);
@@ -992,13 +996,15 @@ describe('isLoginRedirect', function() {
     it('there should be code in query when responseMode is query', () => {
       delete window.location;
       window.location = {
-        search: '?code=fakecode'
+        search: '?code=fakecode',
+        href: 'https://exmple.com/implicit/callback?code=fakecode'
       };
       sdk = new OktaAuth({
         pkce: true,
         responseMode: 'query',
         issuer: 'https://auth-js-test.okta.com',
-        clientId: 'foo'
+        clientId: 'foo',
+        redirectUri: 'https://exmple.com/implicit/callback'
       });
       const result = oauthUtil.isLoginRedirect(sdk);
       expect(result).toBe(true);

--- a/test/spec/oauthUtil.js
+++ b/test/spec/oauthUtil.js
@@ -1009,5 +1009,21 @@ describe('isLoginRedirect', function() {
       const result = oauthUtil.isLoginRedirect(sdk);
       expect(result).toBe(true);
     });
+
+    it('should return false if current URI is not redirect URI', () => {
+      delete window.location;
+      window.location = {
+        search: '?code=somecode',
+        href: 'https://exmple.com/products/search?code=somecode'
+      };
+      sdk = new OktaAuth({
+        pkce: true,
+        issuer: 'https://auth-js-test.okta.com',
+        clientId: 'foo',
+        redirectUri: 'https://exmple.com/implicit/callback'
+      });
+      const result = oauthUtil.isLoginRedirect(sdk);
+      expect(result).toBe(false);
+    });
   });
 });

--- a/test/spec/token.js
+++ b/test/spec/token.js
@@ -877,12 +877,14 @@ describe('token.getWithoutPrompt', function() {
     global.window.location = {
       protocol: 'https:',
       hostname: 'somesite.local',
-      search: '?code=fakecode'
+      search: '?code=fakecode',
+      href: 'https://somesite.local/implicit/callback?code=fakecode'
     };
     const client = new OktaAuth({
       pkce: true,
       issuer: 'https://auth-js-test.okta.com',
-      clientId: 'foo'
+      clientId: 'foo',
+      redirectUri: 'https://somesite.local/implicit/callback'
     });
 
     try {
@@ -1373,12 +1375,14 @@ describe('token.getWithPopup', function() {
     global.window.location = {
       protocol: 'https:',
       hostname: 'somesite.local',
-      search: '?code=fakecode'
+      search: '?code=fakecode',
+      href: 'https://somesite.local/implicit/callback?code=fakecode'
     };
     const client = new OktaAuth({
       pkce: true,
       issuer: 'https://auth-js-test.okta.com',
-      clientId: 'foo'
+      clientId: 'foo',
+      redirectUri: 'https://somesite.local/implicit/callback'
     });
 
     try {
@@ -2186,12 +2190,14 @@ describe('token.getWithRedirect', function() {
     global.window.location = {
       protocol: 'https:',
       hostname: 'somesite.local',
-      search: '?code=fakecode'
+      search: '?code=fakecode',
+      href: 'https://somesite.local/implicit/callback?code=fakecode'
     };
     const client = new OktaAuth({
       pkce: true,
       issuer: 'https://auth-js-test.okta.com',
-      clientId: 'foo'
+      clientId: 'foo',
+      redirectUri: 'https://somesite.local/implicit/callback'
     });
 
     try {


### PR DESCRIPTION
Changes:
- in `token.isLoginRedirect()` check not only presence of parameter `code` in query/hash, but current location URI should be allowed redirect URI

Thus SDK will not false handle any routes with `code` parameter as redirect route.

Resolves: https://github.com/okta/okta-auth-js/issues/474
Internal ref: https://oktainc.atlassian.net/browse/OKTA-331632