### PR TITLE
Add useInteractionCodeFlow option to samples, upgrade test app

### DIFF
--- a/samples/config.js
+++ b/samples/config.js
@@ -1,8 +1,10 @@
 const path = require('path');
+
+// All samples use the same widget version, whether CDN or NPM
+const SIW_VERSION = '5.2.3';
+
 const AUTH_JS_DIR = path.dirname(require.resolve('@okta/okta-auth-js'));
 const AUTH_JS_VERSION = require(path.resolve(AUTH_JS_DIR, '..', '..', 'package.json')).version;
-const SIW_DIR = path.dirname(require.resolve('@okta/okta-signin-widget'));
-const SIW_VERSION = require(path.resolve(SIW_DIR, '..', '..', 'package.json')).version;
 
 const versions = {
   '@okta/okta-auth-js': AUTH_JS_VERSION,

--- a/samples/generated/express-web-no-oidc/public/index.html
+++ b/samples/generated/express-web-no-oidc/public/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <!-- app styles -->

--- a/samples/generated/express-web-with-oidc/public/index.html
+++ b/samples/generated/express-web-with-oidc/public/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <!-- app styles -->

--- a/samples/generated/static-spa/public/app.js
+++ b/samples/generated/static-spa/public/app.js
@@ -200,6 +200,7 @@ function showSigninWidget() {
       baseUrl: config.issuer.split('oauth2')[0],
       clientId: config.clientId,
       redirectUri: config.redirectUri,
+      useInteractionCodeFlow: config.useInteractionCodeFlow,
       authParams: {
         issuer: config.issuer,
         state: JSON.stringify(config.state),
@@ -344,6 +345,11 @@ function showForm() {
     document.querySelector(`#storage [value="${config.storage || ''}"]`).selected = true;
   } catch (e) { showError(e); }
 
+  if (config.useInteractionCodeFlow) {
+    document.getElementById('useInteractionCodeFlow-on').checked = true;
+  } else {
+    document.getElementById('useInteractionCodeFlow-off').checked = true;
+  }
   // Show the form
   document.getElementById('config-form').style.display = 'block'; // show form
 }
@@ -375,6 +381,7 @@ function loadConfig() {
   var flow;
   var requireUserSession;
   var scopes;
+  var useInteractionCodeFlow;
 
   var state;
   if (stateParam) {
@@ -386,6 +393,7 @@ function loadConfig() {
     flow = state.flow;
     requireUserSession = state.requireUserSession;
     scopes = state.scopes;
+    useInteractionCodeFlow = state.useInteractionCodeFlow;
   } else {
     // Read from URL
     issuer = url.searchParams.get('issuer') || config.issuer;
@@ -395,6 +403,7 @@ function loadConfig() {
     requireUserSession = url.searchParams.get('requireUserSession') ? 
       url.searchParams.get('requireUserSession')  === 'true' : config.requireUserSession;
     scopes = url.searchParams.get('scopes') || config.scopes;
+    useInteractionCodeFlow = url.searchParams.get('useInteractionCodeFlow') === 'true' || config.useInteractionCodeFlow;
   }
   // Create a canonical app URI that allows clean reloading with this config
   appUri = window.location.origin + '/' +
@@ -403,7 +412,8 @@ function loadConfig() {
     '&storage=' + encodeURIComponent(storage) + 
     '&requireUserSession=' + encodeURIComponent(requireUserSession) + 
     '&flow=' + encodeURIComponent(flow) +
-    '&scopes=' + encodeURIComponent(scopes);
+    '&scopes=' + encodeURIComponent(scopes) +
+    '&useInteractionCodeFlow=' + encodeURIComponent(useInteractionCodeFlow);
   
   // Add all app options to the state, to preserve config across redirects
   state = {
@@ -413,6 +423,7 @@ function loadConfig() {
     requireUserSession,
     flow,
     scopes,
+    useInteractionCodeFlow
   };
   var newConfig = {};
   Object.assign(newConfig, state);

--- a/samples/generated/static-spa/public/index.html
+++ b/samples/generated/static-spa/public/index.html
@@ -1,14 +1,15 @@
+<!DOCTYPE html>
 <html>
   <head>
     <!-- In this sample, okta-auth-js assets are being served locally from node_modules. Assets are also available on CDN -->
-    <!-- https://global.oktacdn.com/okta-auth-js/4.4.0/okta-auth-js.polyfill.js -->
-    <!-- https://global.oktacdn.com/okta-auth-js/4.4.0/okta-auth-js.min.js -->
+    <!-- https://global.oktacdn.com/okta-auth-js/4.6.1/okta-auth-js.polyfill.js -->
+    <!-- https://global.oktacdn.com/okta-auth-js/4.6.1/okta-auth-js.min.js -->
     <script src="/okta-auth-js.polyfill.js" type="text/javascript"></script>
     <script src="/okta-auth-js.min.js" type="text/javascript"></script>
 
     <!-- okta-signin-widget assets are avilable on CDN -->
-    <script src="https://global.oktacdn.com/okta-signin-widget/5.0.0/js/okta-sign-in.min.js" type="text/javascript"></script>
-    <link href="https://global.oktacdn.com/okta-signin-widget/5.0.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+    <script src="https://global.oktacdn.com/okta-signin-widget/5.2.3/js/okta-sign-in.min.js" type="text/javascript"></script>
+    <link href="https://global.oktacdn.com/okta-signin-widget/5.2.3/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 
     <!-- app styles -->
     <style>
@@ -68,6 +69,11 @@
           <option value="cookie">cookie</option>
           <option value="memory">memory</option>
         </select><br/>
+      
+        <label for="useInteractionCodeFlow">Use <strong>interaction_code</strong> grant (in signin widget flow)</label><br/>
+        <input id="useInteractionCodeFlow-on" name="useInteractionCodeFlow" type="radio" value="true"/>YES<br/>
+        <input id="useInteractionCodeFlow-off" name="useInteractionCodeFlow" type="radio" value="false"/>NO<br/>
+      
         <hr/>
         <input id="login-submit" type="submit" value="Launch App"/>
       </form>

--- a/samples/generated/webpack-spa/package.json
+++ b/samples/generated/webpack-spa/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@okta/okta-auth-js": "*",
-    "@okta/okta-signin-widget": "*"
+    "@okta/okta-signin-widget": "^5.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",

--- a/samples/generated/webpack-spa/public/index.html
+++ b/samples/generated/webpack-spa/public/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <!-- signin widget CSS, served locally from node_modules -->
@@ -61,6 +62,11 @@
           <option value="cookie">cookie</option>
           <option value="memory">memory</option>
         </select><br/>
+      
+        <label for="useInteractionCodeFlow">Use <strong>interaction_code</strong> grant (in signin widget flow)</label><br/>
+        <input id="useInteractionCodeFlow-on" name="useInteractionCodeFlow" type="radio" value="true"/>YES<br/>
+        <input id="useInteractionCodeFlow-off" name="useInteractionCodeFlow" type="radio" value="false"/>NO<br/>
+      
         <hr/>
         <input id="login-submit" type="submit" value="Launch App"/>
       </form>

--- a/samples/generated/webpack-spa/src/index.js
+++ b/samples/generated/webpack-spa/src/index.js
@@ -199,6 +199,7 @@ function showSigninWidget() {
       baseUrl: config.issuer.split('oauth2')[0],
       clientId: config.clientId,
       redirectUri: config.redirectUri,
+      useInteractionCodeFlow: config.useInteractionCodeFlow,
       authParams: {
         issuer: config.issuer,
         state: JSON.stringify(config.state),
@@ -343,6 +344,11 @@ function showForm() {
     document.querySelector(`#storage [value="${config.storage || ''}"]`).selected = true;
   } catch (e) { showError(e); }
 
+  if (config.useInteractionCodeFlow) {
+    document.getElementById('useInteractionCodeFlow-on').checked = true;
+  } else {
+    document.getElementById('useInteractionCodeFlow-off').checked = true;
+  }
   // Show the form
   document.getElementById('config-form').style.display = 'block'; // show form
 }
@@ -374,6 +380,7 @@ function loadConfig() {
   var flow;
   var requireUserSession;
   var scopes;
+  var useInteractionCodeFlow;
 
   var state;
   if (stateParam) {
@@ -385,6 +392,7 @@ function loadConfig() {
     flow = state.flow;
     requireUserSession = state.requireUserSession;
     scopes = state.scopes;
+    useInteractionCodeFlow = state.useInteractionCodeFlow;
   } else {
     // Read from URL
     issuer = url.searchParams.get('issuer') || config.issuer;
@@ -394,6 +402,7 @@ function loadConfig() {
     requireUserSession = url.searchParams.get('requireUserSession') ? 
       url.searchParams.get('requireUserSession')  === 'true' : config.requireUserSession;
     scopes = url.searchParams.get('scopes') || config.scopes;
+    useInteractionCodeFlow = url.searchParams.get('useInteractionCodeFlow') === 'true' || config.useInteractionCodeFlow;
   }
   // Create a canonical app URI that allows clean reloading with this config
   appUri = window.location.origin + '/' +
@@ -402,7 +411,8 @@ function loadConfig() {
     '&storage=' + encodeURIComponent(storage) + 
     '&requireUserSession=' + encodeURIComponent(requireUserSession) + 
     '&flow=' + encodeURIComponent(flow) +
-    '&scopes=' + encodeURIComponent(scopes);
+    '&scopes=' + encodeURIComponent(scopes) +
+    '&useInteractionCodeFlow=' + encodeURIComponent(useInteractionCodeFlow);
   
   // Add all app options to the state, to preserve config across redirects
   state = {
@@ -412,6 +422,7 @@ function loadConfig() {
     requireUserSession,
     flow,
     scopes,
+    useInteractionCodeFlow
   };
   var newConfig = {};
   Object.assign(newConfig, state);

--- a/samples/package.json
+++ b/samples/package.json
@@ -9,10 +9,6 @@
     "dev": "gulp watch",
     "test": "yarn --cwd test start"
   },
-  "dependencies": {
-    "@okta/okta-auth-js": "*",
-    "@okta/okta-signin-widget": "^5.0.0"
-  },
   "devDependencies": {
     "gulp": "^4.0.2",
     "gulp-clean": "^0.4.0",

--- a/samples/templates/express-web/public/index.html
+++ b/samples/templates/express-web/public/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     {{> styles.html }}

--- a/samples/templates/partials/spa/app.js
+++ b/samples/templates/partials/spa/app.js
@@ -202,6 +202,7 @@ function showSigninWidget() {
       baseUrl: config.issuer.split('oauth2')[0],
       clientId: config.clientId,
       redirectUri: config.redirectUri,
+      useInteractionCodeFlow: config.useInteractionCodeFlow,
       authParams: {
         issuer: config.issuer,
         state: JSON.stringify(config.state),
@@ -349,6 +350,11 @@ function showForm() {
     document.querySelector(`#storage [value="${config.storage || ''}"]`).selected = true;
   } catch (e) { showError(e); }
 
+  if (config.useInteractionCodeFlow) {
+    document.getElementById('useInteractionCodeFlow-on').checked = true;
+  } else {
+    document.getElementById('useInteractionCodeFlow-off').checked = true;
+  }
   // Show the form
   document.getElementById('config-form').style.display = 'block'; // show form
 }
@@ -380,6 +386,7 @@ function loadConfig() {
   var flow;
   var requireUserSession;
   var scopes;
+  var useInteractionCodeFlow;
 
   var state;
   if (stateParam) {
@@ -391,6 +398,7 @@ function loadConfig() {
     flow = state.flow;
     requireUserSession = state.requireUserSession;
     scopes = state.scopes;
+    useInteractionCodeFlow = state.useInteractionCodeFlow;
   } else {
     // Read from URL
     issuer = url.searchParams.get('issuer') || config.issuer;
@@ -400,6 +408,7 @@ function loadConfig() {
     requireUserSession = url.searchParams.get('requireUserSession') ? 
       url.searchParams.get('requireUserSession')  === 'true' : config.requireUserSession;
     scopes = url.searchParams.get('scopes') || config.scopes;
+    useInteractionCodeFlow = url.searchParams.get('useInteractionCodeFlow') === 'true' || config.useInteractionCodeFlow;
   }
   // Create a canonical app URI that allows clean reloading with this config
   appUri = window.location.origin + '/' +
@@ -408,7 +417,8 @@ function loadConfig() {
     '&storage=' + encodeURIComponent(storage) + 
     '&requireUserSession=' + encodeURIComponent(requireUserSession) + 
     '&flow=' + encodeURIComponent(flow) +
-    '&scopes=' + encodeURIComponent(scopes);
+    '&scopes=' + encodeURIComponent(scopes) +
+    '&useInteractionCodeFlow=' + encodeURIComponent(useInteractionCodeFlow);
   
   // Add all app options to the state, to preserve config across redirects
   state = {
@@ -418,6 +428,7 @@ function loadConfig() {
     requireUserSession,
     flow,
     scopes,
+    useInteractionCodeFlow
   };
   var newConfig = {};
   Object.assign(newConfig, state);

--- a/samples/templates/partials/spa/form.html
+++ b/samples/templates/partials/spa/form.html
@@ -28,6 +28,11 @@
     <option value="cookie">cookie</option>
     <option value="memory">memory</option>
   </select><br/>
+
+  <label for="useInteractionCodeFlow">Use <strong>interaction_code</strong> grant (in signin widget flow)</label><br/>
+  <input id="useInteractionCodeFlow-on" name="useInteractionCodeFlow" type="radio" value="true"/>YES<br/>
+  <input id="useInteractionCodeFlow-off" name="useInteractionCodeFlow" type="radio" value="false"/>NO<br/>
+
   <hr/>
   <input id="login-submit" type="submit" value="Launch App"/>
 </form>

--- a/samples/templates/static-spa/public/index.html
+++ b/samples/templates/static-spa/public/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <!-- In this sample, okta-auth-js assets are being served locally from node_modules. Assets are also available on CDN -->

--- a/samples/templates/webpack-spa/package.json
+++ b/samples/templates/webpack-spa/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@okta/okta-auth-js": "*",
-    "@okta/okta-signin-widget": "*"
+    "@okta/okta-signin-widget": "^{{ siwVersion }}"
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",

--- a/samples/templates/webpack-spa/public/index.html
+++ b/samples/templates/webpack-spa/public/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <!-- signin widget CSS, served locally from node_modules -->

--- a/test/app/package.json
+++ b/test/app/package.json
@@ -20,6 +20,7 @@
     "@babel/preset-env": "^7.8.2",
     "@webpack-cli/serve": "^0.1.5",
     "babel-loader": "^8.0.6",
+    "btoa": "^1.2.1",
     "express": "^4.17.1",
     "js-cookie": "2.2.0",
     "source-map-loader": "^0.2.4",

--- a/test/app/public/index.html
+++ b/test/app/public/index.html
@@ -1,9 +1,6 @@
 <html>
   <head>
     <link rel="stylesheet" href="/oidc-app.css"/>
-    <!-- Latest CDN production Javascript and CSS -->
-    <script src="https://global.oktacdn.com/okta-signin-widget/4.1.1/js/okta-sign-in.min.js" type="text/javascript"></script>
-    <link href="https://global.oktacdn.com/okta-signin-widget/4.1.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
   </head>
   <body class="oidc-app landing">
     <div id="root"></div>

--- a/test/app/server.js
+++ b/test/app/server.js
@@ -9,10 +9,26 @@ const util = require('./src/util');
 const express = require('express');
 const webpack = require('webpack');
 const webpackDevMiddleware = require('webpack-dev-middleware');
+const querystring = require('querystring');
 
 const app = express();
 const config = require('./webpack.config.js');
 const compiler = webpack(config);
+
+const http = require('http');
+const https = require('https');
+const btoa = require('btoa');
+
+// converts a standard base64-encoded string to a "url/filename safe" variant
+function base64ToBase64Url(b64) {
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+// converts a string to base64 (url/filename safe variant)
+function stringToBase64Url(str) {
+  const b64 = btoa(str);
+  return base64ToBase64Url(b64);
+}
 
 // Tell express to use the webpack-dev-middleware and use the webpack.config.js
 // configuration file as a base.
@@ -62,6 +78,85 @@ app.post('/login', function(req, res) {
     res.redirect('/server' + qs);
   });
 });
+
+// The request query should contain a code and state, or an error and error_description.
+function handleAuthorizationCode(req, res) {
+  const error = req.query.error;
+  if (error) {
+    res.send(`
+      <html>
+        <body>
+          <h1>${error}</h1>
+          <p>
+          ${req.query.error_description}
+          </p>
+        </body>
+      </html>
+    `);
+    return;
+  }
+  // also known as "authorization_code"
+  const code = req.query.code;
+
+  // state can be any string. In this sample are using it to store our config
+  const state = JSON.parse(req.query.state);
+  const { issuer, clientId, _clientSecret, redirectUri } = state;
+
+  console.log('STATE', state);
+  const postData = querystring.stringify({
+    'grant_type': 'authorization_code',
+    'redirect_uri': redirectUri,
+    'code': code
+  });
+  const isHttp = new URL(issuer).protocol === 'http:';
+  const httpRequestor = isHttp ? http : https;
+  const baseUrl = issuer.indexOf('/oauth2') > 0 ? issuer : `${issuer}/oauth2`;
+  const encodedSecret = stringToBase64Url(`${clientId}:${_clientSecret}`);
+  const post = httpRequestor.request(`${baseUrl}/v1/token`, {
+    method: 'POST',
+    headers: {
+      'accept': 'application/json',
+      'authorization': `Basic ${encodedSecret}`,
+      'content-type': 'application/x-www-form-urlencoded',
+    }
+  }, (resp) => {
+    let data = '';
+
+    // A chunk of data has been recieved.
+    resp.on('data', (chunk) => {
+      data += chunk;
+    });
+
+    // The whole response has been received. Print out the result.
+    resp.on('end', () => {
+      res.send(`
+        <html>
+          <body>
+            <code id="oidcResult">${data}</code>
+          </body>
+        </html>
+      `);
+    });
+
+  }).on('error', (err) => {
+    console.log('Error: ' + err.message);
+    res.send(`
+    <html>
+      <body>
+        <h1>${err.message}</h1>
+        <p>
+        ${error.toString()}
+        </p>
+      </body>
+    </html>
+  `);
+  });
+
+  post.write(postData);
+  post.end();
+}
+
+app.get('/authorization-code/callback', handleAuthorizationCode);
 
 const port = config.devServer.port;
 app.listen(port, function () {

--- a/test/app/src/config.ts
+++ b/test/app/src/config.ts
@@ -4,42 +4,37 @@ const HOST = window.location.host;
 const PROTO = window.location.protocol;
 const REDIRECT_URI = `${PROTO}//${HOST}${CALLBACK_PATH}`;
 const POST_LOGOUT_REDIRECT_URI = `${PROTO}//${HOST}/`;
+const DEFAULT_SIW_VERSION = '5.2.3';
 
 export interface Config extends OktaAuthOptions {
-  // redirectUri: string;
-  // postLogoutRedirectUri: string;
-  // issuer: string;
-  // clientId: string;
-  // responseType: string[];
-  // responseMode?: string;
-  // scopes: string[];
   _defaultScopes: boolean;
-  // pkce: boolean;
-  // cookies: {
-  //   secure: boolean;
-  //   sameSite?: string;
-  // };
-  // tokenManager?: {
-  //   storage: string;
-  // };
+  _siwVersion: string;
+  _clientSecret: string;
+  _forceRedirect: boolean;
+  useInteractionCodeFlow: boolean; // widget option
 }
 
 function getDefaultConfig(): Config {
   const ISSUER = process.env.ISSUER;
   const CLIENT_ID = process.env.CLIENT_ID;
-  
+  const CLIENT_SECRET = process.env.CLIENT_SECRET || '';
+
   return {
+    _forceRedirect: false,
+    _siwVersion: DEFAULT_SIW_VERSION,
     redirectUri: REDIRECT_URI,
     postLogoutRedirectUri: POST_LOGOUT_REDIRECT_URI,
     issuer: ISSUER,
     clientId: CLIENT_ID,
+    _clientSecret: CLIENT_SECRET,
     responseType: ['token', 'id_token'],
     scopes: ['openid', 'email', 'offline_access'],
     _defaultScopes: false,
     pkce: true,
     cookies: {
       secure: true
-    }
+    },
+    useInteractionCodeFlow: false
   };
 }
 
@@ -50,6 +45,7 @@ function getConfigFromUrl(): Config {
   const redirectUri = url.searchParams.get('redirectUri') || REDIRECT_URI;
   const postLogoutRedirectUri = url.searchParams.get('postLogoutRedirectUri') || POST_LOGOUT_REDIRECT_URI;
   const clientId = url.searchParams.get('clientId');
+  const _clientSecret = url.searchParams.get('_clientSecret');
   const pkce = url.searchParams.get('pkce') !== 'false'; // On by default
   const _defaultScopes = url.searchParams.get('_defaultScopes') === 'true';
   const scopes = (url.searchParams.get('scopes') || 'openid,email,offline_access').split(',');
@@ -58,12 +54,18 @@ function getConfigFromUrl(): Config {
   const storage = url.searchParams.get('storage') || undefined;
   const secureCookies = url.searchParams.get('secure') !== 'false'; // On by default
   const sameSite = url.searchParams.get('sameSite') || undefined;
+  const _siwVersion = url.searchParams.get('_siwVersion') || DEFAULT_SIW_VERSION;
+  const useInteractionCodeFlow = url.searchParams.get('useInteractionCodeFlow') === 'true'; // off by default
+  const _forceRedirect = url.searchParams.get('_forceRedirect') === 'true'; // off by default
 
   return {
+    _forceRedirect,
+    _siwVersion,
     redirectUri,
     postLogoutRedirectUri,
     issuer,
     clientId,
+    _clientSecret,
     pkce,
     _defaultScopes,
     scopes,
@@ -76,6 +78,7 @@ function getConfigFromUrl(): Config {
     tokenManager: {
       storage,
     },
+    useInteractionCodeFlow
   };
 }
 

--- a/test/app/src/form.ts
+++ b/test/app/src/form.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-statements */
+/* eslint-disable complexity */
 /* eslint-disable max-len */
 import { flattenConfig, Config } from './config';
 
@@ -5,6 +7,7 @@ const Form = `
   <form target="/oidc" method="GET">
   <label for="issuer">Issuer</label><input id="issuer" name="issuer" type="text" /><br/>
   <label for="clientId">Client ID</label><input id="clientId" name="clientId" type="text" /><br/>
+  <label for="_clientSecret">Client Secret</label><input id="_clientSecret" name="_clientSecret" type="text" /><br/>
   <label for="responseType">Response Type (comma separated)</label><input id="responseType" name="responseType" type="text" /><br/>
   <label for="_defaultScopes">Use DEFAULT scopes (defined by authorization server)</label><br/>
   <input id="default-scopes-yes" name="_defaultScopes" type="radio" value="true"/>YES<br/>
@@ -32,12 +35,20 @@ const Form = `
   <label for="secure">Secure Cookies</label><br/>
   <input id="secureCookies-on" name="secure" type="radio" value="true"/>ON<br/>
   <input id="secureCookies-off" name="secure" type="radio" value="false"/>OFF<br/>
+  <label for="sameSite">SameSite</label>
   <select id="sameSite" name="sameSite">
     <option value="" selected>Auto</option>
     <option value="none">None</option>
     <option value="lax">Lax</option>
     <option value="strict">Strict</option>
   </select><br/>
+  <label for="_siwVersion">Sign-in Widget version</label><input id="_siwVersion" name="_siwVersion" type="text" /><br/>
+  <label for="_forceRedirect">Force redirect (for SPA applications)?</label><br/>
+  <input id="_forceRedirect-on" name="_forceRedirect" type="radio" value="true"/>YES<br/>
+  <input id="_forceRedirect-off" name="_forceRedirect" type="radio" value="false"/>NO<br/>
+  <label for="useInteractionCodeFlow">Use <strong>interaction_code</strong> grant (in signin widget flow)</label><br/>
+  <input id="useInteractionCodeFlow-on" name="useInteractionCodeFlow" type="radio" value="true"/>YES<br/>
+  <input id="useInteractionCodeFlow-off" name="useInteractionCodeFlow" type="radio" value="false"/>NO<br/>
   <hr/>
   <input id="login-submit" type="submit" value="Update Config"/>
   </form>
@@ -51,9 +62,11 @@ function updateForm(origConfig: Config): void {
   (document.getElementById('scopes') as HTMLInputElement).value = config.scopes.join(',');
   (document.getElementById('postLogoutRedirectUri') as HTMLInputElement).value = config.postLogoutRedirectUri;
   (document.getElementById('clientId') as HTMLInputElement).value = config.clientId;
+  (document.getElementById('_clientSecret') as HTMLInputElement).value = config._clientSecret;
   (document.querySelector(`#responseMode [value="${config.responseMode || ''}"]`) as HTMLOptionElement).selected = true;
   (document.querySelector(`#storage [value="${config.storage || ''}"]`) as HTMLOptionElement).selected = true;
   (document.querySelector(`#sameSite [value="${config.sameSite || ''}"]`) as HTMLOptionElement).selected = true;
+  (document.getElementById('_siwVersion') as HTMLInputElement).value = config._siwVersion;
 
   if (config.pkce) {
     (document.getElementById('pkce-on') as HTMLInputElement).checked = true;
@@ -73,6 +86,18 @@ function updateForm(origConfig: Config): void {
   } else {
     (document.getElementById('default-scopes-no') as HTMLInputElement).checked = true;
     (document.getElementById('scopes') as HTMLInputElement).disabled = false;
+  }
+
+  if (config.useInteractionCodeFlow) {
+    (document.getElementById('useInteractionCodeFlow-on') as HTMLInputElement).checked = true;
+  } else {
+    (document.getElementById('useInteractionCodeFlow-off') as HTMLInputElement).checked = true;
+  }
+
+  if (config._forceRedirect) {
+    (document.getElementById('_forceRedirect-on') as HTMLInputElement).checked = true;
+  } else {
+    (document.getElementById('_forceRedirect-off') as HTMLInputElement).checked = true;
   }
 }
 

--- a/test/app/src/webpackEntry.ts
+++ b/test/app/src/webpackEntry.ts
@@ -47,7 +47,8 @@ window.getWidgetConfig = function(): any {
     el: '#widget',
     authParams: {
       display: 'page',
-      pkce: config.pkce
+      pkce: config.pkce,
+      responseType: config.responseType
     }
   });
   return siwConfig;

--- a/test/e2e/specs/login.js
+++ b/test/e2e/specs/login.js
@@ -19,18 +19,28 @@ describe('E2E login', () => {
 
   flows.forEach(flow => {
     describe(flow + ' flow', () => {
-      beforeEach(async () => {
-        (flow === 'pkce') ? await openPKCE() : await openImplicit();
-      });
+      async function bootstrap(options = {}) {
+        (flow === 'pkce') ? await openPKCE(options) : await openImplicit(options);
+      }
 
-      it('can login using signin widget', async () => {
+      it('can login using signin widget (no redirect)', async () => {
+        await bootstrap();
         await loginWidget(flow);
         await TestApp.getUserInfo();
         await TestApp.assertUserInfo();
         await TestApp.logoutRedirect();
       });
 
+      it('can login using signin widget (with redirect)', async () => {
+        await bootstrap({ _forceRedirect: true });
+        await loginWidget(flow, true);
+        await TestApp.getUserInfo();
+        await TestApp.assertUserInfo();
+        await TestApp.logoutRedirect();
+      });
+
       it('can login using redirect', async () => {
+        await bootstrap();
         await loginRedirect(flow);
         await TestApp.getUserInfo();
         await TestApp.assertUserInfo();
@@ -38,6 +48,7 @@ describe('E2E login', () => {
       });
 
       it('can login using a popup window', async() => {
+        await bootstrap();
         await loginPopup(flow);
         await TestApp.getUserInfo();
         await TestApp.assertUserInfo();
@@ -45,6 +56,7 @@ describe('E2E login', () => {
       });
 
       it('can login directly, calling signin() with username and password', async () => {
+        await bootstrap();
         await loginDirect(flow);
         await TestApp.getUserInfo();
         await TestApp.assertUserInfo();

--- a/test/e2e/util/loginUtils.js
+++ b/test/e2e/util/loginUtils.js
@@ -50,10 +50,13 @@ async function loginDirect(flow) {
   return handleCallback(flow);
 }
 
-async function loginWidget(flow) {
+async function loginWidget(flow, forceRedirect) {
   await TestApp.showLoginWidget();
   await OktaLogin.signin(USERNAME, PASSWORD);
-  return handleCallback(flow);
+  if (forceRedirect) {
+    return handleCallback(flow);
+  }
+  await TestApp.assertLoggedIn();
 }
 
 export { loginWidget, loginDirect, loginPopup, loginRedirect };

--- a/test/e2e/wdio.conf.js
+++ b/test/e2e/wdio.conf.js
@@ -25,6 +25,12 @@ if (CI) {
     ]);
 }
 
+// drivers may need to be set to run tests locally. Leave undefined for Bacon.
+const drivers = undefined;
+// const drivers = {
+//   chrome: { version: '88.0.4324.96' }
+// };
+
 exports.config = {
     jasmineNodeOpts: {
         defaultTimeoutInterval,
@@ -143,7 +149,12 @@ exports.config = {
     // Services take over a specific job you don't want to take care of. They enhance
     // your test setup with almost no effort. Unlike plugins, they don't add new
     // commands. Instead, they hook themselves up into the test process.
-    services: ['selenium-standalone'],
+    services: [
+      ['selenium-standalone', {
+        installArgs: { drivers },
+        args: { drivers }
+      }]
+    ],
     // Framework you want to run your specs with.
     // The following are supported: Mocha, Jasmine, and Cucumber
     // see also: https://webdriver.io/docs/frameworks.html

--- a/yarn.lock
+++ b/yarn.lock
@@ -1532,25 +1532,10 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@okta/okta-signin-widget@*":
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/@okta/okta-signin-widget/-/okta-signin-widget-4.4.4.tgz#04ce2128c45bc49ccd060af3c386fc118910bf05"
-  integrity sha512-DWKcuphWpbecQA/JvKgpRlOSteop9F3hPseLjy1lYZKm3VAWjPfUlpblPrGpVTDsWKnKpfhfUMDCy3teIsnUfw==
-  dependencies:
-    "@babel/polyfill" "^7.10.1"
-    "@babel/runtime" "^7.10.3"
-    cross-fetch "^3.0.4"
-    handlebars "^4.5.3"
-    q "1.4.1"
-    u2f-api-polyfill "0.4.3"
-    underscore "1.8.3"
-  optionalDependencies:
-    fsevents "*"
-
-"@okta/okta-signin-widget@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-signin-widget/-/okta-signin-widget-5.0.0.tgz#0549074489d30e7afa8cae506eedd76757c2b867"
-  integrity sha512-1Sj44Pt1JUto9GdirItdpciLePHx0BjWaYpLfPY2XxMSxDnn6eLlWIRrH9CxXTaHEHcGB5qlcD10kFYwLzHbAA==
+"@okta/okta-signin-widget@^5.2.3":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@okta/okta-signin-widget/-/okta-signin-widget-5.2.3.tgz#d642a9fd881480506037daf0fc4895ec59fb8fb0"
+  integrity sha512-0w0e1+hBHnadCDsyEzahB0LeGGohHbgndvGnrUeNIRrsoB2dqk5nCviaBVJS0HmCjJpVdAcrQ9xmfKiYjTyJ+g==
   dependencies:
     "@babel/polyfill" "^7.10.1"
     "@babel/runtime" "^7.10.3"


### PR DESCRIPTION
Adds option `useInteractionCodeFlow` to samples that use the widget.

Upgrades test app:
- support any widget version
- control whether the widget redirects or receives tokens directly
- support interaction code flow
- support authorization code flow

Splits SIW E2E tests into redirect and non-redirect variants