### PR TITLE
Fixed usage of revokeRefreshToken option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - '10'
+  - '12'
 
 install:
   - yarn install --frozen-lockfile

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -382,6 +382,7 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
     var accessToken = options.accessToken;
     var refreshToken = options.refreshToken;
     var revokeAccessToken = options.revokeAccessToken !== false;
+    var revokeRefreshToken = options.revokeRefreshToken !== false;
     var idToken = options.idToken;
   
     var logoutUrl = getOAuthUrls(this).logoutUrl;
@@ -391,7 +392,7 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
     }
   
  
-    if (revokeAccessToken && typeof refreshToken === 'undefined') {
+    if (revokeRefreshToken && typeof refreshToken === 'undefined') {
       refreshToken = (await this.tokenManager.getTokens()).refreshToken as RefreshToken;
     }
 
@@ -402,7 +403,7 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
     // Clear all local tokens
     this.tokenManager.clear();
 
-    if (revokeAccessToken && refreshToken) {
+    if (revokeRefreshToken && refreshToken) {
       await this.revokeRefreshToken(refreshToken);
     }
 

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -199,6 +199,7 @@ export interface SignoutOptions {
   postLogoutRedirectUri?: string;
   accessToken?: AccessToken;
   revokeAccessToken?: boolean;
+  revokeRefreshToken?: boolean;
   idToken?: IDToken;
   state?: string;
 }

--- a/test/spec/OktaAuth/browser.ts
+++ b/test/spec/OktaAuth/browser.ts
@@ -458,6 +458,9 @@ describe('Browser', function() {
       });
 
       it('Can pass a "revokeAccessToken=false" to skip revoke logic', function() {
+        const refreshToken = { refreshToken: 'fake'};
+        auth.tokenManager.getTokens = jest.fn().mockResolvedValue({ accessToken, idToken, refreshToken });
+
         return auth.signOut({ revokeAccessToken: false })
           .then(function() {
             expect(auth.tokenManager.getTokens).toHaveBeenCalledTimes(2);
@@ -468,6 +471,9 @@ describe('Browser', function() {
       });
 
       it('Can pass a "revokeRefreshToken=false" to skip revoke logic', function() {
+        const refreshToken = { refreshToken: 'fake'};
+        auth.tokenManager.getTokens = jest.fn().mockResolvedValue({ accessToken, idToken, refreshToken });
+        
         return auth.signOut({ revokeRefreshToken: false })
           .then(function() {
             expect(auth.tokenManager.getTokens).toHaveBeenCalledTimes(2);

--- a/test/spec/OktaAuth/browser.ts
+++ b/test/spec/OktaAuth/browser.ts
@@ -460,8 +460,18 @@ describe('Browser', function() {
       it('Can pass a "revokeAccessToken=false" to skip revoke logic', function() {
         return auth.signOut({ revokeAccessToken: false })
           .then(function() {
-            expect(auth.tokenManager.getTokens).toHaveBeenCalledTimes(1);
+            expect(auth.tokenManager.getTokens).toHaveBeenCalledTimes(2);
             expect(auth.revokeAccessToken).not.toHaveBeenCalled();
+            expect(auth.revokeRefreshToken).toHaveBeenCalled();
+            expect(window.location.assign).toHaveBeenCalledWith(`${issuer}/oauth2/v1/logout?id_token_hint=${idToken.idToken}&post_logout_redirect_uri=${encodedOrigin}`);
+          });
+      });
+
+      it('Can pass a "revokeRefreshToken=false" to skip revoke logic', function() {
+        return auth.signOut({ revokeRefreshToken: false })
+          .then(function() {
+            expect(auth.tokenManager.getTokens).toHaveBeenCalledTimes(2);
+            expect(auth.revokeAccessToken).toHaveBeenCalled();
             expect(auth.revokeRefreshToken).not.toHaveBeenCalled();
             expect(window.location.assign).toHaveBeenCalledWith(`${issuer}/oauth2/v1/logout?id_token_hint=${idToken.idToken}&post_logout_redirect_uri=${encodedOrigin}`);
           });


### PR DESCRIPTION
- Fixed bug: Option `revokeRefreshToken` was not used during signout
- Set Node.js v12 in travis to fix `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`

Issue: https://github.com/okta/okta-auth-js/issues/635
Task: [OKTA-372720](https://oktainc.atlassian.net/browse/OKTA-372720)