### PR TITLE
build: Upgrades our Base64 dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,17 +68,17 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "Base64": "0.3.0",
+    "Base64": "1.1.0",
     "core-js": "^3.6.5",
     "cross-fetch": "^3.0.6",
     "js-cookie": "2.2.1",
+    "karma-coverage": "^2.0.3",
     "node-cache": "^4.2.0",
     "p-cancelable": "^2.0.0",
     "text-encoding": "^0.7.0",
     "tiny-emitter": "1.1.0",
     "webcrypto-shim": "^0.1.5",
-    "xhr2": "0.1.3",
-    "karma-coverage": "^2.0.3"
+    "xhr2": "0.1.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2506,6 +2506,11 @@ Base64@0.3.0:
   resolved "https://registry.yarnpkg.com/Base64/-/Base64-0.3.0.tgz#6da261a4e80d4fa0f5c684254e5bccd16bbdce9f"
   integrity sha1-baJhpOgNT6D1xoQlTlvM0Wu9zp8=
 
+Base64@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/Base64/-/Base64-1.1.0.tgz#810ef21afa8357df92ad7b5389188c446b9cb956"
+  integrity sha512-qeacf8dvGpf+XAT27ESHMh7z84uRzj/ua2pQdJg483m3bEXv/kVFtDnMgvf70BQGqzbZhR9t6BmASzKvqfJf3Q==
+
 JSONStream@^1.2.1, JSONStream@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"


### PR DESCRIPTION
No expected impact on functionality, but it pushes us to a version that has the Apache license, while the previous version had only the DWTFYW license.