### PR TITLE
Fix error on tokens renew with refresh token

### DIFF
--- a/lib/oidc/endpoints/token.ts
+++ b/lib/oidc/endpoints/token.ts
@@ -57,9 +57,9 @@ export function postToTokenEndpoint(sdk, options: TokenParams, urls: CustomUrls)
   });
 }
 
-export function postRenewTokensWithRefreshToken(sdk, options: TokenParams, refreshTokenObject: RefreshToken): Promise<OAuthResponse> {
+export function postRefreshToken(sdk, options: TokenParams, refreshToken: RefreshToken): Promise<OAuthResponse> {
   return http.httpRequest(sdk, {
-    url: refreshTokenObject.tokenUrl,
+    url: refreshToken.tokenUrl,
     method: 'POST',
     withCredentials: false,
     headers: {
@@ -69,8 +69,8 @@ export function postRenewTokensWithRefreshToken(sdk, options: TokenParams, refre
     args: Object.entries({
       client_id: options.clientId, // eslint-disable-line camelcase
       grant_type: 'refresh_token', // eslint-disable-line camelcase
-      scope: refreshTokenObject.scopes.join(' '),
-      refresh_token: refreshTokenObject.refreshToken, // eslint-disable-line camelcase
+      scope: refreshToken.scopes.join(' '),
+      refresh_token: refreshToken.refreshToken, // eslint-disable-line camelcase
     }).map(function ([name, value]) {
       return name + '=' + encodeURIComponent(value);
     }).join('&'),

--- a/lib/oidc/endpoints/token.ts
+++ b/lib/oidc/endpoints/token.ts
@@ -1,7 +1,5 @@
-import { RefreshToken } from './../../../build/lib/types/Token.d';
-
 import { AuthSdkError } from '../../errors';
-import { CustomUrls, OAuthParams, OAuthResponse, TokenParams } from '../../types';
+import { CustomUrls, OAuthParams, OAuthResponse, RefreshToken, TokenParams } from '../../types';
 import { removeNils, toQueryString } from '../../util';
 import http from '../../http';
 

--- a/lib/oidc/endpoints/token.ts
+++ b/lib/oidc/endpoints/token.ts
@@ -1,3 +1,4 @@
+import { RefreshToken } from './../../../build/lib/types/Token.d';
 
 import { AuthSdkError } from '../../errors';
 import { CustomUrls, OAuthParams, OAuthResponse, TokenParams } from '../../types';
@@ -55,5 +56,25 @@ export function postToTokenEndpoint(sdk, options: TokenParams, urls: CustomUrls)
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded'
     }
+  });
+}
+
+export function postRenewTokensWithRefreshToken(sdk, options: TokenParams, refreshTokenObject: RefreshToken): Promise<OAuthResponse> {
+  return http.httpRequest(sdk, {
+    url: refreshTokenObject.tokenUrl,
+    method: 'POST',
+    withCredentials: false,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+
+    args: Object.entries({
+      client_id: options.clientId, // eslint-disable-line camelcase
+      grant_type: 'refresh_token', // eslint-disable-line camelcase
+      scope: refreshTokenObject.scopes.join(' '),
+      refresh_token: refreshTokenObject.refreshToken, // eslint-disable-line camelcase
+    }).map(function ([name, value]) {
+      return name + '=' + encodeURIComponent(value);
+    }).join('&'),
   });
 }

--- a/lib/oidc/handleOAuthResponse.ts
+++ b/lib/oidc/handleOAuthResponse.ts
@@ -62,7 +62,13 @@ export function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res
     responseType = [responseType];
   }
 
-  var scopes = clone(tokenParams.scopes);
+  var scopes;
+  if (res.scope) {
+    scopes = res.scope.split(' ');
+  } else {
+    var scopes = clone(tokenParams.scopes);
+
+  }
   var clientId = tokenParams.clientId || sdk.options.clientId;
 
   // Handling the result from implicit flow or PKCE token exchange

--- a/lib/oidc/handleOAuthResponse.ts
+++ b/lib/oidc/handleOAuthResponse.ts
@@ -66,8 +66,7 @@ export function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res
   if (res.scope) {
     scopes = res.scope.split(' ');
   } else {
-    var scopes = clone(tokenParams.scopes);
-
+    scopes = clone(tokenParams.scopes);
   }
   var clientId = tokenParams.clientId || sdk.options.clientId;
 

--- a/lib/oidc/renewTokensWithRefresh.ts
+++ b/lib/oidc/renewTokensWithRefresh.ts
@@ -15,7 +15,6 @@ import { getOAuthUrls } from './util/oauth';
 import { OktaAuth, TokenParams, RefreshToken, Tokens } from '../types';
 import { handleOAuthResponse } from './handleOAuthResponse';
 import { postRefreshToken } from './endpoints/token';
-import { getDefaultTokenParams } from './util';
 
 export async function renewTokensWithRefresh(
   sdk: OktaAuth,
@@ -27,16 +26,11 @@ export async function renewTokensWithRefresh(
     throw new AuthSdkError('A clientId must be specified in the OktaAuth constructor to renew tokens');
   }
 
-  const renewTokenParams = {
+  const renewTokenParams: TokenParams = Object.assign({}, tokenParams, {
     clientId,
-  };
+  });
   const tokenResponse = await postRefreshToken(sdk, renewTokenParams, refreshTokenObject);
-
-  const { scopes } = getDefaultTokenParams(sdk);
-  const handleResponseParams = {
-    scopes
-  };
   const urls = getOAuthUrls(sdk, tokenParams);
-  const { tokens } = await handleOAuthResponse(sdk, handleResponseParams, tokenResponse, urls);
+  const { tokens } = await handleOAuthResponse(sdk, renewTokenParams, tokenResponse, urls);
   return tokens;
 }

--- a/lib/oidc/renewTokensWithRefresh.ts
+++ b/lib/oidc/renewTokensWithRefresh.ts
@@ -15,23 +15,28 @@ import { getOAuthUrls } from './util/oauth';
 import { OktaAuth, TokenParams, RefreshToken, Tokens } from '../types';
 import { handleOAuthResponse } from './handleOAuthResponse';
 import { postRefreshToken } from './endpoints/token';
+import { getDefaultTokenParams } from './util';
 
 export async function renewTokensWithRefresh(
   sdk: OktaAuth,
   tokenParams: TokenParams,
   refreshTokenObject: RefreshToken
 ): Promise<Tokens> {
-  var clientId = sdk.options.clientId;
+  const { clientId } = sdk.options;
   if (!clientId) {
     throw new AuthSdkError('A clientId must be specified in the OktaAuth constructor to renew tokens');
   }
 
-  var urls = getOAuthUrls(sdk, tokenParams);
   const renewTokenParams = {
     clientId,
   };
-
   const tokenResponse = await postRefreshToken(sdk, renewTokenParams, refreshTokenObject);
-  const { tokens } = await handleOAuthResponse(sdk, renewTokenParams, tokenResponse, urls);
+
+  const { scopes } = getDefaultTokenParams(sdk);
+  const handleResponseParams = {
+    scopes
+  };
+  const urls = getOAuthUrls(sdk, tokenParams);
+  const { tokens } = await handleOAuthResponse(sdk, handleResponseParams, tokenResponse, urls);
   return tokens;
 }

--- a/lib/oidc/renewTokensWithRefresh.ts
+++ b/lib/oidc/renewTokensWithRefresh.ts
@@ -28,7 +28,6 @@ export async function renewTokensWithRefresh(
 
   var urls = getOAuthUrls(sdk, tokenParams);
 
-
   const response = await http.httpRequest(sdk, {
     url: refreshTokenObject.tokenUrl,
     method: 'POST',
@@ -46,6 +45,9 @@ export async function renewTokensWithRefresh(
       return name + '=' + encodeURIComponent(value);
     }).join('&'),
   });
-  return handleOAuthResponse(sdk, tokenParams, response, urls).then(res => res.tokens);
 
+  const renewTokenOptions = {
+    clientId,
+  };
+  return handleOAuthResponse(sdk, renewTokenOptions, response, urls).then(res => res.tokens);
 }

--- a/lib/oidc/renewTokensWithRefresh.ts
+++ b/lib/oidc/renewTokensWithRefresh.ts
@@ -14,7 +14,7 @@ import { AuthSdkError } from '../errors';
 import { getOAuthUrls } from './util/oauth';
 import { OktaAuth, TokenParams, RefreshToken, Tokens } from '../types';
 import { handleOAuthResponse } from './handleOAuthResponse';
-import { postRenewTokensWithRefreshToken } from './endpoints/token';
+import { postRefreshToken } from './endpoints/token';
 
 export async function renewTokensWithRefresh(
   sdk: OktaAuth,
@@ -31,7 +31,7 @@ export async function renewTokensWithRefresh(
     clientId,
   };
 
-  const tokenResponse = await postRenewTokensWithRefreshToken(sdk, renewTokenParams, refreshTokenObject);
+  const tokenResponse = await postRefreshToken(sdk, renewTokenParams, refreshTokenObject);
   const { tokens } = await handleOAuthResponse(sdk, renewTokenParams, tokenResponse, urls);
   return tokens;
 }

--- a/lib/types/OAuth.ts
+++ b/lib/types/OAuth.ts
@@ -42,6 +42,7 @@ export interface OAuthResponse {
   access_token?: string;
   id_token?: string;
   refresh_token?: string;
+  scope?: string;
   error?: string;
   error_description?: string;
 }

--- a/test/spec/oidc/renewTokens.ts
+++ b/test/spec/oidc/renewTokens.ts
@@ -1,8 +1,9 @@
 import tokens from '@okta/test.support/tokens';
 import oauthUtil from '@okta/test.support/oauthUtil';
-import http from '../../../lib/http';
 import { OktaAuth } from '@okta/okta-auth-js';
 import util from '@okta/test.support/util';
+import * as tokenEndpoint from '../../../lib/oidc/endpoints/token';
+
 
 describe('token.renewTokens', function() {
   it('should return tokens', function() {
@@ -191,7 +192,7 @@ describe('token.renewTokens', function() {
   describe('renewTokensWithRefresh', function () {
     beforeEach(function () {
       util.warpToUnixTime(tokens.standardIdToken2Claims.iat);
-      jest.spyOn(http, 'httpRequest').mockImplementation(function () {
+      jest.spyOn(tokenEndpoint, 'postRenewTokensWithRefreshToken').mockImplementation(function () {
 
         return Promise.resolve({
           'id_token': tokens.standardIdToken,
@@ -202,7 +203,6 @@ describe('token.renewTokens', function() {
     afterEach(() => {
       jest.clearAllMocks();
     });
-
 
     it('is called when refresh token is available in browser storage', async function() {
       const authInstance = new OktaAuth({

--- a/test/spec/oidc/renewTokens.ts
+++ b/test/spec/oidc/renewTokens.ts
@@ -1,9 +1,5 @@
 import tokens from '@okta/test.support/tokens';
 import oauthUtil from '@okta/test.support/oauthUtil';
-import { OktaAuth } from '@okta/okta-auth-js';
-import util from '@okta/test.support/util';
-import * as tokenEndpoint from '../../../lib/oidc/endpoints/token';
-
 
 describe('token.renewTokens', function() {
   it('should return tokens', function() {
@@ -188,32 +184,4 @@ describe('token.renewTokens', function() {
       }
     });
   });
-
-  describe('renewTokensWithRefresh', function () {
-    beforeEach(function () {
-      util.warpToUnixTime(tokens.standardIdToken2Claims.iat);
-      jest.spyOn(tokenEndpoint, 'postRefreshToken').mockImplementation(function () {
-
-        return Promise.resolve({
-          'id_token': tokens.standardIdToken,
-          'refresh_token': 'fakeRerfeshTalken'
-        });
-      });
-    });
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
-
-    it('is called when refresh token is available in browser storage', async function() {
-      const authInstance = new OktaAuth({
-          issuer: 'https://auth-js-test.okta.com',
-          clientId: 'NPSfOkH5eZrTy8PMDlvx',
-      });
-      authInstance.tokenManager.add('refreshToken', tokens.standardRefreshToken);
-      const newTokens = await authInstance.token.renewTokens();
-      expect(Object.keys(newTokens)).toContain('idToken');
-      expect(Object.keys(newTokens)).toContain('refreshToken');
-    });
-  });
-
 });

--- a/test/spec/oidc/renewTokens.ts
+++ b/test/spec/oidc/renewTokens.ts
@@ -2,6 +2,7 @@ import tokens from '@okta/test.support/tokens';
 import oauthUtil from '@okta/test.support/oauthUtil';
 import http from '../../../lib/http';
 import { OktaAuth } from '@okta/okta-auth-js';
+import util from '@okta/test.support/util';
 
 describe('token.renewTokens', function() {
   it('should return tokens', function() {
@@ -189,10 +190,11 @@ describe('token.renewTokens', function() {
 
   describe('renewTokensWithRefresh', function () {
     beforeEach(function () {
+      util.warpToUnixTime(tokens.standardIdToken2Claims.iat);
       jest.spyOn(http, 'httpRequest').mockImplementation(function () {
+
         return Promise.resolve({
           'id_token': tokens.standardIdToken,
-          'access_token': tokens.standardAccessToken,
           'refresh_token': 'fakeRerfeshTalken'
         });
       });
@@ -210,7 +212,6 @@ describe('token.renewTokens', function() {
       authInstance.tokenManager.add('refreshToken', tokens.standardRefreshToken);
       const newTokens = await authInstance.token.renewTokens();
       expect(Object.keys(newTokens)).toContain('idToken');
-      expect(Object.keys(newTokens)).toContain('accessToken');
       expect(Object.keys(newTokens)).toContain('refreshToken');
     });
   });

--- a/test/spec/oidc/renewTokens.ts
+++ b/test/spec/oidc/renewTokens.ts
@@ -1,5 +1,7 @@
 import tokens from '@okta/test.support/tokens';
 import oauthUtil from '@okta/test.support/oauthUtil';
+import http from '../../../lib/http';
+import { OktaAuth } from '@okta/okta-auth-js';
 
 describe('token.renewTokens', function() {
   it('should return tokens', function() {
@@ -184,4 +186,33 @@ describe('token.renewTokens', function() {
       }
     });
   });
+
+  describe('renewTokensWithRefresh', function () {
+    beforeEach(function () {
+      jest.spyOn(http, 'httpRequest').mockImplementation(function () {
+        return Promise.resolve({
+          'id_token': tokens.standardIdToken,
+          'access_token': tokens.standardAccessToken,
+          'refresh_token': 'fakeRerfeshTalken'
+        });
+      });
+    });
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+
+    it('is called when refresh token is available in browser storage', async function() {
+      const authInstance = new OktaAuth({
+          issuer: 'https://auth-js-test.okta.com',
+          clientId: 'NPSfOkH5eZrTy8PMDlvx',
+      });
+      authInstance.tokenManager.add('refreshToken', tokens.standardRefreshToken);
+      const newTokens = await authInstance.token.renewTokens();
+      expect(Object.keys(newTokens)).toContain('idToken');
+      expect(Object.keys(newTokens)).toContain('accessToken');
+      expect(Object.keys(newTokens)).toContain('refreshToken');
+    });
+  });
+
 });

--- a/test/spec/oidc/renewTokens.ts
+++ b/test/spec/oidc/renewTokens.ts
@@ -192,7 +192,7 @@ describe('token.renewTokens', function() {
   describe('renewTokensWithRefresh', function () {
     beforeEach(function () {
       util.warpToUnixTime(tokens.standardIdToken2Claims.iat);
-      jest.spyOn(tokenEndpoint, 'postRenewTokensWithRefreshToken').mockImplementation(function () {
+      jest.spyOn(tokenEndpoint, 'postRefreshToken').mockImplementation(function () {
 
         return Promise.resolve({
           'id_token': tokens.standardIdToken,

--- a/test/spec/oidc/renewTokensWithRefresh.ts
+++ b/test/spec/oidc/renewTokensWithRefresh.ts
@@ -65,6 +65,6 @@ describe('renewTokensWithRefresh', function () {
     });
     authInstance.tokenManager.add('refreshToken', tokens.standardRefreshTokenParsed);
     await expect(authInstance.token.renewTokens()).rejects.toThrow(
-      'A clientId and scopes must be specified in the OktaAuth constructor to renew tokens');
+      'A clientId must be specified in the OktaAuth constructor to renew tokens');
   });
 });

--- a/test/spec/oidc/renewTokensWithRefresh.ts
+++ b/test/spec/oidc/renewTokensWithRefresh.ts
@@ -25,6 +25,7 @@ describe('renewTokensWithRefresh', function () {
         'id_token': tokens.standardIdToken,
         'refresh_token': tokens.standardRefreshToken2,
         'expires_in': '0',
+        'scope': 'openid email',
       });
     });
     renewTokenSpy = jest.spyOn(renewTokensWithRefreshTokenModule, 'renewTokensWithRefresh');

--- a/test/spec/oidc/renewTokensWithRefresh.ts
+++ b/test/spec/oidc/renewTokensWithRefresh.ts
@@ -1,0 +1,70 @@
+import { TokenResponse } from './../../../build/lib/types/api.d';
+import { OktaAuth } from '@okta/okta-auth-js';
+import tokens from '@okta/test.support/tokens';
+import util from '@okta/test.support/util';
+import * as tokenEndpoint from '../../../lib/oidc/endpoints/token';
+import * as renewTokensWithRefreshTokenModule from '../../../lib/oidc/renewTokensWithRefresh';
+import * as getWithoutPromptModule from '../../../lib/oidc/getWithoutPrompt';
+import oauthUtil from '@okta/test.support/oauthUtil';
+
+describe('renewTokensWithRefresh', function () {
+  let renewTokenSpy;
+  let authInstance;
+
+  beforeEach(function () {
+    jest.spyOn(getWithoutPromptModule, 'getWithoutPrompt').mockImplementation(function () {
+      const tokenResponse: TokenResponse = {
+        tokens: {},
+        state: '',
+        code: ''
+      };
+      return Promise.resolve(tokenResponse);
+    });
+    jest.spyOn(tokenEndpoint, 'postRefreshToken').mockImplementation(function () {
+      return Promise.resolve({
+        'id_token': tokens.standardIdToken,
+        'refresh_token': tokens.standardRefreshToken2,
+        'expires_in': '0',
+      });
+    });
+    renewTokenSpy = jest.spyOn(renewTokensWithRefreshTokenModule, 'renewTokensWithRefresh');
+
+    util.warpToUnixTime(tokens.standardIdToken2Claims.iat);
+    authInstance = new OktaAuth({
+      issuer: 'https://auth-js-test.okta.com',
+      clientId: 'NPSfOkH5eZrTy8PMDlvx',
+    });
+    authInstance.tokenManager.clear();
+    oauthUtil.loadWellKnownAndKeysCache(authInstance);
+  });
+
+
+  it('is called when refresh token is available in browser storage', async function() {
+    await authInstance.token.renewTokens();
+    expect(renewTokenSpy).not.toHaveBeenCalled();
+
+    authInstance.tokenManager.add('refreshToken', tokens.standardRefreshTokenParsed);
+    await authInstance.token.renewTokens();
+
+    const renewTokenArguments = renewTokenSpy.mock.calls[0];
+    expect(renewTokenSpy).toHaveBeenCalled();
+    expect(renewTokenArguments[2]).toMatchObject(tokens.standardRefreshTokenParsed);
+  });
+
+  it('returns tokens dict', async function() {
+    authInstance.tokenManager.add('refreshToken', tokens.standardRefreshTokenParsed);
+
+    const newTokens = await authInstance.token.renewTokens();
+    expect(newTokens['idToken']).toEqual(tokens.standardIdTokenParsed);
+    expect(newTokens['refreshToken']).toEqual(tokens.standardRefreshToken2Parsed);
+  });
+
+  it('throws when SDK has no clientId configured', async function() {
+    authInstance = new OktaAuth({
+      issuer: 'https://auth-js-test.okta.com',
+    });
+    authInstance.tokenManager.add('refreshToken', tokens.standardRefreshTokenParsed);
+    await expect(authInstance.token.renewTokens()).rejects.toThrow(
+      'A clientId and scopes must be specified in the OktaAuth constructor to renew tokens');
+  });
+});

--- a/test/spec/oidc/util/handleOAuthResponse.ts
+++ b/test/spec/oidc/util/handleOAuthResponse.ts
@@ -60,6 +60,14 @@ describe('handleOAuthResponse', () => {
         expect(res.tokens.refreshToken).toBeTruthy();
         expect(res.tokens.refreshToken.refreshToken).toBe('bloo');
       });
+      it('prefers "scope" value from endpoint response over method parameter', async () => {
+        const tokenParams = { responseType: ['token', 'id_token', 'refresh_token'], scopes: ['profile'] };
+        const oauthRes = { id_token: 'foo', access_token: 'blar', refresh_token: 'bloo', scope: 'openid offline_access' };
+        const res = await handleOAuthResponse(sdk, tokenParams, oauthRes, undefined);
+        expect(res.tokens.accessToken.scopes).toEqual(['openid', 'offline_access']);
+        expect(res.tokens.idToken.scopes).toEqual(['openid', 'offline_access']);
+        expect(res.tokens.refreshToken.scopes).toEqual(['openid', 'offline_access']);
+      });
 
       describe('errors', () => {
         beforeEach(() => {

--- a/test/support/tokens.js
+++ b/test/support/tokens.js
@@ -325,8 +325,8 @@ tokens.standardRefreshToken = {
     'email',
     'offline_access'
   ],
-  'tokenUrl': 'https://auth-js-test.okta.com//oauth2/v1/token',
-  'authorizeUrl': 'https://auth-js-test.okta.com//oauth2/v1/authorize',
+  'tokenUrl': 'https://auth-js-test.okta.com/oauth2/v1/token',
+  'authorizeUrl': 'https://auth-js-test.okta.com/oauth2/v1/authorize',
   'issuer': 'https://auth-js-test.okta.com'
 };
 

--- a/test/support/tokens.js
+++ b/test/support/tokens.js
@@ -316,14 +316,28 @@ tokens.authServerAccessTokenParsed = {
   userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
 };
 
-tokens.standardRefreshToken = {
+tokens.standardRefreshToken = 'NrJBJ5-89k9CHZ7CJz4Q42yNqoIjm7BclN-1TH_B7z0';
+tokens.standardRefreshTokenParsed = {
   'value': 'NrJBJ5-89k9CHZ7CJz4Q42yNqoIjm7BclN-1TH_B7z0',
   'refreshToken': 'NrJBJ5-89k9CHZ7CJz4Q42yNqoIjm7BclN-1TH_B7z0',
   'expiresAt': 1613750805,
   'scopes': [
     'openid',
     'email',
-    'offline_access'
+  ],
+  'tokenUrl': 'https://auth-js-test.okta.com/oauth2/v1/token',
+  'authorizeUrl': 'https://auth-js-test.okta.com/oauth2/v1/authorize',
+  'issuer': 'https://auth-js-test.okta.com'
+};
+
+tokens.standardRefreshToken2 = 'fUlkhRyaAFvlsEHXzkz0KYnThBEs-j3yRZwXBwbPTUA';
+tokens.standardRefreshToken2Parsed = {
+  'value': 'fUlkhRyaAFvlsEHXzkz0KYnThBEs-j3yRZwXBwbPTUA',
+  'refreshToken': 'fUlkhRyaAFvlsEHXzkz0KYnThBEs-j3yRZwXBwbPTUA',
+  'expiresAt': 1449696330,
+  'scopes': [
+    'openid',
+    'email',
   ],
   'tokenUrl': 'https://auth-js-test.okta.com/oauth2/v1/token',
   'authorizeUrl': 'https://auth-js-test.okta.com/oauth2/v1/authorize',

--- a/test/support/tokens.js
+++ b/test/support/tokens.js
@@ -316,6 +316,20 @@ tokens.authServerAccessTokenParsed = {
   userinfoUrl: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/userinfo'
 };
 
+tokens.standardRefreshToken = {
+  'value': 'NrJBJ5-89k9CHZ7CJz4Q42yNqoIjm7BclN-1TH_B7z0',
+  'refreshToken': 'NrJBJ5-89k9CHZ7CJz4Q42yNqoIjm7BclN-1TH_B7z0',
+  'expiresAt': 1613750805,
+  'scopes': [
+    'openid',
+    'email',
+    'offline_access'
+  ],
+  'tokenUrl': 'https://auth-js-test.okta.com//oauth2/v1/token',
+  'authorizeUrl': 'https://auth-js-test.okta.com//oauth2/v1/authorize',
+  'issuer': 'https://auth-js-test.okta.com'
+};
+
 tokens.standardAuthorizationCode = '35cFyfgCU2u0a1EzAqbO';
 
 tokens.standardKey = {


### PR DESCRIPTION
`/token` response validation fails as code mistakenly [expects](https://github.com/okta/okta-auth-js/blob/80a3cfea45fe31eefdc526d5989b1608eadd2664/lib/oidc/handleOAuthResponse.ts#L71) it to contain `state` property .

Resolves [OKTA-367047](https://oktainc.atlassian.net/browse/OKTA-367047)