### PR TITLE
feat: When retrieving well known configuration, do not require credentials

### DIFF
--- a/lib/oidc/endpoints/well-known.ts
+++ b/lib/oidc/endpoints/well-known.ts
@@ -18,7 +18,8 @@ import AuthSdkError from '../../errors/AuthSdkError';
 export function getWellKnown(sdk: OktaAuth, issuer?: string): Promise<WellKnownResponse> {
   var authServerUri = (issuer || sdk.options.issuer);
   return http.get(sdk, authServerUri + '/.well-known/openid-configuration', {
-    cacheResponse: true
+    cacheResponse: true,
+    withCredentials: false,
   });
 }
 
@@ -47,7 +48,8 @@ export function getKey(sdk: OktaAuth, issuer: string, kid: string): Promise<stri
 
     // Pull the latest keys if the key wasn't in the cache
     return http.get(sdk, jwksUri, {
-      cacheResponse: true
+      cacheResponse: true,
+      withCredentials: false,
     })
     .then(function(res) {
       var key = find(res.keys, {

--- a/test/spec/oidc/endpoints/well-known.ts
+++ b/test/spec/oidc/endpoints/well-known.ts
@@ -38,7 +38,8 @@ describe('getWellKnown', function() {
         {
           request: {
             method: 'get',
-            uri: '/.well-known/openid-configuration'
+            uri: '/.well-known/openid-configuration',
+            withCredentials: false
           },
           response: 'well-known'
         }
@@ -61,7 +62,8 @@ describe('getWellKnown', function() {
         {
           request: {
             method: 'get',
-            uri: '/oauth2/default/.well-known/openid-configuration'
+            uri: '/oauth2/default/.well-known/openid-configuration',
+            withCredentials: false
           },
           response: 'well-known'
         }
@@ -84,7 +86,8 @@ describe('getWellKnown', function() {
         {
           request: {
             method: 'get',
-            uri: '/oauth2/custom/.well-known/openid-configuration'
+            uri: '/oauth2/custom/.well-known/openid-configuration',
+            withCredentials: false
           },
           response: 'well-known'
         }
@@ -106,7 +109,8 @@ describe('getWellKnown', function() {
         {
           request: {
             method: 'get',
-            uri: '/oauth2/custom2/.well-known/openid-configuration'
+            uri: '/oauth2/custom2/.well-known/openid-configuration',
+            withCredentials: false
           },
           response: 'well-known'
         }
@@ -128,7 +132,8 @@ describe('getWellKnown', function() {
         {
           request: {
             method: 'get',
-            uri: '/.well-known/openid-configuration'
+            uri: '/.well-known/openid-configuration',
+            withCredentials: false
           },
           response: 'well-known'
         }
@@ -183,7 +188,8 @@ describe('getWellKnown', function() {
         {
           request: {
             method: 'get',
-            uri: '/.well-known/openid-configuration'
+            uri: '/.well-known/openid-configuration',
+            withCredentials: false
           },
           response: 'well-known'
         }
@@ -219,7 +225,8 @@ describe('getWellKnown', function() {
         {
           request: {
             method: 'get',
-            uri: '/.well-known/openid-configuration'
+            uri: '/.well-known/openid-configuration',
+            withCredentials: false
           },
           response: 'well-known'
         }
@@ -251,7 +258,8 @@ describe('getWellKnown', function() {
         {
           request: {
             method: 'get',
-            uri: '/.well-known/openid-configuration'
+            uri: '/.well-known/openid-configuration',
+            withCredentials: false
           },
           response: 'well-known'
         }
@@ -291,7 +299,8 @@ describe('getWellKnown', function() {
         {
           request: {
             method: 'get',
-            uri: '/.well-known/openid-configuration'
+            uri: '/.well-known/openid-configuration',
+            withCredentials: false
           },
           response: 'well-known'
         }
@@ -339,7 +348,8 @@ describe('getKey', function() {
         {
           request: {
             method: 'get',
-            uri: '/oauth2/v1/keys'
+            uri: '/oauth2/v1/keys',
+            withCredentials: false
           },
           response: 'keys'
         }
@@ -373,7 +383,8 @@ describe('getKey', function() {
         {
           request: {
             method: 'get',
-            uri: '/oauth2/v1/keys'
+            uri: '/oauth2/v1/keys',
+            withCredentials: false
           },
           response: 'keys'
         }
@@ -427,7 +438,8 @@ describe('getKey', function() {
         {
           request: {
             method: 'get',
-            uri: '/oauth2/v1/keys'
+            uri: '/oauth2/v1/keys',
+            withCredentials: false
           },
           response: 'keys'
         }


### PR DESCRIPTION
When the preflight request is made to retrieve the .well-known/openid-configuration metadata file, do not force withCredentials to be true.

This resolves an issue with the okta-auth-js library wherein the browser blocks the well-known request due to a CORS conflict if the authorisation server does not enforce an Access-Control-Allow-Origin header containing the requesting domain on the well-known endpoints. Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials.

Given these well-known endpoints in some server implementations are often publically accessible and therefore have an Access-Control-Allow-Origin of '*', this small change allows the same library to be used for both Okta official authorisation endpoints and other Oauth2 implementations without hitting the CORS issue.