### PR TITLE
detect error and error_description in redirect uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.6.0
+
+### Other
+
+- [#583](https://github.com/okta/okta-auth-js/pull/583) Better error handling for redirect flows: if redirect URI contains `error` or `error_description` then `isLoginRedirect` will return true and `parseFromUrl` will throw `OAuthError`
+
 ## 4.5.0
 
 ### Features

--- a/test/spec/token.ts
+++ b/test/spec/token.ts
@@ -2847,6 +2847,38 @@ describe('token.parseFromUrl', function() {
       util.expectErrorToEqual(e, error);
     });
   });
+
+  it('throws an OAuthError error if "error" and "error_description" in the url', () => {
+    const error = {
+      name: 'OAuthError',
+      message: 'fake_description',
+      errorCode: 'fake_error',
+      errorSummary: 'fake_description',
+      errorId: 'INTERNAL',
+      errorCauses: []
+    };
+    return oauthUtil.setupParseUrl({
+      willFail: true,
+      hashMock: '#error=fake_error&error_description=fake_description',
+      oauthParams: JSON.stringify({
+        responseType: ['id_token', 'token'],
+        state: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        nonce: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        scopes: ['openid', 'email'],
+        urls: {
+          issuer: 'https://auth-js-test.okta.com',
+          tokenUrl: 'https://auth-js-test.okta.com/oauth2/v1/token',
+          authorizeUrl: 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+          userinfoUrl: 'https://auth-js-test.okta.com/oauth2/v1/userinfo'
+        }
+      })
+    })
+    .catch(function(e) {
+      util.expectErrorToEqual(e, error);
+    });
+
+  });
+
 });
 
 describe('token.renew', function() {


### PR DESCRIPTION
- `isLoginRedirect` will now return true when there is an error and error_description in the redirect uri
- adds test for OAuthError from `parseFromUrl` which encapsulates this error from the backend
