### PR TITLE
chore: upgrade node-cache to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "cross-fetch": "^3.0.6",
     "js-cookie": "2.2.1",
     "karma-coverage": "^2.0.3",
-    "node-cache": "^4.2.0",
+    "node-cache": "^5.1.2",
     "p-cancelable": "^2.0.0",
     "text-encoding": "^0.7.0",
     "tiny-emitter": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10553,6 +10553,13 @@ node-cache@^4.2.0:
     clone "2.x"
     lodash "^4.17.15"
 
+node-cache@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
+  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
+  dependencies:
+    clone "2.x"
+
 node-dir@^0.1.17:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"


### PR DESCRIPTION
node cache breaking change in v5: https://github.com/node-cache/node-cache#breaking-major-release-v5x

should be safe to upgrade in auth-js 4.8.