### PR TITLE
fix: validate token using issuer from well-known config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2328,7 +2328,12 @@ Manually verify the validity of an ID token's claims and check the signature on 
 > **Note:** Token validation occurs automatically when tokens are returned via `getWithoutPrompt`, `getWithPopup`, and `getWithRedirect`.
 
 * `idTokenObject` - an ID token returned by this library. note: this is not the raw ID token JWT
-* `validationOptions` - Optional object to assert ID token claim values. Defaults to the configuration passed in during client instantiation.
+* `validationOptions` - Optional object to assert ID token claim values.
+  * `clientId` - Default: the `clientId` passed to the `OktaAuth` constructor
+  * `issuer` - Default: the `issuer` from [/.well-known/openid-configuration](https://developer.okta.com/docs/reference/api/oidc/#well-known-openid-configuration)
+  * `ignoreSignature` - Default: `false`. If `true`, the token's cryptographic signature will not be verified. This may be required if running on an insecure connection or an embedded browser where crypto libraries are not available.
+  * `accessToken` - Default: none. A raw access token string to be validated against the idToken's `at_hash` claim. This check validates that the `accessToken` was issued to the same user represented by the `idToken`. Note: the raw access token string is available as the `accessToken` property on the object returned by this library: `tokenManager.get('accessToken').accessToken`
+  * `nonce` - Default: none. The `nonce` value was created by the client and sent to the server in the original token request. Pass the `nonce` option here to verify that the token matches that request.
 
 ```javascript
 var validationOptions = {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -9,3 +9,8 @@ global.TextEncoder = TextEncoder;
 
 // Suppress warning messages
 global.console.warn = function() {};
+
+// Throw an error if any test tries to make a live network request
+global.fetch = function(url) {
+  throw new Error(`Attempt to make a live network request: ${url}`);
+};

--- a/lib/oidc/verifyToken.ts
+++ b/lib/oidc/verifyToken.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-len */
+/* eslint-disable complexity */
 /*!
  * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
@@ -10,58 +12,51 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-import { getKey, validateClaims } from '../oidc';
+import { getWellKnown, getKey } from './endpoints/well-known';
+import { validateClaims } from './util';
 import { AuthSdkError } from '../errors';
 import { IDToken, OktaAuth, TokenVerifyParams } from '../types';
 import { decodeToken } from './decodeToken';
 import * as sdkCrypto from '../crypto';
 
 // Verify the id token
-export function verifyToken(sdk: OktaAuth, token: IDToken, validationParams: TokenVerifyParams): Promise<IDToken> {
-  return Promise.resolve()
-    .then(function () {
-      if (!token || !token.idToken) {
-        throw new AuthSdkError('Only idTokens may be verified');
-      }
+export async function verifyToken(sdk: OktaAuth, token: IDToken, validationParams: TokenVerifyParams): Promise<IDToken> {
+  if (!token || !token.idToken) {
+    throw new AuthSdkError('Only idTokens may be verified');
+  }
 
-      var jwt = decodeToken(token.idToken);
+  // Decode the Jwt object (may throw)
+  var jwt = decodeToken(token.idToken);
 
-      var validationOptions: TokenVerifyParams = {
-        clientId: sdk.options.clientId,
-        issuer: sdk.options.issuer,
-        ignoreSignature: sdk.options.ignoreSignature
-      };
+  var openIdConfig = await getWellKnown(sdk); // using sdk.options.issuer
 
-      Object.assign(validationOptions, validationParams);
+  var validationOptions: TokenVerifyParams = {
+    issuer: openIdConfig.issuer, // sdk.options.issuer may point to a proxy. Use "real" issuer for validation.
+    clientId: sdk.options.clientId,
+    ignoreSignature: sdk.options.ignoreSignature
+  };
 
-      // Standard claim validation
-      validateClaims(sdk, jwt.payload, validationOptions);
+  Object.assign(validationOptions, validationParams);
 
-      // If the browser doesn't support native crypto or we choose not
-      // to verify the signature, bail early
-      if (validationOptions.ignoreSignature == true || !sdk.features.isTokenVerifySupported()) {
-        return token;
-      }
+  // Standard claim validation (may throw)
+  validateClaims(sdk, jwt.payload, validationOptions);
 
-      return getKey(sdk, token.issuer, jwt.header.kid)
-        .then(function (key) {
-          return sdkCrypto.verifyToken(token.idToken, key);
-        })
-        .then(function (valid) {
-          if (!valid) {
-            throw new AuthSdkError('The token signature is not valid');
-          }
-          if (validationParams && validationParams.accessToken && token.claims.at_hash) {
-            return sdkCrypto.getOidcHash(validationParams.accessToken)
-              .then(hash => {
-                if (hash !== token.claims.at_hash) {
-                  throw new AuthSdkError('Token hash verification failed');
-                }
-              });
-          }
-        })
-        .then(() => {
-          return token;
-        });
-    });
+  // If the browser doesn't support native crypto or we choose not
+  // to verify the signature, bail early
+  if (validationOptions.ignoreSignature == true || !sdk.features.isTokenVerifySupported()) {
+    return token;
+  }
+
+  const key = await getKey(sdk, token.issuer, jwt.header.kid);
+  const valid = await sdkCrypto.verifyToken(token.idToken, key);
+  if (!valid) {
+    throw new AuthSdkError('The token signature is not valid');
+  }
+  if (validationParams && validationParams.accessToken && token.claims.at_hash) {
+    const hash = await sdkCrypto.getOidcHash(validationParams.accessToken);
+    if (hash !== token.claims.at_hash) {
+      throw new AuthSdkError('Token hash verification failed');
+    }
+  }
+  return token;
 }

--- a/test/spec/OktaAuth/browser.ts
+++ b/test/spec/OktaAuth/browser.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-new */
 /* global window */
-jest.mock('cross-fetch');
 jest.mock('../../../lib/tx');
 
 import { 

--- a/test/spec/api-base-token.js
+++ b/test/spec/api-base-token.js
@@ -1,7 +1,5 @@
-/* global USER_AGENT */
-jest.mock('cross-fetch');
+/* global USER_AGENT, fetch */
 
-import fetch from 'cross-fetch';
 import util from '@okta/test.support/util';
 import { OktaAuth } from '@okta/okta-auth-js';
 import tokens from '@okta/test.support/tokens';
@@ -13,7 +11,12 @@ describe('base token API', function() {
 
   function createOktaAuth(options = {}) {
     return new OktaAuth(Object.assign({
-      issuer: tokens.ISSUER
+      issuer: tokens.ISSUER,
+      storageManager: {
+        cache: {
+          storageType: 'memory'
+        }
+      }
     }, options));
   }
   describe('prepareTokenParams', function() {
@@ -113,14 +116,11 @@ describe('base token API', function() {
       util.warpToUnixTime(oauthUtil.getTime());
     });
 
-    afterEach(() => {
-      fetch.mockReset();
-    });
-
     util.itMakesCorrectRequestResponse({
       title: 'requests a token using authorizationCode',
       setup: _.cloneDeep(setup),
       execute: function (test) {
+        oauthUtil.loadWellKnownAndKeysCache(test.oa);
         return test.oa.token.exchangeCodeForTokens({
           authorizationCode,
           codeVerifier,

--- a/test/spec/authn/errors.js
+++ b/test/spec/authn/errors.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import _ from 'lodash';
 import util from '@okta/test.support/util';
 

--- a/test/spec/authn/factor-enroll.js
+++ b/test/spec/authn/factor-enroll.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import util from '@okta/test.support/util';
 import _ from 'lodash';
 

--- a/test/spec/authn/general.js
+++ b/test/spec/authn/general.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import util from '@okta/test.support/util';
 
 describe('General Methods', function () {

--- a/test/spec/authn/locked-out.js
+++ b/test/spec/authn/locked-out.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import util from '@okta/test.support/util';
 
 describe('LOCKED_OUT', function () {

--- a/test/spec/authn/mfa-challenge.js
+++ b/test/spec/authn/mfa-challenge.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import util from '@okta/test.support/util';
 import * as sdkUtil from '../../../lib/util';
 

--- a/test/spec/authn/mfa-enroll-activate.js
+++ b/test/spec/authn/mfa-enroll-activate.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import util from '@okta/test.support/util';
 import * as sdkUtil from '../../../lib/util';
 

--- a/test/spec/authn/mfa-enroll.js
+++ b/test/spec/authn/mfa-enroll.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import util from '@okta/test.support/util';
 import _ from 'lodash';
 

--- a/test/spec/authn/mfa-required.js
+++ b/test/spec/authn/mfa-required.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import util from '@okta/test.support/util';
 import _ from 'lodash';
 

--- a/test/spec/authn/no-auth-status.js
+++ b/test/spec/authn/no-auth-status.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import util from '@okta/test.support/util';
 
 describe('NO AUTH STATUS', function () {

--- a/test/spec/authn/password-expired.js
+++ b/test/spec/authn/password-expired.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import util from '@okta/test.support/util';
 
 describe('PASSWORD_EXPIRED', function () {

--- a/test/spec/authn/password-reset.js
+++ b/test/spec/authn/password-reset.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import util from '@okta/test.support/util';
 
 describe('PASSWORD_RESET', function () {

--- a/test/spec/authn/password-warn.js
+++ b/test/spec/authn/password-warn.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import util from '@okta/test.support/util';
 
 describe('PASSWORD_WARN', function () {

--- a/test/spec/authn/recovery.js
+++ b/test/spec/authn/recovery.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import util from '@okta/test.support/util';
 
 describe('RECOVERY', function () {

--- a/test/spec/authn/recovery_challenge.js
+++ b/test/spec/authn/recovery_challenge.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import util from '@okta/test.support/util';
 
 describe('RECOVERY_CHALLENGE', function () {

--- a/test/spec/fetch-request.js
+++ b/test/spec/fetch-request.js
@@ -1,4 +1,12 @@
 /* global window */
+const mocked = {
+  crossFetch: jest.fn()
+};
+
+jest.mock('cross-fetch', () => {
+  return mocked.crossFetch;
+});
+
 describe('fetchRequest', function () {
   let fetchSpy;
 
@@ -10,18 +18,16 @@ describe('fetchRequest', function () {
   let responseJSON;
   let responseText;
 
-  const mockFetchObj = {
-    fetch: function mockFetchFunc() {
-      return Promise.resolve(response);
-    }
-  };
-  jest.setMock('cross-fetch', function() {
-    return mockFetchObj.fetch.apply(null, arguments);
-  });
   const fetchRequest = require('../../lib/fetch/fetchRequest').default;
 
   beforeEach(function() {
-    fetchSpy = jest.spyOn(mockFetchObj, 'fetch');
+    mocked.crossFetch.mockReset();
+    mocked.crossFetch.mockImplementation(() => {
+      return Promise.resolve(response);
+    });
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(() => {
+      return Promise.resolve(response);
+    });
     responseHeaders = new Map();
     responseHeaders.set('Content-Type', 'application/json');
     responseJSON = { isFakeResponse: true };
@@ -58,7 +64,7 @@ describe('fetchRequest', function () {
     it('uses cross-fetch if no native fetch', () => {
       return fetchRequest(requestMethod, requestUrl, {})
       .then(() => {
-        expect(fetchSpy).toHaveBeenCalled();
+        expect(mocked.crossFetch).toHaveBeenCalled();
       });
     });
     it('uses native fetch if available', () => {

--- a/test/spec/fingerprint.js
+++ b/test/spec/fingerprint.js
@@ -1,5 +1,4 @@
 /* global window, document */
-jest.mock('cross-fetch');
 
 import { OktaAuth } from '@okta/okta-auth-js';
 import util from '@okta/test.support/util';

--- a/test/spec/http.js
+++ b/test/spec/http.js
@@ -1,5 +1,4 @@
 /* global USER_AGENT */
-jest.mock('cross-fetch');
 
 import http from '../../lib/http';
 import { OktaAuth, DEFAULT_CACHE_DURATION, AuthApiError, STATE_TOKEN_KEY_NAME } from '@okta/okta-auth-js';

--- a/test/spec/oidc/endpoints/token.ts
+++ b/test/spec/oidc/endpoints/token.ts
@@ -1,7 +1,3 @@
-
-
-jest.mock('cross-fetch');
-
 import { OktaAuth, AuthSdkError } from '@okta/okta-auth-js';
 import util from '@okta/test.support/util';
 import http from '../../../../lib/http';

--- a/test/spec/oidc/endpoints/well-known.ts
+++ b/test/spec/oidc/endpoints/well-known.ts
@@ -1,6 +1,4 @@
 /* global window, localStorage, sessionStorage */
-jest.mock('cross-fetch');
-
 import { getWellKnown, getKey } from '../../../../lib/oidc/endpoints/well-known';
 import oauthUtilHelpers from '@okta/test.support/oauthUtil';
 import util from '@okta/test.support/util';

--- a/test/spec/oidc/getUserInfo.ts
+++ b/test/spec/oidc/getUserInfo.ts
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import { OktaAuth, AccessToken, IDToken } from '@okta/okta-auth-js';
 import tokens from '@okta/test.support/tokens';
 import util from '@okta/test.support/util';

--- a/test/spec/oidc/util/loginRedirect.ts
+++ b/test/spec/oidc/util/loginRedirect.ts
@@ -1,6 +1,4 @@
 /* global window */
-jest.mock('cross-fetch');
-
 import { OktaAuth } from '@okta/okta-auth-js';
 import {
   isInteractionRequired,

--- a/test/spec/oidc/util/prepareTokenParams.ts
+++ b/test/spec/oidc/util/prepareTokenParams.ts
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 const getWellKnown = jest.fn();
 jest.mock('../../../../lib/oidc/endpoints/well-known', () => {
   return { getWellKnown };

--- a/test/spec/session.js
+++ b/test/spec/session.js
@@ -1,5 +1,4 @@
 /* global window */
-jest.mock('cross-fetch');
 
 import {
   closeSession,

--- a/test/spec/webfinger.js
+++ b/test/spec/webfinger.js
@@ -1,5 +1,3 @@
-jest.mock('cross-fetch');
-
 import util from '@okta/test.support/util';
 
 describe('webfinger', function () {

--- a/test/support/oauthUtil.js
+++ b/test/support/oauthUtil.js
@@ -68,14 +68,15 @@ oauthUtil.getResponseForUrl = function(url) {
 
 oauthUtil.loadWellKnownAndKeysCache = function(authClient) {
   // mock responses to /.well-known/openid-configuration and /oauth2/v1/keys
-  jest.spyOn(authClient.options, 'httpRequestClient').mockImplementation(async (method, url) => {
+  const origMethod = authClient.options.httpRequestClient;
+  jest.spyOn(authClient.options, 'httpRequestClient').mockImplementation(async (method, url, options) => {
     const response = oauthUtil.getResponseForUrl(url);
     if (response) {
       return {
         responseText: JSON.stringify(response)
       };
     }
-    throw new Error(`Unexpected HTTP call: ${url}`);
+    return origMethod.apply(this, [method, url, options]);
   });
 };
 

--- a/test/support/util.js
+++ b/test/support/util.js
@@ -7,8 +7,6 @@ import { OktaAuth } from '@okta/okta-auth-js';
 import browserStorage from '../../lib/browser/browserStorage';
 const cookies = browserStorage.storage;
 
-import fetch from 'cross-fetch';
-
 var util = {};
 
 
@@ -88,7 +86,7 @@ function mockAjax(pairs) {
     setNextPair(pairs);
   }
 
-  fetch.mockImplementation(function (url, args) {
+  jest.spyOn(global, 'fetch').mockImplementation(function (url, args) {
     var pair = allPairs.shift();
     if (!pair) {
       throw new Error('We are making a request that we have not anticipated: ' + url);


### PR DESCRIPTION
Sets the default issuer in `validationOptions` to the issuer from well-known openid configuration, rather than the issuer from sdk options.  This supports a scenario where the configured issuer is a proxy server. The well known endpoint will be requested using the configured issuer, but the value returned will be compared against the minted token.

Resolves issue: https://github.com/okta/okta-auth-js/issues/377