### PR TITLE
Use /.well-known/openid-configuration issuer attribute for id_token validation

### DIFF
--- a/lib/token.ts
+++ b/lib/token.ts
@@ -57,6 +57,7 @@ import {
   TokenResponse,
   CustomUrls,
   PKCEMeta,
+  WellKnownResponse,
   ParseFromUrlOptions,
   Tokens
 } from './types';
@@ -293,15 +294,24 @@ function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res: OAuth
         accessToken: accessToken
       };
 
-      if (tokenParams.ignoreSignature !== undefined) {
-        validationParams.ignoreSignature = tokenParams.ignoreSignature;
-      }
+      return getWellKnown(sdk, urls.issuer)
+      .then (function (wellKnownInfo: WellKnownResponse) {
 
-      return verifyToken(sdk, idTokenObj, validationParams)
-      .then(function() {
-        tokenDict.idToken = idTokenObj;
-        return tokenDict;
-      });
+        if (tokenParams.ignoreSignature !== undefined) {
+          validationParams.ignoreSignature = tokenParams.ignoreSignature;
+        }
+
+        if (validationParams.issuer != wellKnownInfo.issuer) {
+          validationParams.issuer = wellKnownInfo.issuer
+        }
+
+        return verifyToken(sdk, idTokenObj, validationParams)
+        .then(function() {
+          tokenDict.idToken = idTokenObj;
+          return tokenDict;
+        });
+        
+      })
     }
 
     return tokenDict;

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -130,8 +130,10 @@ function verifyToken(sdk: OktaAuth, token: IDToken, validationParams: TokenVerif
 
     return getWellKnown(sdk, null)
     .then (function (wellKnownInfo: WellKnownResponse) {
+
+      var temp = validationOptions.issuer;
       
-      if(wellKnownInfo.issuer != validationOptions.issuer) {
+      if(jwt.payload.iss != validationOptions.issuer) {
         validationOptions.issuer = wellKnownInfo.issuer
       }
       
@@ -309,7 +311,7 @@ function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res: OAuth
       if (tokenParams.ignoreSignature !== undefined) {
         validationParams.ignoreSignature = tokenParams.ignoreSignature;
       }
-      
+
       return verifyToken(sdk, idTokenObj, validationParams)
       .then(function() {
         tokenDict.idToken = idTokenObj;

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -294,7 +294,7 @@ function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res: OAuth
         accessToken: accessToken
       };
 
-      return getWellKnown(sdk, urls.issuer)
+      return getWellKnown(sdk, null)
       .then (function (wellKnownInfo: WellKnownResponse) {
 
         if (tokenParams.ignoreSignature !== undefined) {


### PR DESCRIPTION
Other Okta SDK's use the issuer URL found in the /.well-known/openid-configuration response body when validating the id_token. This SDK currently uses the URL specified in the config object passed to the constructor at the time the OAuth client object is instantiated. This is not desirable as it makes it impossible to use a proxy with Okta.
    
The change made uses the issuer attribute found in the /.well-known/openid-configuration response body and compares it to the issuer claim in the id_token to validate the token.