### PR TITLE
feat: add methods for v4.1 - OKTA-340176

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Adds new methods in sdk browser scope:
     - `sdk.signInWithCredentials`
     - `sdk.signInWithRedirect`
+    - `sdk.isAuthenticated`
     - `sdk.getUser`
     - `sdk.getIdToken`
     - `sdk.getAccessToken`

--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ var config = {
 * [verifyRecoveryToken](#verifyrecoverytokenoptions)
 * [webfinger](#webfingeroptions)
 * [fingerprint](#fingerprintoptions)
+* [isAuthenticated](#isAuthenticated)
 * [getUser](#getuser)
 * [getIdToken](#getidtoken)
 * [getAccessToken](#getaccesstoken)
@@ -678,8 +679,8 @@ You can use [storeTokensFromRedirect](#storetokensfromredirect) to store tokens 
 
 ```javascript
 if (authClient.token.isLoginRedirect()) {
-  // Call handleAuthentication to store tokens when redirect back from OKTA
-  authClient.storeTokensFromRedirect();
+  // Store tokens when redirect back from OKTA
+  await authClient.storeTokensFromRedirect();
   // Get and clear fromUri from storage
   const fromUri = authClient.getFromUri();
   authClient.removeFromUri();
@@ -900,6 +901,12 @@ authClient.fingerprint()
 })
 ```
 
+### `isAuthenticated(timeout?)`
+
+> :hourglass: async
+
+Resolves with `authState.isAuthenticated` from non-pending [authState](#authstatemanager).
+
 ### `getUser()`
 
 > :hourglass: async
@@ -908,15 +915,11 @@ Alias method of [token.getUserInfo](#tokengetuserinfoaccesstokenobject-idtokenob
 
 ### `getIdToken()`
 
-> :hourglass: async
-
-Resolves with the id token string retrieved from storage if it exists. Devs should prefer to consult the synchronous results emitted from subscribing to the [authStateManager.subscribe](#authstatemanagersubscribehandler).
+Returns the id token string retrieved from [authState](#authstatemanager) if it exists.
 
 ### `getAccessToken()`
 
-> :hourglass: async
-
-Resolves with the access token string retrieved from storage if it exists. Devs should prefer to consult the synchronous results emitted from subscribing to the [authStateManager.subscribe](#authstatemanagersubscribehandler).
+Returns the access token string retrieved from [authState](#authstatemanager) if it exists.
 
 ### `storeTokensFromRedirect()`
 
@@ -2077,7 +2080,7 @@ Retrieve the [details about a user](https://developer.okta.com/docs/api/resource
 * `accessTokenObject` - (optional) an access token returned by this library. **Note**: this is not the raw access token.
 * `idTokenObject` - (optional) an ID token returned by this library. **Note**: this is not the raw ID token.
 
-By default, if no parameters are passed, both the access token and ID token objects will be retrieved from the TokenManager. If either token has expired it will be renewed automatically by the TokenManager before the user info is requested. It is assumed that the access token is stored using the key "accessToken" and the ID token is stored under the key "idToken". If you have stored either token in a non-standard location, this logic can be skipped by passing the access and ID token objects directly.
+By default, if no parameters are passed, both the access token and ID token objects will be retrieved from the TokenManager. It is assumed that the access token is stored using the key "accessToken" and the ID token is stored under the key "idToken". If you have stored either token in a non-standard location, this logic can be skipped by passing the access and ID token objects directly.
 
 
 ```javascript

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -388,19 +388,19 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
       return Promise.resolve(authState.isAuthenticated);
     }
 
+    let clear, handler, timeoutId;
     return new Promise(resolve => {
-      const clear = () => {
+      clear = () => {
         this.authStateManager.unsubscribe(handler);
         clearTimeout(timeoutId);
       };
-      const handler = ({isAuthenticated, isPending}) => {
-        console.log(isAuthenticated, isPending);
+      handler = ({isAuthenticated, isPending}) => {
         if (!isPending) {
           resolve(isAuthenticated);
           clear();
         }
       };
-      const timeoutId = setTimeout(() => {
+      timeoutId = setTimeout(() => {
         resolve(false);
         clear();
       }, timeout || 60 * 1000);

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -382,26 +382,46 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
   // Common Methods from downstream SDKs
   //
 
+  async isAuthenticated(timeout?: number): Promise<boolean> {
+    const authState = this.authStateManager.getAuthState();
+    if (!authState.isPending) {
+      return Promise.resolve(authState.isAuthenticated);
+    }
+
+    return new Promise(resolve => {
+      const clear = () => {
+        this.authStateManager.unsubscribe(handler);
+        clearTimeout(timeoutId);
+      };
+      const handler = ({isAuthenticated, isPending}) => {
+        console.log(isAuthenticated, isPending);
+        if (!isPending) {
+          resolve(isAuthenticated);
+          clear();
+        }
+      };
+      const timeoutId = setTimeout(() => {
+        resolve(false);
+        clear();
+      }, timeout || 60 * 1000);
+      this.authStateManager.subscribe(handler);
+      this.authStateManager.updateAuthState();
+    });
+  }
+
   async getUser(): Promise<UserClaims> {
-    return this.token.getUserInfo();
+    const { idToken, accessToken } = this.authStateManager.getAuthState();
+    return this.token.getUserInfo(accessToken, idToken);
   }
 
-  async getIdToken(): Promise<string | undefined> {
-    try {
-      const idToken = (await this.tokenManager.getTokens()).idToken as IDToken;
-      return idToken ? idToken.idToken : undefined;
-    } catch (err) {
-      return undefined;
-    }
+  getIdToken(): string | undefined {
+    const { idToken } = this.authStateManager.getAuthState();
+    return idToken ? idToken.idToken : undefined;
   }
 
-  async getAccessToken(): Promise<string | undefined> {
-    try {
-      const accessToken = (await this.tokenManager.getTokens()).accessToken as AccessToken;
-      return accessToken ? accessToken.accessToken : undefined;
-    } catch (err) {
-      return undefined;
-    }
+  getAccessToken(): string | undefined {
+    const { accessToken } = this.authStateManager.getAuthState();
+    return accessToken ? accessToken.accessToken : undefined;
   }
 
   /**

--- a/lib/browser/index.ts
+++ b/lib/browser/index.ts
@@ -17,3 +17,4 @@ export * from '../types';
 export * from '../tx';
 export * from '../errors';
 export * from '../TokenManager';
+export * from '../util';

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -82,6 +82,14 @@ export function toAbsoluteUrl(url = '', baseUrl) {
   return url[0] === '/' ? `${baseUrl}${url}` : `${baseUrl}/${url}`;
 }
 
+export function toRelativeUrl(url = '', baseUrl) {
+  if (isAbsoluteUrl(url)) {
+    url = url.substring(baseUrl.length);
+  }
+
+  return url[0] === '/' ? url : `/${url}`
+}
+
 export function isString(obj: any): obj is string {
   return Object.prototype.toString.call(obj) === '[object String]';
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -87,7 +87,7 @@ export function toRelativeUrl(url = '', baseUrl) {
     url = url.substring(baseUrl.length);
   }
 
-  return url[0] === '/' ? url : `/${url}`
+  return url[0] === '/' ? url : `/${url}`;
 }
 
 export function isString(obj: any): obj is string {

--- a/test/spec/util.js
+++ b/test/spec/util.js
@@ -235,4 +235,29 @@ describe('util', function() {
       expect(util.toAbsoluteUrl(url, baseUrl)).toEqual('http://fake.com/relative');
     });
   });
+
+  describe('toRelativeUrl', () => {
+    it('should return same url if url is an relative url', () => {
+      const url = '/path';
+      expect(util.toRelativeUrl(url)).toEqual(url);
+    });
+
+    it('should return correct url when valid baseUrl and relative url are provided', () => {
+      const baseUrl = 'http://fake.com';
+      const url = 'http://fake.com/relative';
+      expect(util.toRelativeUrl(url, baseUrl)).toEqual('/relative');
+    });
+
+    it('should return correct url when baseUrl has trailing "/"', () => {
+      const baseUrl = 'http://fake.com/';
+      const url = 'http://fake.com/relative';
+      expect(util.toRelativeUrl(url, baseUrl)).toEqual('/relative');
+    });
+
+    it('should return correct url when relative url without "/"', () => {
+      const baseUrl = 'http://fake.com';
+      const url = 'http://fake.com/relative';
+      expect(util.toRelativeUrl(url, baseUrl)).toEqual('/relative');
+    });
+  });
 });


### PR DESCRIPTION
Changes:
* adds `sdk.isAuthenticated` to resolve with non-pending `isAuthenticated` state
* changes `sdk.getAccessToken` and `getIdToken` to read from in-memory authState
* provides tokens to `sdk.getUser` from in-memory authState
* add `util.toRelativeUrl`