### PR TITLE
fix: respect scopes set in constructor

### DIFF
--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -267,15 +267,14 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
     }
 
     this._pending.handleLogin = true;
-    const { scopes, responseType } = this.options;
     try {
       // Trigger default signIn redirect flow
       if (originalUri) {
         this.setOriginalUri(originalUri);
       }
       const params = Object.assign({
-        scopes: scopes || ['openid', 'email', 'profile'],
-        responseType: responseType || ['id_token', 'token']
+        // TODO: remove this line when default scopes are changed OKTA-343294
+        scopes: this.options.scopes || ['openid', 'email', 'profile']
       }, additionalParams);
       await this.token.getWithRedirect(params);
     } finally {

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -326,16 +326,17 @@ function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res: OAuth
 }
 
 function getDefaultTokenParams(sdk: OktaAuth): TokenParams {
+  const { pkce, clientId, redirectUri, responseType, responseMode, scopes, ignoreSignature } = sdk.options;
   return {
-    pkce: sdk.options.pkce,
-    clientId: sdk.options.clientId,
-    redirectUri: sdk.options.redirectUri || window.location.href,
-    responseType: sdk.options.responseType || ['token', 'id_token'],
-    responseMode: sdk.options.responseMode,
+    pkce,
+    clientId,
+    redirectUri: redirectUri || window.location.href,
+    responseType: responseType || ['token', 'id_token'],
+    responseMode,
     state: generateState(),
     nonce: generateNonce(),
-    scopes: ['openid', 'email'],
-    ignoreSignature: sdk.options.ignoreSignature
+    scopes: scopes || ['openid', 'email'],
+    ignoreSignature
   };
 }
 

--- a/test/spec/browser.js
+++ b/test/spec/browser.js
@@ -211,12 +211,12 @@ describe('Browser', function() {
       expect(setItemMock).not.toHaveBeenCalled();
     });
 
-    it('should use default scopes and responseType if none is provided', async () => {
+    // TODO: remove this test when default scopes are changed OKTA-343294
+    it('should use default scopes if none is provided', async () => {
       await auth.signInWithRedirect({ foo: 'bar' });
       expect(auth.token.getWithRedirect).toHaveBeenCalledWith({
         foo: 'bar',
-        scopes: ['openid', 'email', 'profile'],
-        responseType: ['id_token', 'token']
+        scopes: ['openid', 'email', 'profile']
       });
     });
 


### PR DESCRIPTION
A bug in `getDefaultTokenParams` was preventing scopes set in the constructor from being honored.

Also cleans up/refactors the code a little bit, removes unnecessary override of `responseType` in `signInWithRedirect`