### PR TITLE
feat: accept 'state' as a constructor option

### DIFF
--- a/lib/OktaAuthBase.ts
+++ b/lib/OktaAuthBase.ts
@@ -46,25 +46,39 @@ export default class OktaAuthBase implements OktaAuth, SigninAPI {
   constructor(args: OktaAuthOptions) {
     assertValidConfig(args);
     this.options = {
+      // OIDC configuration
       issuer: removeTrailingSlash(args.issuer),
       tokenUrl: removeTrailingSlash(args.tokenUrl),
+      authorizeUrl: removeTrailingSlash(args.authorizeUrl),
+      userinfoUrl: removeTrailingSlash(args.userinfoUrl),
+      revokeUrl: removeTrailingSlash(args.revokeUrl),
+      logoutUrl: removeTrailingSlash(args.logoutUrl),
+      clientId: args.clientId,
+      redirectUri: args.redirectUri,
+      state: args.state,
+      scopes: args.scopes,
+      postLogoutRedirectUri: args.postLogoutRedirectUri,
+      responseMode: args.responseMode,
+      responseType: args.responseType,
+      pkce: args.pkce,
+
+      // Internal options
       httpRequestClient: args.httpRequestClient,
       transformErrorXHR: args.transformErrorXHR,
+      transformAuthState: args.transformAuthState,
+      restoreOriginalUri: args.restoreOriginalUri,
       storageUtil: args.storageUtil,
       headers: args.headers,
       devMode: args.devMode || false,
-      clientId: args.clientId,
-      redirectUri: args.redirectUri,
-      pkce: args.pkce,
       storageManager: Object.assign({
         token: {},
         transaction: {}
       }, args.storageManager),
-      cookies: args.cookies
-    };
+      cookies: args.cookies,
 
-    // Give the developer the ability to disable token signature validation.
-    this.options.ignoreSignature = !!args.ignoreSignature;
+      // Give the developer the ability to disable token signature validation.
+      ignoreSignature: !!args.ignoreSignature
+    };
 
     const { storageManager, cookies, storageUtil } = this.options;
     this.storageManager = new StorageManager(storageManager, cookies, storageUtil);

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -163,20 +163,8 @@ class OktaAuthBrowser extends OktaAuthBase implements OktaAuth, SignoutAPI {
 
     this._pending = { handleLogin: false };
     this.options = Object.assign(this.options, {
-      clientId: args.clientId,
-      authorizeUrl: removeTrailingSlash(args.authorizeUrl),
-      userinfoUrl: removeTrailingSlash(args.userinfoUrl),
-      revokeUrl: removeTrailingSlash(args.revokeUrl),
-      logoutUrl: removeTrailingSlash(args.logoutUrl),
-      pkce: args.pkce === false ? false : true,
-      redirectUri: toAbsoluteUrl(args.redirectUri, window.location.origin),
-      postLogoutRedirectUri: args.postLogoutRedirectUri,
-      responseMode: args.responseMode,
-      responseType: args.responseType,
-      transformErrorXHR: args.transformErrorXHR,
-      scopes: args.scopes,
-      transformAuthState: args.transformAuthState,
-      restoreOriginalUri: args.restoreOriginalUri
+      pkce: args.pkce === false ? false : true, // PKCE defaults to true for browser
+      redirectUri: toAbsoluteUrl(args.redirectUri, window.location.origin), // allow relative URIs
     });
   
     this.userAgent = getUserAgent(args, `okta-auth-js/${SDK_VERSION}`);

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -19,7 +19,6 @@ import * as features from './features';
 import fetchRequest from '../fetch/fetchRequest';
 import browserStorage from './browserStorage';
 import { 
-  removeTrailingSlash, 
   toQueryString, 
   toAbsoluteUrl,
   clone, 

--- a/lib/oidc/util/defaultTokenParams.ts
+++ b/lib/oidc/util/defaultTokenParams.ts
@@ -16,14 +16,14 @@ import { generateNonce, generateState } from './oauth';
 import { OktaAuth, TokenParams } from '../../types';
 
 export function getDefaultTokenParams(sdk: OktaAuth): TokenParams {
-  const { pkce, clientId, redirectUri, responseType, responseMode, scopes, ignoreSignature } = sdk.options;
+  const { pkce, clientId, redirectUri, responseType, responseMode, scopes, state, ignoreSignature } = sdk.options;
   return {
     pkce,
     clientId,
     redirectUri: redirectUri || window.location.href,
     responseType: responseType || ['token', 'id_token'],
     responseMode,
-    state: generateState(),
+    state: state || generateState(),
     nonce: generateNonce(),
     scopes: scopes || ['openid', 'email'],
     ignoreSignature

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -48,6 +48,7 @@ export interface OktaAuthOptions extends CustomUrls {
   responseType?: string | string[];
   responseMode?: string;
   scopes?: string[];
+  state?: string;
   ignoreSignature?: boolean;
   tokenManager?: TokenManagerOptions;
   postLogoutRedirectUri?: string;

--- a/test/spec/OktaAuthBase.ts
+++ b/test/spec/OktaAuthBase.ts
@@ -1,0 +1,94 @@
+import OktaAuthBase from '../../lib/OktaAuthBase';
+
+describe('OktaAuthBase', () => {
+  const apiUrlOptions = [
+    'issuer',
+    'tokenUrl',
+    'authorizeUrl',
+    'userinfoUrl',
+    'revokeUrl',
+    'logoutUrl',
+  ];
+
+  const fnOptions = [
+    'httpRequestClient',
+    'transformErrorXHR',
+    'transformAuthState',
+    'restoreOriginalUri',
+    'storageUtil',
+  ];
+
+  const objOptions = [
+    'storageManager',
+  ];
+
+  const savedOptions = apiUrlOptions
+  .concat(fnOptions)
+  .concat(objOptions)
+  .concat([
+    'clientId',
+    'redirectUri',
+    'state',
+    'scopes',
+    'postLogoutRedirectUri',
+    'responseMode',
+    'responseType',
+    'pkce',
+    'headers',
+    'devMode',
+
+    'cookies',
+    'ignoreSignature'
+  ]);
+
+  describe('constructor', function() {
+    
+    it('saves expected options', () => {
+      const config = {};
+      savedOptions.forEach((option) => {
+        let val: string | object | boolean = 'fake_' + option;
+        switch (option) {
+          case 'issuer':
+            val = 'http://' + val;
+            break;
+          case 'storageManager':
+            val = {
+              token: {},
+              transaction: {}
+            };
+            break;
+          case 'ignoreSignature':
+            val = true;
+            break;
+        }
+        config[option] = val;
+      });
+      const oa = new OktaAuthBase(config);
+      savedOptions.forEach((option) => {
+        expect(oa.options[option]).toEqual(config[option]);
+      });
+    });
+
+    it('removes trailing slash from api urls', () => {
+      const config = {};
+      apiUrlOptions.forEach((option) => {
+        config[option] = 'http://fake_' + option + '/';
+      });
+      const oa = new OktaAuthBase(config);
+      apiUrlOptions.forEach((option) => {
+        expect(oa.options[option] + '/').toBe(config[option]);
+      });
+    });
+
+    it('accepts some options as functions', () => {
+      const config = { issuer: 'http://fake' };
+      fnOptions.forEach((option) => {
+        config[option] = function () {};
+      });
+      const oa = new OktaAuthBase(config);
+      fnOptions.forEach((option) => {
+        expect(oa.options[option]).toBe(config[option]);
+      });
+    });
+  });
+});

--- a/test/spec/oidc/util/defaultTokenParams.ts
+++ b/test/spec/oidc/util/defaultTokenParams.ts
@@ -1,0 +1,56 @@
+/* global window */
+import { getDefaultTokenParams } from '../../../../lib/oidc/util/defaultTokenParams';
+import { OktaAuth } from '../../../../lib/types';
+
+describe('getDefaultTokenParams', () => {
+
+  it('`pkce`: uses value from sdk.options', () => {
+    const sdk = { options: { pkce: true } } as OktaAuth;
+    expect(getDefaultTokenParams(sdk).pkce).toBe(true);
+  });
+  
+  it('`clientId`: uses value from sdk.options', () => {
+    const sdk = { options: { clientId: 'abc' } } as OktaAuth;
+    expect(getDefaultTokenParams(sdk).clientId).toBe('abc');
+  });
+  
+  describe('`redirectUri`: ', () => {
+    it('defaults to window.location.href', () => {
+      expect(window.location.href).toBeTruthy();
+      expect(getDefaultTokenParams({ options: {} } as OktaAuth).redirectUri).toBe(window.location.href);
+    });
+    it('uses values from sdk.options', () => {
+      const sdk = { options: { redirectUri: 'abc' } } as OktaAuth;
+      expect(getDefaultTokenParams(sdk).redirectUri).toBe('abc');
+    });
+  });
+  
+  describe('`responseType`: ', () => {
+    it('defaults to ["token", "id_token"]', () => {
+      expect(getDefaultTokenParams({ options: {} } as OktaAuth).responseType).toEqual(['token', 'id_token']);
+    });
+    it('uses values from sdk.options', () => {
+      const sdk = { options: { responseType: 'abc' } } as OktaAuth;
+      expect(getDefaultTokenParams(sdk).responseType).toBe('abc');
+    });
+  });
+
+  it('`responseMode`: uses value from sdk.options', () => {
+    const sdk = { options: { responseMode: 'abc' } } as OktaAuth;
+    expect(getDefaultTokenParams(sdk).responseMode).toBe('abc');
+  });
+
+  describe('`state`: ', () => {
+    it('generates a default value', () => {
+      expect(getDefaultTokenParams({ options: {} } as OktaAuth).state).toBeTruthy();
+    });
+    it('uses values from sdk.options', () => {
+      const sdk = { options: { state: 'abc' } } as OktaAuth;
+      expect(getDefaultTokenParams(sdk).state).toBe('abc');
+    });
+  });
+
+  it('`nonce`: generates a default value', () => {
+    expect(getDefaultTokenParams({ options: {} } as OktaAuth).nonce).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Most OIDC options are accepted in the constructor. `state` was missing. Adding `state` will help the widget here: https://github.com/okta/okta-signin-widget/blob/cc14afe715ba58e6e6ac34684905edb05023e906/src/v2/client/interact.js#L44

Also moving common config values to the `OktaAuthBase` class. Added tests.