### PR TITLE
fix: samples should reference last published auth-js version

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -20,6 +20,7 @@
     "gulp-compile-handlebars": "^0.6.1",
     "gulp-handlebars": "^5.0.2",
     "handlebars": "^4.7.6",
+    "shelljs": "0.8.3",
     "through2": "^4.0.2",
     "yargs": "^16.0.3"
   }


### PR DESCRIPTION
There is a minor issue with samples generation where it uses the version of auth-js from package.json, which is always ahead of the last published version. This means that the CDN URL in the HTML comment will not work.

This PR retrieves the last published version and uses that instead.