### PR TITLE
use native fetch (if available)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.6.0
 
+### Features
+
+- [#585](https://github.com/okta/okta-auth-js/pull/585) Uses native fetch, if available
+
 ### Other
 
 - [#583](https://github.com/okta/okta-auth-js/pull/583) Better error handling for redirect flows: if redirect URI contains `error` or `error_description` then `isLoginRedirect` will return true and `parseFromUrl` will throw `OAuthError`

--- a/lib/fetch/fetchRequest.ts
+++ b/lib/fetch/fetchRequest.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import fetch from 'cross-fetch';
+import crossFetch from 'cross-fetch';
 import { FetchOptions, FetchResponse, HttpResponse } from '../types';
 
 function readData(response: FetchResponse): Promise<object | string> {
@@ -52,7 +52,7 @@ function fetchRequest(method: string, url: string, args: FetchOptions) {
   if (contentType === 'application/json' && body && typeof body !== 'string') {
     body = JSON.stringify(body);
   }
-
+  var fetch = global.fetch || crossFetch;
   var fetchPromise = fetch(url, {
     method: method,
     headers: args.headers,

--- a/test/karma/spec/loginFlow.js
+++ b/test/karma/spec/loginFlow.js
@@ -46,6 +46,7 @@ describe('Complete login flow', function() {
   var _history;
   var _location;
   var $app;
+  var fetch;
 
   beforeEach(function() {
     _history = {
@@ -60,12 +61,15 @@ describe('Complete login flow', function() {
     date.setTime(ASSUMED_TIME * 1000);
     jasmine.clock().mockDate(date);
     jasmine.Ajax.install();
+    fetch = window.fetch;
+    window.fetch = null; // disable native fetch, force XHR
   });
 
   afterEach(function() {
     document.body.removeChild(document.getElementById('root'));
     jasmine.clock().uninstall();
     jasmine.Ajax.uninstall();
+    window.fetch = fetch;
   });
 
   async function bootstrap(config, pathname) {

--- a/test/karma/spec/renewToken.js
+++ b/test/karma/spec/renewToken.js
@@ -30,7 +30,7 @@ describe('Renew token', function() {
   const JWKS_URI = 'http://myfake.jwks.local';
 
   var sdk;
-
+  var fetch;
 
   beforeEach(function() {
     document.body.insertAdjacentHTML('beforeend', '<div id="root"></div>');
@@ -38,6 +38,8 @@ describe('Renew token', function() {
     date.setTime(ASSUMED_TIME * 1000);
     jasmine.clock().mockDate(date);
     jasmine.Ajax.install();
+    fetch = window.fetch;
+    window.fetch = null; // disable native fetch, force XHR
   });
 
   afterEach(function() {
@@ -45,6 +47,7 @@ describe('Renew token', function() {
     jasmine.clock().uninstall();
     jasmine.Ajax.uninstall();
     token.$imports.$restore();
+    window.fetch = fetch;
   });
 
   function bootstrap(config) {

--- a/test/spec/fetch-request.js
+++ b/test/spec/fetch-request.js
@@ -1,3 +1,4 @@
+/* global window */
 describe('fetchRequest', function () {
   let fetchSpy;
 
@@ -43,6 +44,34 @@ describe('fetchRequest', function () {
     };
     requestMethod = 'GET';
     requestUrl = 'http://fakey.local';
+  });
+
+  describe('fetch implementation', () => {
+    let defaultFetch;
+    beforeEach(() => {
+      defaultFetch = window.fetch;
+      window.fetch = null;
+    });
+    afterEach(() => {
+      window.fetch = defaultFetch;
+    });
+    it('uses cross-fetch if no native fetch', () => {
+      return fetchRequest(requestMethod, requestUrl, {})
+      .then(() => {
+        expect(fetchSpy).toHaveBeenCalled();
+      });
+    });
+    it('uses native fetch if available', () => {
+      const globalFetch = jest.fn(() => {
+        return Promise.resolve(response);
+      });
+      window.fetch = globalFetch;
+      return fetchRequest(requestMethod, requestUrl, {})
+      .then(() => {
+        expect(globalFetch).toHaveBeenCalled();
+        expect(fetchSpy).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('request', () => {


### PR DESCRIPTION
This bypasses the `cross-fetch` module when native fetch is available