### PR TITLE
updates spa samples for social auth flow

### DIFF
--- a/samples/config.js
+++ b/samples/config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 // All samples use the same widget version, whether CDN or NPM
-const SIW_VERSION = '5.3.2';
+const SIW_VERSION = '5.4.0';
 
 const AUTH_JS_DIR = path.dirname(require.resolve('@okta/okta-auth-js'));
 const AUTH_JS_VERSION = require(path.resolve(AUTH_JS_DIR, '..', '..', 'package.json')).version;

--- a/samples/generated/static-spa/public/app.js
+++ b/samples/generated/static-spa/public/app.js
@@ -153,7 +153,8 @@ function renderUnauthenticated() {
 
 function handleLoginRedirect() {
   if (authClient.isInteractionRequired()) {
-    return beginAuthFlow(); // widget will resume transaction
+    beginAuthFlow(); // widget will resume transaction
+    return Promise.resolve();
   }
   
   // If the URL contains a code, `parseFromUrl` will grab it and exchange the code for tokens
@@ -228,8 +229,7 @@ function showSigninWidget() {
       redirectUri: config.redirectUri,
       useInteractionCodeFlow: config.useInteractionCodeFlow,
       authParams: {
-        issuer: config.issuer,
-        state: JSON.stringify(config.state),
+        issuer: config.issuer
       },
       idps: config.idps.split(/\s+/).map(idpToken => {
         const [type, id] = idpToken.split(/:/);
@@ -241,7 +241,8 @@ function showSigninWidget() {
     });
   
     signIn.showSignInToGetTokens({
-      el: '#signin-widget'
+      el: '#signin-widget',
+      state: JSON.stringify(config.state)
     })
     .then(function(tokens) {
       document.getElementById('flow-widget').style.display = 'none';
@@ -421,9 +422,12 @@ function loadConfig() {
   var idps;
 
   var state;
-  if (stateParam) {
-    // Read from state
+  try {
     state = JSON.parse(stateParam);
+  } catch{};
+
+  if (state) {
+    // Read from state
     issuer = state.issuer;
     clientId = state.clientId;
     storage = state.storage;

--- a/samples/generated/static-spa/public/index.html
+++ b/samples/generated/static-spa/public/index.html
@@ -8,8 +8,8 @@
     <script src="/okta-auth-js.min.js" type="text/javascript"></script>
 
     <!-- okta-signin-widget assets are avilable on CDN -->
-    <script src="https://global.oktacdn.com/okta-signin-widget/5.3.2/js/okta-sign-in.min.js" type="text/javascript"></script>
-    <link href="https://global.oktacdn.com/okta-signin-widget/5.3.2/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+    <script src="https://global.oktacdn.com/okta-signin-widget/5.4.0/js/okta-sign-in.min.js" type="text/javascript"></script>
+    <link href="https://global.oktacdn.com/okta-signin-widget/5.4.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 
     <!-- app styles -->
     <style>

--- a/samples/generated/webpack-spa/package.json
+++ b/samples/generated/webpack-spa/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@okta/okta-auth-js": "*",
-    "@okta/okta-signin-widget": "^5.3.2"
+    "@okta/okta-signin-widget": "^5.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",

--- a/samples/generated/webpack-spa/src/index.js
+++ b/samples/generated/webpack-spa/src/index.js
@@ -404,10 +404,10 @@ function loadConfig() {
   var redirectUri = window.location.origin + '/login/callback'; // Should also be set in Okta Admin UI
   
   // Params which are not in the state
-  var stateParam = url.searchParams.get('state');
-  var error = url.searchParams.get('error');
-  var showForm = url.searchParams.get('showForm');
-  var getTokens = url.searchParams.get('getTokens');
+  var stateParam = url.searchParams.get('state'); // received on login redirect callback
+  var error = url.searchParams.get('error'); // received on login redirect callback
+  var showForm = url.searchParams.get('showForm'); // forces config form to show
+  var getTokens = url.searchParams.get('getTokens'); // forces redirect to get tokens
 
   // Params which are encoded into the state
   var issuer;
@@ -422,9 +422,11 @@ function loadConfig() {
 
   var state;
   try {
-    state = JSON.parse(stateParam);
-  } catch{};
-
+    // State will be passed on callback. If state exists in the URL parse it as a JSON object and use those values.
+    state = stateParam ? JSON.parse(stateParam) : null;
+  } catch (e) {
+    console.warn('Could not parse state from the URL.');
+  }
   if (state) {
     // Read from state
     issuer = state.issuer;
@@ -436,7 +438,7 @@ function loadConfig() {
     useInteractionCodeFlow = state.useInteractionCodeFlow;
     idps = state.idps;
   } else {
-    // Read from URL
+    // Read individually named parameters from URL, or use defaults
     issuer = url.searchParams.get('issuer') || config.issuer;
     clientId = url.searchParams.get('clientId') || config.clientId;
     storage = url.searchParams.get('storage') || config.storage;
@@ -458,8 +460,6 @@ function loadConfig() {
     useInteractionCodeFlow,
     idps,
   }).map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join('&');
-
-  
   // Add all app options to the state, to preserve config across redirects
   state = {
     issuer,
@@ -482,9 +482,7 @@ function loadConfig() {
     showForm,
     getTokens
   });
-
   Object.assign(config, newConfig);
-
   // Render the config to HTML
   var logConfig = {};
   var skipKeys = ['state', 'appUri', 'error', 'showForm', 'getTokens']; // internal config

--- a/samples/generated/webpack-spa/src/index.js
+++ b/samples/generated/webpack-spa/src/index.js
@@ -152,7 +152,8 @@ function renderUnauthenticated() {
 
 function handleLoginRedirect() {
   if (authClient.isInteractionRequired()) {
-    return beginAuthFlow(); // widget will resume transaction
+    beginAuthFlow(); // widget will resume transaction
+    return Promise.resolve();
   }
   
   // If the URL contains a code, `parseFromUrl` will grab it and exchange the code for tokens
@@ -227,8 +228,7 @@ function showSigninWidget() {
       redirectUri: config.redirectUri,
       useInteractionCodeFlow: config.useInteractionCodeFlow,
       authParams: {
-        issuer: config.issuer,
-        state: JSON.stringify(config.state),
+        issuer: config.issuer
       },
       idps: config.idps.split(/\s+/).map(idpToken => {
         const [type, id] = idpToken.split(/:/);
@@ -240,7 +240,8 @@ function showSigninWidget() {
     });
   
     signIn.showSignInToGetTokens({
-      el: '#signin-widget'
+      el: '#signin-widget',
+      state: JSON.stringify(config.state)
     })
     .then(function(tokens) {
       document.getElementById('flow-widget').style.display = 'none';
@@ -420,9 +421,12 @@ function loadConfig() {
   var idps;
 
   var state;
-  if (stateParam) {
-    // Read from state
+  try {
     state = JSON.parse(stateParam);
+  } catch{};
+
+  if (state) {
+    // Read from state
     issuer = state.issuer;
     clientId = state.clientId;
     storage = state.storage;

--- a/samples/templates/partials/spa/app.js
+++ b/samples/templates/partials/spa/app.js
@@ -152,7 +152,8 @@ function renderUnauthenticated() {
 
 function handleLoginRedirect() {
   if (authClient.isInteractionRequired()) {
-    return beginAuthFlow(); // widget will resume transaction
+    beginAuthFlow(); // widget will resume transaction
+    return Promise.resolve();
   }
   
   // If the URL contains a code, `parseFromUrl` will grab it and exchange the code for tokens
@@ -234,8 +235,7 @@ function showSigninWidget() {
       redirectUri: config.redirectUri,
       useInteractionCodeFlow: config.useInteractionCodeFlow,
       authParams: {
-        issuer: config.issuer,
-        state: JSON.stringify(config.state),
+        issuer: config.issuer
       },
       idps: config.idps.split(/\s+/).map(idpToken => {
         const [type, id] = idpToken.split(/:/);
@@ -247,7 +247,8 @@ function showSigninWidget() {
     });
   
     signIn.showSignInToGetTokens({
-      el: '#signin-widget'
+      el: '#signin-widget',
+      state: JSON.stringify(config.state)
     })
     .then(function(tokens) {
       document.getElementById('flow-widget').style.display = 'none';
@@ -434,9 +435,12 @@ function loadConfig() {
   {{/if}}
 
   var state;
-  if (stateParam) {
-    // Read from state
+  try {
     state = JSON.parse(stateParam);
+  } catch{};
+
+  if (state) {
+    // Read from state
     issuer = state.issuer;
     clientId = state.clientId;
     storage = state.storage;

--- a/samples/templates/partials/spa/app.js
+++ b/samples/templates/partials/spa/app.js
@@ -416,10 +416,10 @@ function loadConfig() {
   var redirectUri = window.location.origin + '{{ redirectPath }}'; // Should also be set in Okta Admin UI
   
   // Params which are not in the state
-  var stateParam = url.searchParams.get('state');
-  var error = url.searchParams.get('error');
-  var showForm = url.searchParams.get('showForm');
-  var getTokens = url.searchParams.get('getTokens');
+  var stateParam = url.searchParams.get('state'); // received on login redirect callback
+  var error = url.searchParams.get('error'); // received on login redirect callback
+  var showForm = url.searchParams.get('showForm'); // forces config form to show
+  var getTokens = url.searchParams.get('getTokens'); // forces redirect to get tokens
 
   // Params which are encoded into the state
   var issuer;
@@ -436,9 +436,11 @@ function loadConfig() {
 
   var state;
   try {
-    state = JSON.parse(stateParam);
-  } catch{};
-
+    // State will be passed on callback. If state exists in the URL parse it as a JSON object and use those values.
+    state = stateParam ? JSON.parse(stateParam) : null;
+  } catch (e) {
+    console.warn('Could not parse state from the URL.');
+  }
   if (state) {
     // Read from state
     issuer = state.issuer;
@@ -452,7 +454,7 @@ function loadConfig() {
     idps = state.idps;
     {{/if}}
   } else {
-    // Read from URL
+    // Read individually named parameters from URL, or use defaults
     issuer = url.searchParams.get('issuer') || config.issuer;
     clientId = url.searchParams.get('clientId') || config.clientId;
     storage = url.searchParams.get('storage') || config.storage;
@@ -478,8 +480,6 @@ function loadConfig() {
     idps,
     {{/if}}
   }).map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join('&');
-
-  
   // Add all app options to the state, to preserve config across redirects
   state = {
     issuer,
@@ -504,9 +504,7 @@ function loadConfig() {
     showForm,
     getTokens
   });
-
   Object.assign(config, newConfig);
-
   // Render the config to HTML
   var logConfig = {};
   var skipKeys = ['state', 'appUri', 'error', 'showForm', 'getTokens']; // internal config

--- a/test/app/package.json
+++ b/test/app/package.json
@@ -18,7 +18,7 @@
     "@babel/core": "^7.8.0",
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.8.2",
-    "@okta/okta-signin-widget": "^5.3.1",
+    "@okta/okta-signin-widget": "^5.4.0",
     "babel-loader": "^8.0.6",
     "btoa": "^1.2.1",
     "express": "^4.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1544,25 +1544,10 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@okta/okta-signin-widget@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@okta/okta-signin-widget/-/okta-signin-widget-5.3.1.tgz#114c38a27a640e9c3e3a97cae8e3be20f8418b67"
-  integrity sha512-BK9+81c79AXDjwspJkr0mFft1NczYTle4/kz1Cbp4+DdoM+ISyP7UEGNrSJWYBrexEsnHO0w7jNnqhOR36fypg==
-  dependencies:
-    "@babel/polyfill" "^7.10.1"
-    "@babel/runtime" "^7.10.3"
-    cross-fetch "^3.0.4"
-    handlebars "^4.5.3"
-    q "1.4.1"
-    u2f-api-polyfill "0.4.3"
-    underscore "1.8.3"
-  optionalDependencies:
-    fsevents "*"
-
-"@okta/okta-signin-widget@^5.3.2":
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/@okta/okta-signin-widget/-/okta-signin-widget-5.3.2.tgz#34b90a84a57c338acd480215ff1b7b6a8f194088"
-  integrity sha512-GmO0ZmCACUWBbDN4nJcTRa+gwe3sYbHdgSdcNzRK4yV8//XravQkcZAjFoXSaGtUE4wTEbm6TkbQBjCMwlb1xg==
+"@okta/okta-signin-widget@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-signin-widget/-/okta-signin-widget-5.4.0.tgz#021eeeb60c68aff8b01abe41f5df47b3ac14ab7b"
+  integrity sha512-HzhGnaJongWBiIveGyf/x03cky1AON4X+orCEntuiyK//ZCYPjbg1htMShkLuaEqpQYP3rHvbGVVSobW7kR7aQ==
   dependencies:
     "@babel/polyfill" "^7.10.1"
     "@babel/runtime" "^7.10.3"


### PR DESCRIPTION
- updates widget version to 5.4.0
- passes state as argument to `showSignInToGetTokens` (there is a bug with passing state in authParams constructor. See OKTA-374197)
- handles error from invalid state (will be seen if user chooses "sign out" from MFA enrollment. This may be another SIW bug)