### PR TITLE
fix: magic link pkce error - OKTA-377624

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - [#656](https://github.com/okta/okta-auth-js/pull/656) Fixes `TokenManager.renew` to renew only requested token
+- [#669](https://github.com/okta/okta-auth-js/pull/669) Fixes reset password magic link pkce error
 
 ### Features
 

--- a/lib/TransactionManager.ts
+++ b/lib/TransactionManager.ts
@@ -128,7 +128,9 @@ export default class TransactionManager {
   }
 
   // load transaction meta from storage
+  // eslint-disable-next-line complexity, max-statements
   load(options: TransactionMetaOptions = {}): TransactionMeta {
+
     let storage: StorageProvider = this.storageManager.getTransactionStorage();
     let meta = storage.getStorage();
     if (isTransactionMeta(meta)) {


### PR DESCRIPTION
The issue:
Email magic link starts a new tab to redirect users back to the oidc app, pkce error is thrown due to transaction meta is stored in sessionStorage by default.

The fix:
Add transaction meta to localStorage as a fallback for sessionStorage option, clear both storage meta at the end of transaction.