### PR TITLE
:seedling: Session Cookie Support In Token Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,16 @@ var config = {
 }
 ```
 
+If `cookie` storage is specified, it possible specify whether or not a session cookie is used by the tokenManager. This will automatically be configured if `sessionStorage` is specified and you fall back to `cookie` storage. If sessionCookie is not specified it will create a cookie with an expiry date of `2200-01-01T00:00:00.000Z`
+
+```javascript
+var config = {
+  tokenManager: {
+    sessionCookie: true
+  }
+}
+```
+
 By default, the `tokenManager` will attempt to renew tokens before they expire. If you wish to manually control token renewal, set `autoRenew` to false to disable this feature. You can listen to [`expired`](#tokenmanageronevent-callback-context) events to know when the token has expired.
 
 ```javascript

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -34,6 +34,7 @@ const DEFAULT_OPTIONS = {
   autoRemove: true,
   storage: 'localStorage',
   expireEarlySeconds: 30,
+  sessionCookie: false,
   storageKey: TOKEN_STORAGE_NAME,
   _storageEventDelay: 0
 };
@@ -437,6 +438,11 @@ export class TokenManager {
       throw new AuthSdkError('Emitter should be initialized before TokenManager');
     }
 
+    if (options.storage === 'sessionStorage')
+    {
+      options.sessionCookie = true;
+    }
+
     if (options.storage === 'localStorage' && !storageUtil.browserHasLocalStorage()) {
       warn('This browser doesn\'t support localStorage. Switching to sessionStorage.');
       options.storage = 'sessionStorage';
@@ -465,8 +471,8 @@ export class TokenManager {
           break;
         case 'cookie':
           // Implement customized cookie storage to make sure each token is stored separatedly in cookie
-          storageProvider = (function(options) {
-            var storage = storageUtil.getCookieStorage(options);
+          storageProvider = (function(storageOptions) {
+            var storage = storageUtil.getCookieStorage({...storageOptions, sessionCookie: options.sessionCookie});
             return {
               getItem: function(key) {
                 var data = storage.getItem();

--- a/lib/browser/browserStorage.ts
+++ b/lib/browser/browserStorage.ts
@@ -77,14 +77,14 @@ var storageUtil: StorageUtil = {
   getCookieStorage: function(options) {
     const secure = options.secure;
     const sameSite = options.sameSite;
+    const sessionCookie = options.sessionCookie;
     if (typeof secure === 'undefined' || typeof sameSite === 'undefined') {
       throw new AuthSdkError('getCookieStorage: "secure" and "sameSite" options must be provided');
     }
     return {
       getItem: storageUtil.storage.get,
       setItem: function(key, value) {
-        // Cookie shouldn't expire
-        storageUtil.storage.set(key, value, '2200-01-01T00:00:00.000Z', {
+        storageUtil.storage.set(key, value, sessionCookie ? null : '2200-01-01T00:00:00.000Z', {
           secure: secure, 
           sameSite: sameSite
         });

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -20,6 +20,7 @@ export interface TokenManagerOptions {
   autoRenew?: boolean;
   autoRemove?: boolean;
   secure?: boolean;
+  sessionCookie?: boolean
   storage?: string;
   storageKey?: string;
   expireEarlySeconds?: number;

--- a/lib/types/Storage.ts
+++ b/lib/types/Storage.ts
@@ -30,6 +30,7 @@ export interface PKCEStorage extends StorageProvider {
 }
 
 export interface StorageOptions extends CookieOptions {
+  sessionCookie?: boolean;
   preferLocalStorage?: boolean;
 }
 

--- a/test/spec/browserStorage.js
+++ b/test/spec/browserStorage.js
@@ -215,13 +215,25 @@ describe('browserStorage', () => {
       expect(browserStorage.storage.get).toHaveBeenCalledWith(key);
     });
 
-    it('setItem: will call storage.set, passing secure and sameSite options', () => {
+    it('setItem: will call storage.set, passing secure and sameSite options but no sessionCookie option', () => {
       jest.spyOn(browserStorage.storage, 'set').mockReturnValue(null);
       const storage = browserStorage.getCookieStorage({ secure: 'fakey', sameSite: 'strictly fakey' });
       const key = 'fake-key';
       const val = { fakeValue: true };
       storage.setItem(key, val);
       expect(browserStorage.storage.set).toHaveBeenCalledWith(key, val, '2200-01-01T00:00:00.000Z', {
+        secure: 'fakey',
+        sameSite: 'strictly fakey'
+      });
+    });
+
+    it('setItem: will call storage.set, passing sessionCookie, secure and sameSite options ', () => {
+      jest.spyOn(browserStorage.storage, 'set').mockReturnValue(null);
+      const storage = browserStorage.getCookieStorage({ secure: 'fakey', sameSite: 'strictly fakey', sessionCookie: true });
+      const key = 'fake-key';
+      const val = { fakeValue: true };
+      storage.setItem(key, val);
+      expect(browserStorage.storage.set).toHaveBeenCalledWith(key, val, null, {
         secure: 'fakey',
         sameSite: 'strictly fakey'
       });

--- a/test/spec/tokenManager.js
+++ b/test/spec/tokenManager.js
@@ -31,6 +31,7 @@ function createAuth(options) {
     tokenManager: {
       expireEarlySeconds: options.tokenManager.expireEarlySeconds || 0,
       storage: options.tokenManager.storage,
+      sessionCookie: options.tokenManager.sessionCookie,
       storageKey: options.tokenManager.storageKey,
       autoRenew: options.tokenManager.autoRenew || false,
       autoRemove: options.tokenManager.autoRemove || false,
@@ -112,6 +113,41 @@ describe('TokenManager', function() {
       var payload = { foo: 'bar' };
       client.emitter.emit('fake', payload);
       expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sessionCookie', function() {
+    it('Uses a fixed date by default', function() {
+      setupSync({
+        tokenManager: {
+          storage: 'cookie'
+        }
+      });
+      var setCookieMock = util.mockSetCookie();
+      client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
+      expect(setCookieMock).toHaveBeenCalledWith(
+        'okta-token-storage_test-idToken',
+        JSON.stringify(tokens.standardIdTokenParsed),
+        '2200-01-01T00:00:00.000Z',
+        secureCookieSettings
+      );
+    });
+
+    it('Uses a session cookie when set', function() {
+      setupSync({
+        tokenManager: {
+          storage: 'cookie',
+          sessionCookie: true
+        }
+      });
+      var setCookieMock = util.mockSetCookie();
+      client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
+      expect(setCookieMock).toHaveBeenCalledWith(
+        'okta-token-storage_test-idToken',
+        JSON.stringify(tokens.standardIdTokenParsed),
+        null,
+        secureCookieSettings
+      );
     });
   });
 
@@ -252,7 +288,7 @@ describe('TokenManager', function() {
       expect(setCookieMock).toHaveBeenCalledWith(
         'okta-token-storage_test-idToken',
         JSON.stringify(tokens.standardIdTokenParsed),
-        '2200-01-01T00:00:00.000Z',
+        null,
         secureCookieSettings
       );
     });


### PR DESCRIPTION
Access and Id Token can now set as session cookies when using cookie storage