### PR TITLE
fix: Remove overeager catch when using refresh token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 - [#583](https://github.com/okta/okta-auth-js/pull/583) Better error handling for redirect flows: if redirect URI contains `error` or `error_description` then `isLoginRedirect` will return true and `parseFromUrl` will throw `OAuthError`
 
+## 4.5.1
+
+### Bug Fixes
+- [#579](https://github.com/okta/okta-auth-js/pull/579) Removes overeager `catch` when using refresh token
+
 ## 4.5.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.6.1 
+- [#595](https://github.com/okta/okta-auth-js/pull/595) Ports fix for overeager `catch` when using refresh token originally from [#579](https://github.com/okta/okta-auth-js/pull/579)
+
 ## 4.6.0
 
 ### Features

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -802,28 +802,26 @@ async function renewTokensWithRefresh(
 
   var urls = getOAuthUrls(sdk, tokenParams);
 
-  try {
-    const response = await http.httpRequest(sdk, {
-      url: refreshTokenObject.tokenUrl,
-      method: 'POST',
-      withCredentials: false,
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
 
-      args: Object.entries({
-        client_id: clientId, // eslint-disable-line camelcase
-        grant_type: 'refresh_token', // eslint-disable-line camelcase
-        scope: refreshTokenObject.scopes.join(' '),
-        refresh_token: refreshTokenObject.refreshToken, // eslint-disable-line camelcase
-      }).map(function ([name, value]) {
-        return name + '=' + encodeURIComponent(value);
-      }).join('&'),
-    });
-    return handleOAuthResponse(sdk, tokenParams, response, urls).then(res => res.tokens);
-  } catch (err) {
-    console.log({ err });
-  }
+  const response = await http.httpRequest(sdk, {
+    url: refreshTokenObject.tokenUrl,
+    method: 'POST',
+    withCredentials: false,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+
+    args: Object.entries({
+      client_id: clientId, // eslint-disable-line camelcase
+      grant_type: 'refresh_token', // eslint-disable-line camelcase
+      scope: refreshTokenObject.scopes.join(' '),
+      refresh_token: refreshTokenObject.refreshToken, // eslint-disable-line camelcase
+    }).map(function ([name, value]) {
+      return name + '=' + encodeURIComponent(value);
+    }).join('&'),
+  });
+  return handleOAuthResponse(sdk, tokenParams, response, urls).then(res => res.tokens);
+
 }
 
 function renewTokens(sdk, options: TokenParams): Promise<Tokens> {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
Foreporting the change from 4.5.1 to the 4.6 branch