### PR TITLE
Fix compilation error TS2411 on Storage.d.ts

### DIFF
--- a/lib/types/Storage.ts
+++ b/lib/types/Storage.ts
@@ -100,5 +100,5 @@ export interface CookieStorage extends SimpleStorage {
 export interface StorageManagerOptions {
   token?: StorageOptions;
   transaction?: StorageOptions;
-  [propName: string]: StorageOptions; // custom sections are allowed
+  [propName: string]: StorageOptions | undefined; // custom sections are allowed
 }


### PR DESCRIPTION
Got the following errors when updated the package @okta/okta-angular to v3.0.1:

Error: node_modules/@okta/okta-auth-js/lib/types/Storage.d.ts:79:5 - error TS2411: Property 'token' of type 'StorageOptions | undefined' is not
assignable to string index type 'StorageOptions'.

79     token?: StorageOptions;
       ~~~~~

Error: node_modules/@okta/okta-auth-js/lib/types/Storage.d.ts:80:5 - error TS2411: Property 'transaction' of type 'StorageOptions | undefined' is not assignable to string index type 'StorageOptions'.

80     transaction?: StorageOptions;
       ~~~~~~~~~~~

The above fixed it.