### PR TITLE
Update SPA client id

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -9,7 +9,7 @@ export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/build2/reports/e2e"
 
 export ISSUER=https://samples-javascript.okta.com/oauth2/default
-export CLIENT_ID=0oapmwm72082GXal14x6
+export CLIENT_ID=0oa1xyzajgPFGWlLP4x7
 export USERNAME=george@acme.com
 get_secret prod/okta-sdk-vars/password PASSWORD
 


### PR DESCRIPTION
- I updated the existing SPA client used in the e2e tests to support one time refresh tokens. This is causing one of the token tests related to okta session cookie fail, since one time refresh tokens don't depend on okta session cookie.
- Created a new SPA client that doesn't have refresh token which needs to updated in the tests.