### PR TITLE
fix: promise returned on fetch missing finally

### DIFF
--- a/lib/fetch/fetchRequest.ts
+++ b/lib/fetch/fetchRequest.ts
@@ -30,7 +30,7 @@ function readData(response: FetchResponse): Promise<object | string> {
 }
 
 function formatResult(status: number, data: object | string) {
-  const isObject = typeof data === 'object'; 
+  const isObject = typeof data === 'object';
   const result: HttpResponse = {
     responseText: isObject ? JSON.stringify(data) : data as string,
     status: status
@@ -58,8 +58,13 @@ function fetchRequest(method: string, url: string, args: FetchOptions) {
     headers: args.headers,
     body: body as string,
     credentials: args.withCredentials ? 'include' : 'omit'
-  })
-  .then(function(response) {
+  });
+
+  if (!fetchPromise.finally) {
+    fetchPromise = Promise.resolve(fetchPromise);
+  }
+
+  return fetchPromise.then(function(response) {
     var error = !response.ok;
     var status = response.status;
     return readData(response)
@@ -74,7 +79,6 @@ function fetchRequest(method: string, url: string, args: FetchOptions) {
         return result;
       });
   });
-  return fetchPromise;
 }
 
 export default fetchRequest;

--- a/test/spec/fetch-request.js
+++ b/test/spec/fetch-request.js
@@ -72,6 +72,24 @@ describe('fetchRequest', function () {
         expect(fetchSpy).not.toHaveBeenCalled();
       });
     });
+    it('fetchRequest returns a promise with finally on it', () => {
+      const globalFetch = jest.fn(() => {
+        return Promise.resolve(response);
+      });
+      window.fetch = globalFetch;
+      const fetchRequestPromise = fetchRequest(requestMethod, requestUrl, {});
+      expect(fetchRequestPromise.finally).toBeDefined();
+    });
+    it('fetchRequest returns a promise with finally on it even if fetch doesnt return a promise with fetch', () => {
+      const globalFetch = jest.fn(() => {
+        const resolvedPromise = Promise.resolve(response);
+        resolvedPromise.finally = null;
+        return resolvedPromise;
+      });
+      window.fetch = globalFetch;
+      const fetchRequestPromise = fetchRequest(requestMethod, requestUrl, {});
+      expect(fetchRequestPromise.finally).toBeDefined();
+    });
   });
 
   describe('request', () => {

--- a/test/spec/fetch-request.js
+++ b/test/spec/fetch-request.js
@@ -82,9 +82,10 @@ describe('fetchRequest', function () {
     });
     it('fetchRequest returns a promise with finally on it even if fetch doesnt return a promise with fetch', () => {
       const globalFetch = jest.fn(() => {
-        const resolvedPromise = Promise.resolve(response);
-        resolvedPromise.finally = null;
-        return resolvedPromise;
+        return {
+          then: () => {},
+          catch: () => {}
+        };
       });
       window.fetch = globalFetch;
       const fetchRequestPromise = fetchRequest(requestMethod, requestUrl, {});


### PR DESCRIPTION
* In Edge 17 and lower the promise returned by fetch api call doesnt have
finally on it.

* Fix is if finally is not present on promise returned by fetch we explicitly wrap it with
a promise.

RESOLVES: OKTA-367504

**Chrome**

https://user-images.githubusercontent.com/17267130/106799100-b0b51000-6613-11eb-9ba0-91c823e0fa78.mov

**Edge**

https://user-images.githubusercontent.com/17267130/106799245-e1954500-6613-11eb-8b62-d817a94e1fc6.mov

