### PR TITLE
feat: When retrieving well known configuration, do not require credentials

### DIFF
--- a/lib/oidc/endpoints/well-known.ts
+++ b/lib/oidc/endpoints/well-known.ts
@@ -18,7 +18,8 @@ import AuthSdkError from '../../errors/AuthSdkError';
 export function getWellKnown(sdk: OktaAuth, issuer?: string): Promise<WellKnownResponse> {
   var authServerUri = (issuer || sdk.options.issuer);
   return http.get(sdk, authServerUri + '/.well-known/openid-configuration', {
-    cacheResponse: true
+    cacheResponse: true,
+    withCredentials: false,
   });
 }
 
@@ -47,7 +48,8 @@ export function getKey(sdk: OktaAuth, issuer: string, kid: string): Promise<stri
 
     // Pull the latest keys if the key wasn't in the cache
     return http.get(sdk, jwksUri, {
-      cacheResponse: true
+      cacheResponse: true,
+      withCredentials: false,
     })
     .then(function(res) {
       var key = find(res.keys, {


### PR DESCRIPTION
When the preflight request is made to retrieve the .well-known/openid-configuration metadata file, do not force withCredentials to be true. 

This resolves an issue with the okta-auth-js library wherein the browser blocks the well-known request due to a CORS conflict if the authorisation server does not enforce an Access-Control-Allow-Origin header containing the requesting domain on the well-known endpoints. Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials.

Given these well-known endpoints in some server implementations are often publically accessible and therefore have an Access-Control-Allow-Origin of '*', this small change allows the same library to be used for _both_ Okta official authorisation endpoints and other Oauth2 implementations without hitting the CORS issue.