### PR TITLE
changes autorenew behavior, adds start/stop methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+- [#689](https://github.com/okta/okta-auth-js/pull/689) New methods `start` and `stop` are added to control `OktaAuth` as a service. TokenManager options `autoRenew`, and  `autoRemove` will only take effect after calling `start`.
 - [#515](https://github.com/okta/okta-auth-js/pull/515) Removes `token.value` field
 - [#540](https://github.com/okta/okta-auth-js/pull/540) Locks `tokenManager.expireEarlySeconds` option with the default value (30s) for non-dev environment
 - [#677](https://github.com/okta/okta-auth-js/pull/677) Http requests will not send cookies by default

--- a/lib/AuthStateManager.ts
+++ b/lib/AuthStateManager.ts
@@ -71,7 +71,7 @@ export class AuthStateManager {
 
   updateAuthState(): void {
     const { transformAuthState, devMode } = this._sdk.options;
-    const { autoRenew, autoRemove } = this._sdk.tokenManager._getOptions();
+    const { autoRenew, autoRemove } = this._sdk.tokenManager.getOptions();
 
     const log = (status) => {
       const { event, key, token } = this._logOptions;
@@ -95,7 +95,7 @@ export class AuthStateManager {
       devMode && log('emitted');
     };
 
-    const shouldEvaluateIsPending = () => (autoRenew || autoRemove);
+    const shouldEvaluateIsPending = () => !!(autoRenew || autoRemove);
 
     if (this._pending.updateAuthStatePromise) {
       if (this._pending.canceledTimes >= MAX_PROMISE_CANCEL_TIMES) {

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -248,6 +248,15 @@ class OktaAuth implements SigninAPI, SignoutAPI {
     this.authStateManager = new AuthStateManager(this);
   }
 
+  start() {
+    this.tokenManager.start();
+    this.authStateManager.updateAuthState();
+  }
+
+  stop() {
+    this.tokenManager.stop();
+  }
+
   // ES6 module users can use named exports to access all symbols
   // CommonJS module users (CDN) need all exports on this object
 
@@ -331,7 +340,7 @@ class OktaAuth implements SigninAPI, SignoutAPI {
   async revokeAccessToken(accessToken?: AccessToken): Promise<object> {
     if (!accessToken) {
       accessToken = (await this.tokenManager.getTokens()).accessToken as AccessToken;
-      const accessTokenKey = this.tokenManager._getStorageKeyByType('accessToken');
+      const accessTokenKey = this.tokenManager.getStorageKeyByType('accessToken');
       this.tokenManager.remove(accessTokenKey);
     }
     // Access token may have been removed. In this case, we will silently succeed.
@@ -345,7 +354,7 @@ class OktaAuth implements SigninAPI, SignoutAPI {
   async revokeRefreshToken(refreshToken?: RefreshToken): Promise<object> {
     if (!refreshToken) {
       refreshToken = (await this.tokenManager.getTokens()).refreshToken as RefreshToken;
-      const refreshTokenKey = this.tokenManager._getStorageKeyByType('refreshToken');
+      const refreshTokenKey = this.tokenManager.getStorageKeyByType('refreshToken');
       this.tokenManager.remove(refreshTokenKey);
     }
     // Refresh token may have been removed. In this case, we will silently succeed.

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -10,14 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-/* global window */
-/* eslint complexity:[0,8] max-statements:[0,21] */
-import { removeNils, warn, isObject, clone } from './util';
+import { removeNils, warn, clone } from './util';
 import AuthSdkError from './errors/AuthSdkError';
-import { isLocalhost, isIE11OrLess, isBrowser } from './features';
+import { isLocalhost, isIE11OrLess } from './features';
 import { TOKEN_STORAGE_NAME } from './constants';
 import SdkClock from './clock';
-import { 
+import {
+  EventEmitter,
   Token, 
   Tokens, 
   TokenType, 
@@ -28,9 +27,10 @@ import {
   StorageOptions,
   StorageType,
   OktaAuth,
-  RefreshToken
+  StorageProvider
 } from './types';
 import { ID_TOKEN_STORAGE_KEY, ACCESS_TOKEN_STORAGE_KEY, REFRESH_TOKEN_STORAGE_KEY } from './constants';
+import { TokenService } from './services/TokenService';
 
 const DEFAULT_OPTIONS = {
   autoRenew: true,
@@ -38,6 +38,7 @@ const DEFAULT_OPTIONS = {
   storage: undefined, // will use value from storageManager config
   expireEarlySeconds: 30,
   storageKey: TOKEN_STORAGE_NAME,
+  syncStorage: true,
   _storageEventDelay: 0
 };
 export const EVENT_EXPIRED = 'expired';
@@ -45,371 +46,6 @@ export const EVENT_RENEWED = 'renewed';
 export const EVENT_ADDED = 'added';
 export const EVENT_REMOVED = 'removed';
 export const EVENT_ERROR = 'error';
-
-function getExpireTime(tokenMgmtRef, token) {
-  var expireTime = token.expiresAt - tokenMgmtRef.options.expireEarlySeconds;
-  return expireTime;
-}
-
-function hasExpired(tokenMgmtRef, token) {
-  var expireTime = getExpireTime(tokenMgmtRef, token);
-  return expireTime <= tokenMgmtRef.clock.now();
-}
-
-function emitExpired(tokenMgmtRef, key, token) {
-  tokenMgmtRef.emitter.emit(EVENT_EXPIRED, key, token);
-}
-
-function emitRenewed(tokenMgmtRef, key, freshToken, oldToken) {
-  tokenMgmtRef.emitter.emit(EVENT_RENEWED, key, freshToken, oldToken);
-}
-
-function emitAdded(tokenMgmtRef, key, token) {
-  tokenMgmtRef.emitter.emit(EVENT_ADDED, key, token);
-}
-
-function emitRemoved(tokenMgmtRef, key, token?) {
-  tokenMgmtRef.emitter.emit(EVENT_REMOVED, key, token);
-}
-
-function emitError(tokenMgmtRef, error) {
-  tokenMgmtRef.emitter.emit(EVENT_ERROR, error);
-}
-
-function emitEventsForCrossTabsStorageUpdate(tokenMgmtRef, newValue, oldValue) {
-  const oldTokens = getTokensFromStorageValue(oldValue);
-  const newTokens = getTokensFromStorageValue(newValue);
-  Object.keys(newTokens).forEach(key => {
-    const oldToken = oldTokens[key];
-    const newToken = newTokens[key];
-    if (JSON.stringify(oldToken) !== JSON.stringify(newToken)) {
-      emitAdded(tokenMgmtRef, key, newToken);
-    }
-  });
-  Object.keys(oldTokens).forEach(key => {
-    const oldToken = oldTokens[key];
-    const newToken = newTokens[key];
-    if (!newToken) {
-      emitRemoved(tokenMgmtRef, key, oldToken);
-    }
-  });
-}
-
-function clearExpireEventTimeout(tokenMgmtRef, key) {
-  clearTimeout(tokenMgmtRef.expireTimeouts[key]);
-  delete tokenMgmtRef.expireTimeouts[key];
-
-  // Remove the renew promise (if it exists)
-  delete tokenMgmtRef.renewPromise[key];
-}
-
-function clearExpireEventTimeoutAll(tokenMgmtRef) {
-  var expireTimeouts = tokenMgmtRef.expireTimeouts;
-  for (var key in expireTimeouts) {
-    if (!Object.prototype.hasOwnProperty.call(expireTimeouts, key)) {
-      continue;
-    }
-    clearExpireEventTimeout(tokenMgmtRef, key);
-  }
-}
-
-function setExpireEventTimeout(sdk, tokenMgmtRef, key, token) {
-  var expireTime = getExpireTime(tokenMgmtRef, token);
-  var expireEventWait = Math.max(expireTime - tokenMgmtRef.clock.now(), 0) * 1000;
-
-  // Clear any existing timeout
-  clearExpireEventTimeout(tokenMgmtRef, key);
-
-  var expireEventTimeout = setTimeout(function() {
-    emitExpired(tokenMgmtRef, key, token);
-  }, expireEventWait);
-
-  // Add a new timeout
-  tokenMgmtRef.expireTimeouts[key] = expireEventTimeout;
-}
-
-function setExpireEventTimeoutAll(sdk, tokenMgmtRef, storage) {
-  try {
-    var tokenStorage = storage.getStorage();
-  } catch(e) {
-    // Any errors thrown on instantiation will not be caught,
-    // because there are no listeners yet
-    emitError(tokenMgmtRef, e);
-    return;
-  }
-
-  for(var key in tokenStorage) {
-    if (!Object.prototype.hasOwnProperty.call(tokenStorage, key)) {
-      continue;
-    }
-    var token = tokenStorage[key];
-    setExpireEventTimeout(sdk, tokenMgmtRef, key, token);
-  }
-}
-
-// reset timeouts to setup autoRenew for tokens from other document context (tabs)
-function resetExpireEventTimeoutAll(sdk, tokenMgmtRef, storage) {
-  clearExpireEventTimeoutAll(tokenMgmtRef);
-  setExpireEventTimeoutAll(sdk, tokenMgmtRef, storage);
-}
-
-function validateToken(token: Token) {
-  if (!isObject(token) ||
-      !token.scopes ||
-      (!token.expiresAt && token.expiresAt !== 0) ||
-      (!isIDToken(token) && !isAccessToken(token) && !isRefreshToken(token))) {
-    throw new AuthSdkError(
-      'Token must be an Object with scopes, expiresAt, and one of: an idToken, accessToken, or refreshToken property'
-      );
-  }
-}
-
-function _add(sdk, tokenMgmtRef, storage, key, token: Token) {
-  var tokenStorage = storage.getStorage();
-  validateToken(token);
-  tokenStorage[key] = token;
-  storage.setStorage(tokenStorage);
-  emitAdded(tokenMgmtRef, key, token);
-  setExpireEventTimeout(sdk, tokenMgmtRef, key, token);
-}
-
-function add(sdk, tokenMgmtRef, storage, key, token: Token) {
-  if (sdk.features.isLocalhost()) {
-    warn(
-      'Use setTokens() instead if you want to add a set of tokens at same time.\n' + 
-      'It prevents current tab from emitting unnecessary StorageEvent,\n' + 
-      'which may cause false-positive authState change cross tabs.'
-    );
-  }
-
-  _add(sdk, tokenMgmtRef, storage, key, token);
-}
-
-function get(storage, key) {
-  var tokenStorage = storage.getStorage();
-  return tokenStorage[key];
-}
-
-function getKeyByType(storage, type: TokenType): string {
-  const tokenStorage = storage.getStorage();
-  const key = Object.keys(tokenStorage).filter(key => {
-    const token = tokenStorage[key];
-    return (isAccessToken(token) && type === 'accessToken') 
-      || (isIDToken(token) && type === 'idToken')
-      || (isRefreshToken(token) && type === 'refreshToken');
-  })[0];
-  return key;
-}
-
-function getAsync(storage, key) {
-  return new Promise(function(resolve) {
-    var token = get(storage, key);
-    return resolve(token);
-  });
-}
-
-function getTokens(storage): Tokens {
-  const tokens = {} as Tokens;
-  const tokenStorage = storage.getStorage();
-  Object.keys(tokenStorage).forEach(key => {
-    const token = tokenStorage[key];
-    if (isAccessToken(token)) {
-      tokens.accessToken = token;
-    } else if (isIDToken(token)) {
-      tokens.idToken = token;
-    } else if (isRefreshToken(token)) { 
-      tokens.refreshToken = token;
-    }
-  });
-  return tokens;
-}
-
-function getTokensAsync(storage): Promise<Tokens> {
-  return new Promise((resolve) => {
-    const tokens = getTokens(storage);
-    return resolve(tokens);
-  });
-}
-
-/* eslint-disable max-params */
-function setTokens(
-  sdk, 
-  tokenMgmtRef, 
-  storage, 
-  { accessToken, idToken, refreshToken }: Tokens, 
-  accessTokenCb?: Function, 
-  idTokenCb?: Function,
-  refreshTokenCb?: Function
-): void {
-  const handleAdded = (key, token, tokenCb) => {
-    emitAdded(tokenMgmtRef, key, token);
-    setExpireEventTimeout(sdk, tokenMgmtRef, key, token);
-    if (tokenCb) {
-      tokenCb(key, token);
-    }
-  };
-  const handleRemoved = (key, token, tokenCb) => {
-    clearExpireEventTimeout(tokenMgmtRef, key);
-    emitRemoved(tokenMgmtRef, key, token);
-    if (tokenCb) {
-      tokenCb(key, token);
-    }
-  };
-
-  if (idToken) {
-    validateToken(idToken);
-  }
-  if (accessToken) {
-    validateToken(accessToken);
-  }
-  const idTokenKey = getKeyByType(storage, 'idToken') || ID_TOKEN_STORAGE_KEY;
-  const accessTokenKey = getKeyByType(storage, 'accessToken') || ACCESS_TOKEN_STORAGE_KEY;
-  const refreshTokenKey = getKeyByType(storage, 'refreshToken') || REFRESH_TOKEN_STORAGE_KEY;
-
-  // add token to storage
-  const tokenStorage = { 
-    ...(idToken && { [idTokenKey]: idToken }),
-    ...(accessToken && { [accessTokenKey]: accessToken }),
-    ...(refreshToken && { [refreshTokenKey]: refreshToken })
-  };
-  storage.setStorage(tokenStorage);
-
-  // emit event and start expiration timer
-  const existingTokens = getTokens(storage);
-  if (idToken) {
-    handleAdded(idTokenKey, idToken, idTokenCb);
-  } else if (existingTokens.idToken) {
-    handleRemoved(idTokenKey, existingTokens.idToken, idTokenCb);
-  }
-  if (accessToken) {
-    handleAdded(accessTokenKey, accessToken, accessTokenCb);
-  } else if (existingTokens.accessToken) {
-    handleRemoved(accessTokenKey, existingTokens.accessToken, accessTokenCb);
-  }
-  if (refreshToken) {
-    handleAdded(refreshTokenKey, refreshToken, refreshTokenCb);
-  } else if (existingTokens.refreshToken) {
-    handleRemoved(refreshTokenKey, existingTokens.refreshToken, refreshTokenCb);
-  }
-}
-/* eslint-enable max-params */
-
-function remove(tokenMgmtRef, storage, key) {
-  // Clear any listener for this token
-  clearExpireEventTimeout(tokenMgmtRef, key);
-
-  var tokenStorage = storage.getStorage();
-  var removedToken = tokenStorage[key];
-  delete tokenStorage[key];
-  storage.setStorage(tokenStorage);
-
-  emitRemoved(tokenMgmtRef, key, removedToken);
-}
-
-function _renewToken(sdk, token) {
-  return this.getTokens()
-    .then(tokens => tokens.refreshToken as RefreshToken)
-    .then(refreshTokenObject => {
-      if (refreshTokenObject) {
-        return sdk.token.renewTokensWithRefresh({
-          scopes: token.scopes,
-        }, refreshTokenObject)
-        .then(function(freshTokens) {
-          // Multiple tokens may have come back. Return only the token which was requested.
-          return isIDToken(token) ? freshTokens.idToken : freshTokens.accessToken;
-        });
-      } else {
-        return sdk.token.renew(token);
-      }
-    });
-}
-
-function renew(sdk, tokenMgmtRef, storage, key) {
-  // Multiple callers may receive the same promise. They will all resolve or reject from the same request.
-  var existingPromise = tokenMgmtRef.renewPromise[key];
-  if (existingPromise) {
-    return existingPromise;
-  }
-
-  try {
-    var token = get(storage, key);
-    if (!token) {
-      throw new AuthSdkError('The tokenManager has no token for the key: ' + key);
-    }
-  } catch (e) {
-    return Promise.reject(e);
-  }
-
-  // Remove existing autoRenew timeout
-  clearExpireEventTimeout(tokenMgmtRef, key);
-
-  // A refresh token means a replace instead of renewal
-  // Store the renew promise state, to avoid renewing again
-  tokenMgmtRef.renewPromise[key] = _renewToken.call(this, sdk, token)
-    .then(function(freshToken) {
-      // store and emit events for freshToken
-      const oldTokenStorage = storage.getStorage();
-      remove(tokenMgmtRef, storage, key);
-      _add(sdk, tokenMgmtRef, storage, key, freshToken);
-      emitRenewed(tokenMgmtRef, key, freshToken, oldTokenStorage[key]);
-      return freshToken;
-    })
-    .catch(function(err) {
-      if (err.name === 'OAuthError' || err.name === 'AuthSdkError') {
-        // remove expired token in storage
-        const tokenStorage = storage.getStorage();
-        const currentToken = tokenStorage[key];
-        if (currentToken && hasExpired(tokenMgmtRef, currentToken)) {
-          delete tokenStorage[key];
-          clearExpireEventTimeout(tokenMgmtRef, key);
-          storage.setStorage(tokenStorage);
-          emitRemoved(tokenMgmtRef, key, currentToken);
-        } else {
-          // token have been removed from other tabs
-          // still trigger removed event for downstream listeners
-          emitRemoved(tokenMgmtRef, key);
-        }
-        
-        err.tokenKey = key;
-        emitError(tokenMgmtRef, err);
-      }
-      throw err;
-    })
-    .finally(function() {
-      // Remove existing promise key
-      delete tokenMgmtRef.renewPromise[key];
-    });
-
-  return tokenMgmtRef.renewPromise[key];
-}
-
-function clear(tokenMgmtRef, storage) {
-  clearExpireEventTimeoutAll(tokenMgmtRef);
-  storage.clearStorage();
-}
-
-function shouldThrottleRenew(renewTimeQueue) {
-  let res = false;
-  renewTimeQueue.push(Date.now());
-  if (renewTimeQueue.length >= 10) {
-    // get and remove first item from queue
-    const firstTime = renewTimeQueue.shift();
-    const lastTime = renewTimeQueue[renewTimeQueue.length - 1];
-    res = lastTime - firstTime < 30 * 1000;
-  }
-  return res;
-}
-
-function getTokensFromStorageValue(value) {
-  let tokens;
-  try {
-    tokens = JSON.parse(value) || {};
-  } catch (e) {
-    tokens = {};
-  }
-  return tokens;
-}
-
 interface TokenError {
   errorSummary: string;
   errorCode: string;
@@ -419,44 +55,61 @@ interface TokenError {
 }
 type TokenErrorEventHandler = (error: TokenError) => void;
 type TokenEventHandler = (key: string, token: Token, oldtoken?: Token) => void;
-
+interface TokenManagerState {
+  expireTimeouts: Record<string, unknown>;
+  renewPromise: Record<string, Promise<Token>>;
+}
+function defaultState(): TokenManagerState {
+  return {
+    expireTimeouts: {},
+    renewPromise: {}
+  };
+}
 export class TokenManager {
-  get: (key: string) => Promise<Token>;
-  add: (key: string, token: Token) => void;
-  clear: () => void;
-  remove: (key: string) => void;
-  renew: (key: string) => Promise<Token>;
+  private sdk: OktaAuth;
+  private clock: SdkClock;
+  private emitter: EventEmitter;
+  private storage: StorageProvider;
+  private state: TokenManagerState;
+  private options: TokenManagerOptions;
+  private service: TokenService;
+
+  // get: (key: string) => Promise<Token>;
+  // add: (key: string, token: Token) => void;
+  // clear: () => void;
+  // remove: (key: string) => void;
+  // renew: (key: string) => Promise<Token>;
   on: (event: string, handler: TokenErrorEventHandler | TokenEventHandler, context?: object) => void;
   off: (event: string, handler?: TokenErrorEventHandler | TokenEventHandler) => void;
-  hasExpired: (token: Token) => boolean;
-  getTokens: () => Promise<Tokens>;
-  setTokens: (tokens: Tokens) => void;
+  // hasExpired: (token: Token) => boolean;
+  // getTokens: () => Promise<Tokens>;
+  // setTokens: (tokens: Tokens) => void;
   
-  // This is exposed so we can get storage key agnostic tokens set in internal state managers
-  _getStorageKeyByType: (type: TokenType) => string;
-  // This is exposed so we can set clear timeouts in our tests
-  _clearExpireEventTimeoutAll: () => void;
-  // This is exposed read-only options for internal sdk use
-  _getOptions: () => TokenManagerOptions;
-  // Expose cross tabs communication helper functions to tests
-  _resetExpireEventTimeoutAll: () => void;
-  _emitEventsForCrossTabsStorageUpdate: (newValue: string, oldValue: string) => void;
+  // // This is exposed so we can get storage key agnostic tokens set in internal state managers
+  // _getStorageKeyByType: (type: TokenType) => string;
+  // // This is exposed so we can set clear timeouts in our tests
+  // _clearExpireEventTimeoutAll: () => void;
+  // // This is exposed read-only options for internal sdk use
+  // _getOptions: () => TokenManagerOptions;
+  // // Expose cross tabs communication helper functions to tests
+  // _resetExpireEventTimeoutAll: () => void;
+  // _emitEventsForCrossTabsStorageUpdate: (newValue: string, oldValue: string) => void;
 
   constructor(sdk: OktaAuth, options: TokenManagerOptions = {}) {
-    options = Object.assign({}, DEFAULT_OPTIONS, removeNils(options));
-
-    const emitter = (sdk as any).emitter;
-    if (!emitter) {
+    this.sdk = sdk;
+    this.emitter = (sdk as any).emitter;
+    if (!this.emitter) {
       throw new AuthSdkError('Emitter should be initialized before TokenManager');
     }
 
+    options = Object.assign({}, DEFAULT_OPTIONS, removeNils(options));
     if (isIE11OrLess()) {
       options._storageEventDelay = options._storageEventDelay || 1000;
     }
-
     if (!isLocalhost()) {
       options.expireEarlySeconds = DEFAULT_OPTIONS.expireEarlySeconds;
     }
+    this.options = options;
 
     const storageOptions: StorageOptions = removeNils({
       storageKey: options.storageKey,
@@ -469,73 +122,374 @@ export class TokenManager {
       storageOptions.storageType = options.storage as StorageType;
     }
 
-    const storage = sdk.storageManager.getTokenStorage(storageOptions);
+    this.storage = sdk.storageManager.getTokenStorage(storageOptions);
+    this.clock = SdkClock.create(/* sdk, options */);
+    this.state = defaultState();
 
-    var clock = SdkClock.create(/* sdk, options */);
-    var tokenMgmtRef = {
-      clock: clock,
-      options: options,
-      emitter: emitter,
-      expireTimeouts: {},
-      renewPromise: {}
-    };
+    // this.add = add.bind(this, sdk, tokenMgmtRef, storage);
+    // this.get = getAsync.bind(this, storage);
+    // this.remove = remove.bind(this, tokenMgmtRef, storage);
+    // this.clear = clear.bind(this, tokenMgmtRef, storage);
+    // this.renew = renew.bind(this, sdk, tokenMgmtRef, storage);
+    this.on = this.emitter.on.bind(this.emitter);
+    this.off = this.emitter.off.bind(this.emitter);
+    // this.hasExpired = hasExpired.bind(this, tokenMgmtRef);
+    // this.getTokens = getTokensAsync.bind(this, storage);
+    // this.setTokens = setTokens.bind(this, sdk, tokenMgmtRef, storage);
+    // this._getStorageKeyByType = getKeyByType.bind(this, storage);
+    // this._clearExpireEventTimeoutAll = clearExpireEventTimeoutAll.bind(this, tokenMgmtRef);
+    // this._getOptions = () => clone(options);
+    // this._resetExpireEventTimeoutAll = resetExpireEventTimeoutAll.bind(this, tokenMgmtRef, storage);
+    // this._emitEventsForCrossTabsStorageUpdate = emitEventsForCrossTabsStorageUpdate.bind(this, tokenMgmtRef);
+  }
 
-    this.add = add.bind(this, sdk, tokenMgmtRef, storage);
-    this.get = getAsync.bind(this, storage);
-    this.remove = remove.bind(this, tokenMgmtRef, storage);
-    this.clear = clear.bind(this, tokenMgmtRef, storage);
-    this.renew = renew.bind(this, sdk, tokenMgmtRef, storage);
-    this.on = tokenMgmtRef.emitter.on.bind(tokenMgmtRef.emitter);
-    this.off = tokenMgmtRef.emitter.off.bind(tokenMgmtRef.emitter);
-    this.hasExpired = hasExpired.bind(this, tokenMgmtRef);
-    this.getTokens = getTokensAsync.bind(this, storage);
-    this.setTokens = setTokens.bind(this, sdk, tokenMgmtRef, storage);
-    this._getStorageKeyByType = getKeyByType.bind(this, storage);
-    this._clearExpireEventTimeoutAll = clearExpireEventTimeoutAll.bind(this, tokenMgmtRef);
-    this._getOptions = () => clone(options);
-    this._resetExpireEventTimeoutAll = resetExpireEventTimeoutAll.bind(this, sdk, tokenMgmtRef, storage);
-    this._emitEventsForCrossTabsStorageUpdate = emitEventsForCrossTabsStorageUpdate.bind(this, tokenMgmtRef);
+  start() {
+    if (this.service) {
+      this.stop();
+    }
+    this.service = new TokenService(this, this.getOptions());
+    this.service.start();
+  }
   
-    const renewTimeQueue = [];
-    const onTokenExpiredHandler = (key) => {
-      if (options.autoRenew) {
-        if (shouldThrottleRenew(renewTimeQueue)) {
-          const error = new AuthSdkError('Too many token renew requests');
-          emitError(tokenMgmtRef, error);
-        } else {
-          this.renew(key).catch(() => {}); // Renew errors will emit an "error" event 
-        }
-      } else if (options.autoRemove) {
-        this.remove(key);
-      }
-    };
-    this.on(EVENT_EXPIRED, onTokenExpiredHandler);
-
-    setExpireEventTimeoutAll(sdk, tokenMgmtRef, storage);
-
-    if (isBrowser()) {
-    // Sync authState cross multiple tabs when localStorage is used as the storageProvider
-    // A StorageEvent is sent to a window when a storage area it has access to is changed 
-    // within the context of another document.
-    // https://developer.mozilla.org/en-US/docs/Web/API/StorageEvent
-    window.addEventListener('storage', ({ key, newValue, oldValue }: StorageEvent) => {
-        const handleCrossTabsStorageChange = () => {
-          this._resetExpireEventTimeoutAll();
-          this._emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
-        };
-
-        // Skip if:
-        // not from localStorage.clear (event.key is null)
-        // event.key is not the storageKey
-        // oldValue === newValue
-        if (key && (key !== options.storageKey || newValue === oldValue)) {
-          return;
-        }
-
-        // LocalStorage cross tabs update is not synced in IE, set a 1s timer by default to read latest value
-        // https://stackoverflow.com/questions/24077117/localstorage-in-win8-1-ie11-does-not-synchronize
-        setTimeout(() => handleCrossTabsStorageChange(), options._storageEventDelay);
-      });
+  stop() {
+    if (this.service) {
+      this.service.stop();
+      this.service = null;
     }
   }
+
+  getOptions(): TokenManagerOptions {
+    return clone(this.options);
+  }
+  
+  getExpireTime(token) {
+    var expireTime = token.expiresAt - this.options.expireEarlySeconds;
+    return expireTime;
+  }
+  
+  hasExpired(token) {
+    var expireTime = this.getExpireTime(token);
+    return expireTime <= this.clock.now();
+  }
+  
+  emitExpired(key, token) {
+    this.emitter.emit(EVENT_EXPIRED, key, token);
+  }
+  
+  emitRenewed(key, freshToken, oldToken) {
+    this.emitter.emit(EVENT_RENEWED, key, freshToken, oldToken);
+  }
+  
+  emitAdded(key, token) {
+    this.emitter.emit(EVENT_ADDED, key, token);
+  }
+  
+  emitRemoved(key, token?) {
+    this.emitter.emit(EVENT_REMOVED, key, token);
+  }
+  
+  emitError(error) {
+    this.emitter.emit(EVENT_ERROR, error);
+  }
+  
+  emitEventsForCrossTabsStorageUpdate(newValue, oldValue) {
+    const oldTokens = this.getTokensFromStorageValue(oldValue);
+    const newTokens = this.getTokensFromStorageValue(newValue);
+    Object.keys(newTokens).forEach(key => {
+      const oldToken = oldTokens[key];
+      const newToken = newTokens[key];
+      if (JSON.stringify(oldToken) !== JSON.stringify(newToken)) {
+        this.emitAdded(key, newToken);
+      }
+    });
+    Object.keys(oldTokens).forEach(key => {
+      const oldToken = oldTokens[key];
+      const newToken = newTokens[key];
+      if (!newToken) {
+        this.emitRemoved(key, oldToken);
+      }
+    });
+  }
+  
+  clearExpireEventTimeout(key) {
+    clearTimeout(this.state.expireTimeouts[key] as any);
+    delete this.state.expireTimeouts[key];
+  
+    // Remove the renew promise (if it exists)
+    delete this.state.renewPromise[key];
+  }
+  
+  clearExpireEventTimeoutAll() {
+    var expireTimeouts = this.state.expireTimeouts;
+    for (var key in expireTimeouts) {
+      if (!Object.prototype.hasOwnProperty.call(expireTimeouts, key)) {
+        continue;
+      }
+      this.clearExpireEventTimeout(key);
+    }
+  }
+  
+  setExpireEventTimeout(key, token) {
+    var expireTime = this.getExpireTime(token);
+    var expireEventWait = Math.max(expireTime - this.clock.now(), 0) * 1000;
+  
+    // Clear any existing timeout
+    this.clearExpireEventTimeout(key);
+  
+    var expireEventTimeout = setTimeout(() => {
+      this.emitExpired(key, token);
+    }, expireEventWait);
+  
+    // Add a new timeout
+    this.state.expireTimeouts[key] = expireEventTimeout;
+  }
+  
+  setExpireEventTimeoutAll() {
+    var tokenStorage = this.storage.getStorage();
+    for(var key in tokenStorage) {
+      if (!Object.prototype.hasOwnProperty.call(tokenStorage, key)) {
+        continue;
+      }
+      var token = tokenStorage[key];
+      this.setExpireEventTimeout(key, token);
+    }
+  }
+  
+  // reset timeouts to setup autoRenew for tokens from other document context (tabs)
+  resetExpireEventTimeoutAll() {
+    this.clearExpireEventTimeoutAll();
+    this.setExpireEventTimeoutAll();
+  }
+  
+  validateToken(token: Token) {
+    if (!isIDToken(token) && !isAccessToken(token) && !isRefreshToken(token)) {
+      throw new AuthSdkError(
+        'Token must be an Object with scopes, expiresAt, and one of: an idToken, accessToken, or refreshToken property'
+        );
+    }
+  }
+  
+  add(key, token: Token) {
+    var tokenStorage = this.storage.getStorage();
+    this.validateToken(token);
+    tokenStorage[key] = token;
+    this.storage.setStorage(tokenStorage);
+    this.emitAdded(key, token);
+    this.setExpireEventTimeout(key, token);
+  }
+  
+  getSync(key) {
+    var tokenStorage = this.storage.getStorage();
+    return tokenStorage[key];
+  }
+  
+  async get(key) {
+    return this.getSync(key);
+  }
+  
+  getTokensSync(): Tokens {
+    const tokens = {} as Tokens;
+    const tokenStorage = this.storage.getStorage();
+    Object.keys(tokenStorage).forEach(key => {
+      const token = tokenStorage[key];
+      if (isAccessToken(token)) {
+        tokens.accessToken = token;
+      } else if (isIDToken(token)) {
+        tokens.idToken = token;
+      } else if (isRefreshToken(token)) { 
+        tokens.refreshToken = token;
+      }
+    });
+    return tokens;
+  }
+  
+  async getTokens(): Promise<Tokens> {
+    return this.getTokensSync();
+  }
+  
+  getStorageKeyByType(type: TokenType): string {
+    const tokenStorage = this.storage.getStorage();
+    const key = Object.keys(tokenStorage).filter(key => {
+      const token = tokenStorage[key];
+      return (isAccessToken(token) && type === 'accessToken') 
+        || (isIDToken(token) && type === 'idToken')
+        || (isRefreshToken(token) && type === 'refreshToken');
+    })[0];
+    return key;
+  }
+
+  // eslint-disable-next-line complexity
+  setTokens(
+    { accessToken, idToken, refreshToken }: Tokens, 
+    accessTokenCb?: Function, 
+    idTokenCb?: Function,
+    refreshTokenCb?: Function
+  ): void {
+    const handleAdded = (key, token, tokenCb) => {
+      this.emitAdded(key, token);
+      this.setExpireEventTimeout(key, token);
+      if (tokenCb) {
+        tokenCb(key, token);
+      }
+    };
+    const handleRemoved = (key, token, tokenCb) => {
+      this.clearExpireEventTimeout(key);
+      this.emitRemoved(key, token);
+      if (tokenCb) {
+        tokenCb(key, token);
+      }
+    };
+  
+    if (idToken) {
+      this.validateToken(idToken);
+    }
+    if (accessToken) {
+      this.validateToken(accessToken);
+    }
+    const idTokenKey = this.getStorageKeyByType('idToken') || ID_TOKEN_STORAGE_KEY;
+    const accessTokenKey = this.getStorageKeyByType('accessToken') || ACCESS_TOKEN_STORAGE_KEY;
+    const refreshTokenKey = this.getStorageKeyByType('refreshToken') || REFRESH_TOKEN_STORAGE_KEY;
+  
+    // add token to storage
+    const tokenStorage = { 
+      ...(idToken && { [idTokenKey]: idToken }),
+      ...(accessToken && { [accessTokenKey]: accessToken }),
+      ...(refreshToken && { [refreshTokenKey]: refreshToken })
+    };
+    this.storage.setStorage(tokenStorage);
+  
+    // emit event and start expiration timer
+    const existingTokens = this.getTokensSync();
+    if (idToken) {
+      handleAdded(idTokenKey, idToken, idTokenCb);
+    } else if (existingTokens.idToken) {
+      handleRemoved(idTokenKey, existingTokens.idToken, idTokenCb);
+    }
+    if (accessToken) {
+      handleAdded(accessTokenKey, accessToken, accessTokenCb);
+    } else if (existingTokens.accessToken) {
+      handleRemoved(accessTokenKey, existingTokens.accessToken, accessTokenCb);
+    }
+    if (refreshToken) {
+      handleAdded(refreshTokenKey, refreshToken, refreshTokenCb);
+    } else if (existingTokens.refreshToken) {
+      handleRemoved(refreshTokenKey, existingTokens.refreshToken, refreshTokenCb);
+    }
+  }
+  /* eslint-enable max-params */
+  
+  remove(key) {
+    // Clear any listener for this token
+    this.clearExpireEventTimeout(key);
+  
+    var tokenStorage = this.storage.getStorage();
+    var removedToken = tokenStorage[key];
+    delete tokenStorage[key];
+    this.storage.setStorage(tokenStorage);
+  
+    this.emitRemoved(key, removedToken);
+  }
+  
+  async renewToken(token) {
+    const tokens = this.getTokensSync();
+    let freshTokens;
+    if (tokens.refreshToken) {
+      freshTokens = await this.sdk.token.renewTokensWithRefresh({
+        scopes: token.scopes,
+      }, tokens.refreshToken);
+      // Multiple tokens may have come back. Return only the token which was requested.
+      return isIDToken(token) ? freshTokens.idToken : freshTokens.accessToken;
+    }
+    return this.sdk.token.renew(token);
+  }
+  
+  renew(key): Promise<Token> {
+    // Multiple callers may receive the same promise. They will all resolve or reject from the same request.
+    var existingPromise = this.state.renewPromise[key];
+    if (existingPromise) {
+      return existingPromise;
+    }
+  
+    try {
+      var token = this.getSync(key);
+      if (!token) {
+        throw new AuthSdkError('The tokenManager has no token for the key: ' + key);
+      }
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  
+    // Remove existing autoRenew timeout
+    this.clearExpireEventTimeout(key);
+  
+    // A refresh token means a replace instead of renewal
+    // Store the renew promise state, to avoid renewing again
+    this.state.renewPromise[key] = this.renewToken(token)
+      .then(freshToken => {
+        // store and emit events for freshToken
+        const oldTokenStorage = this.storage.getStorage();
+        this.remove(key);
+        this.add(key, freshToken);
+        this.emitRenewed(key, freshToken, oldTokenStorage[key]);
+        return freshToken;
+      })
+      .catch(err => {
+        if (err.name === 'OAuthError' || err.name === 'AuthSdkError') {
+          // remove expired token in storage
+          const tokenStorage = this.storage.getStorage();
+          const currentToken = tokenStorage[key];
+          if (currentToken && this.hasExpired(currentToken)) {
+            delete tokenStorage[key];
+            this.clearExpireEventTimeout(key);
+            this.storage.setStorage(tokenStorage);
+            this.emitRemoved(key, currentToken);
+          } else {
+            // token have been removed from other tabs
+            // still trigger removed event for downstream listeners
+            this.emitRemoved(key);
+          }
+          
+          err.tokenKey = key;
+          this.emitError(err);
+        }
+        throw err;
+      })
+      .finally(() => {
+        // Remove existing promise key
+        delete this.state.renewPromise[key];
+      });
+  
+    return this.state.renewPromise[key];
+  }
+  
+  clear() {
+    this.clearExpireEventTimeoutAll();
+    this.storage.clearStorage();
+  }
+  
+  getTokensFromStorageValue(value) {
+    let tokens;
+    try {
+      tokens = JSON.parse(value) || {};
+    } catch (e) {
+      tokens = {};
+    }
+    return tokens;
+  }
+}
+
+if (isLocalhost()) {
+  (function addWarningsForLocalhost() {
+    const { add } = TokenManager.prototype;
+    Object.assign(TokenManager.prototype, {
+      add: function(key, token: Token) {
+        warn(
+          'Use setTokens() instead if you want to add a set of tokens at same time.\n' + 
+          'It prevents current tab from emitting unnecessary StorageEvent,\n' + 
+          'which may cause false-positive authState change cross tabs.'
+        );
+        add.call(this, key, token);
+      }
+    });
+  })();
 }

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -74,26 +74,8 @@ export class TokenManager {
   private options: TokenManagerOptions;
   private service: TokenService;
 
-  // get: (key: string) => Promise<Token>;
-  // add: (key: string, token: Token) => void;
-  // clear: () => void;
-  // remove: (key: string) => void;
-  // renew: (key: string) => Promise<Token>;
   on: (event: string, handler: TokenErrorEventHandler | TokenEventHandler, context?: object) => void;
   off: (event: string, handler?: TokenErrorEventHandler | TokenEventHandler) => void;
-  // hasExpired: (token: Token) => boolean;
-  // getTokens: () => Promise<Tokens>;
-  // setTokens: (tokens: Tokens) => void;
-  
-  // // This is exposed so we can get storage key agnostic tokens set in internal state managers
-  // _getStorageKeyByType: (type: TokenType) => string;
-  // // This is exposed so we can set clear timeouts in our tests
-  // _clearExpireEventTimeoutAll: () => void;
-  // // This is exposed read-only options for internal sdk use
-  // _getOptions: () => TokenManagerOptions;
-  // // Expose cross tabs communication helper functions to tests
-  // _resetExpireEventTimeoutAll: () => void;
-  // _emitEventsForCrossTabsStorageUpdate: (newValue: string, oldValue: string) => void;
 
   constructor(sdk: OktaAuth, options: TokenManagerOptions = {}) {
     this.sdk = sdk;
@@ -126,21 +108,8 @@ export class TokenManager {
     this.clock = SdkClock.create(/* sdk, options */);
     this.state = defaultState();
 
-    // this.add = add.bind(this, sdk, tokenMgmtRef, storage);
-    // this.get = getAsync.bind(this, storage);
-    // this.remove = remove.bind(this, tokenMgmtRef, storage);
-    // this.clear = clear.bind(this, tokenMgmtRef, storage);
-    // this.renew = renew.bind(this, sdk, tokenMgmtRef, storage);
     this.on = this.emitter.on.bind(this.emitter);
     this.off = this.emitter.off.bind(this.emitter);
-    // this.hasExpired = hasExpired.bind(this, tokenMgmtRef);
-    // this.getTokens = getTokensAsync.bind(this, storage);
-    // this.setTokens = setTokens.bind(this, sdk, tokenMgmtRef, storage);
-    // this._getStorageKeyByType = getKeyByType.bind(this, storage);
-    // this._clearExpireEventTimeoutAll = clearExpireEventTimeoutAll.bind(this, tokenMgmtRef);
-    // this._getOptions = () => clone(options);
-    // this._resetExpireEventTimeoutAll = resetExpireEventTimeoutAll.bind(this, tokenMgmtRef, storage);
-    // this._emitEventsForCrossTabsStorageUpdate = emitEventsForCrossTabsStorageUpdate.bind(this, tokenMgmtRef);
   }
 
   start() {

--- a/lib/services/TokenService.ts
+++ b/lib/services/TokenService.ts
@@ -1,0 +1,86 @@
+/* global window */
+import { TokenManager, EVENT_EXPIRED } from '../TokenManager';
+import { AuthSdkError } from '../errors';
+import { isBrowser } from '../features';
+import { TokenManagerOptions } from '../types';
+
+function shouldThrottleRenew(renewTimeQueue) {
+  let res = false;
+  renewTimeQueue.push(Date.now());
+  if (renewTimeQueue.length >= 10) {
+    // get and remove first item from queue
+    const firstTime = renewTimeQueue.shift();
+    const lastTime = renewTimeQueue[renewTimeQueue.length - 1];
+    res = lastTime - firstTime < 30 * 1000;
+  }
+  return res;
+}
+
+export class TokenService {
+  private tokenManager: TokenManager;
+  private options: TokenManagerOptions;
+  private storageListener: (event: StorageEvent) => void;
+  private onTokenExpiredHandler: (key: string) => void;
+  private syncTimeout: unknown;
+
+  constructor(tokenManager: TokenManager, options: TokenManagerOptions = {}) {
+    this.tokenManager = tokenManager;
+    this.options = options;
+  }
+
+  start() {
+    const renewTimeQueue = [];
+    this.onTokenExpiredHandler = (key) => {
+      if (this.options.autoRenew) {
+        if (shouldThrottleRenew(renewTimeQueue)) {
+          const error = new AuthSdkError('Too many token renew requests');
+          this.tokenManager.emitError(error);
+        } else {
+          this.tokenManager.renew(key).catch(() => {}); // Renew errors will emit an "error" event 
+        }
+      } else if (this.options.autoRemove) {
+        this.tokenManager.remove(key);
+      }
+    };
+    this.tokenManager.on(EVENT_EXPIRED, this.onTokenExpiredHandler);
+
+    this.tokenManager.setExpireEventTimeoutAll();
+
+    if (this.options.syncStorage && isBrowser()) {
+      // Sync authState cross multiple tabs when localStorage is used as the storageProvider
+      // A StorageEvent is sent to a window when a storage area it has access to is changed 
+      // within the context of another document.
+      // https://developer.mozilla.org/en-US/docs/Web/API/StorageEvent
+
+      this.storageListener = ({ key, newValue, oldValue }: StorageEvent) => {
+        const handleCrossTabsStorageChange = () => {
+          this.tokenManager.resetExpireEventTimeoutAll();
+          this.tokenManager.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
+        };
+
+        // Skip if:
+        // not from localStorage.clear (event.key is null)
+        // event.key is not the storageKey
+        // oldValue === newValue
+        if (key && (key !== this.options.storageKey || newValue === oldValue)) {
+          return;
+        }
+
+        // LocalStorage cross tabs update is not synced in IE, set a 1s timer by default to read latest value
+        // https://stackoverflow.com/questions/24077117/localstorage-in-win8-1-ie11-does-not-synchronize
+        this.syncTimeout = setTimeout(() => handleCrossTabsStorageChange(), this.options._storageEventDelay);
+      };
+
+      window.addEventListener('storage', this.storageListener);
+    }
+  }
+
+  stop() {
+    this.tokenManager.clearExpireEventTimeoutAll();
+    this.tokenManager.off(EVENT_EXPIRED, this.onTokenExpiredHandler);
+    if (this.options.syncStorage && isBrowser()) {
+      window.removeEventListener('storage', this.storageListener);
+      clearTimeout(this.syncTimeout as any);
+    }
+  }
+}

--- a/lib/types/EventEmitter.ts
+++ b/lib/types/EventEmitter.ts
@@ -1,0 +1,6 @@
+export declare class EventEmitter {
+  on   (event: string, callback: Function, ctx?: any): EventEmitter;
+  once (event: string, callback: Function, ctx?: any): EventEmitter;
+  emit (event: string, ...args: any[]): EventEmitter;
+  off  (event: string, callback?: Function): EventEmitter;
+}

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -25,6 +25,7 @@ export interface TokenManagerOptions {
   storage?: string | SimpleStorage;
   storageKey?: string;
   expireEarlySeconds?: number;
+  syncStorage?: boolean;
   _storageEventDelay?: number;
 }
 

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -149,7 +149,7 @@ export interface TokenAPI extends BaseTokenAPI {
   revoke(token: RevocableToken): Promise<object>;
   renew(token: Token): Promise<Token>;
   renewTokens(): Promise<Tokens>;
-  renewTokensWithRefresh(refreshTokenObject: RefreshToken): Promise<Tokens>;
+  renewTokensWithRefresh(tokenParams: TokenParams, refreshTokenObject: RefreshToken): Promise<Tokens>;
   verify(token: IDToken, params?: object): Promise<IDToken>;
   isLoginRedirect(): boolean;
 }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -12,6 +12,7 @@
 
 export * from './api';
 export * from './AuthState';
+export * from './EventEmitter';
 export * from './Transaction';
 export * from './Cookies';
 export * from './http';

--- a/test/app/src/testApp.ts
+++ b/test/app/src/testApp.ts
@@ -47,6 +47,8 @@ function logoutLink(app: TestApp): string {
 
 const Toolbar = `
   <div class="actions subscribe">
+    <a id="start-service" onclick="startService(event)">Start service</a>
+    <a id="stop-service" onclick="stopService(event)">Stop service</a>
     <a id="subscribe-auth-state" onclick="subscribeToAuthState(event)">Subscribe to AuthState</a>
     <a id="subscribe-token-events" onclick="subscribeToTokenEvents(event)">Subscribe to TokenManager events</a>
   </div>
@@ -91,7 +93,9 @@ function bindFunctions(testApp: TestApp, window: Window): void {
     testConcurrentLogin: testApp.testConcurrentLogin.bind(testApp),
     testConcurrentLoginViaTokenRenewFailure: testApp.testConcurrentLoginViaTokenRenewFailure.bind(testApp),
     subscribeToAuthState: testApp.subscribeToAuthState.bind(testApp),
-    subscribeToTokenEvents: testApp.subscribeToTokenEvents.bind(testApp)
+    subscribeToTokenEvents: testApp.subscribeToTokenEvents.bind(testApp),
+    startService: testApp.startService.bind(testApp),
+    stopService: testApp.stopService.bind(testApp),
   };
   Object.keys(boundFunctions).forEach(functionName => {
     (window as any)[functionName] = makeClickHandler((boundFunctions as any)[functionName]);
@@ -128,6 +132,14 @@ class TestApp {
       scopes: this.config.defaultScopes ? [] : this.config.scopes
     }));
     return this.oktaAuth;
+  }
+
+  startService(): void {
+    this.oktaAuth.start();
+  }
+
+  stopService(): void {
+    this.oktaAuth.stop();
   }
 
   subscribeToAuthState(): void {

--- a/test/e2e/pageobjects/TestApp.js
+++ b/test/e2e/pageobjects/TestApp.js
@@ -47,7 +47,7 @@ class TestApp {
   // Toolbar
   get subscribeAuthStateBtn() { return $('#subscribe-auth-state'); }
   get subscribeTokenEventsBtn() { return $('#subscribe-token-events'); }
-  
+  get startServiceBtn() { return $('#start-service'); }
   get handleCallbackBtn() { return $('#handle-callback'); }
   get callbackResult() { return $('#callback-result'); }
   get returnHomeBtn() { return $('#return-home'); }
@@ -148,6 +148,10 @@ class TestApp {
     await this.waitForLoginBtn();
   }
 
+  async startService() {
+    await this.startServiceBtn.then(el => el.click());
+  }
+  
   async subscribeToAuthState() {
     await this.subscribeAuthStateBtn.then(el => el.click());
   }

--- a/test/e2e/specs/crossTabs.js
+++ b/test/e2e/specs/crossTabs.js
@@ -6,11 +6,13 @@ import { loginPopup } from '../util/loginUtils';
 const openMultipleTabs = async () => {
   await openPKCE();
   await TestApp.subscribeToAuthState(); // re-render on auth state change
+  await TestApp.startService();
 
   // open in new tab
   await browser.newWindow('/');
   await openPKCE();
   await TestApp.subscribeToAuthState(); // re-render on auth state change
+  await TestApp.startService();
 };
 
 const assertSameTokensInTabs = async (tabTokenMap, handles) => {

--- a/test/spec/OktaAuth/api.ts
+++ b/test/spec/OktaAuth/api.ts
@@ -22,6 +22,34 @@ describe('OktaAuth (api)', function() {
     expect(auth instanceof OktaAuth).toBe(true);
   });
 
+  describe('service methods', () => {
+    afterEach(() => {
+      auth.stop();
+    });
+
+    describe('start', () => {
+      it('starts the token service', () => {
+        jest.spyOn(auth.tokenManager, 'start');
+        auth.start();
+        expect(auth.tokenManager.start).toHaveBeenCalled(); 
+      });
+      it('updates auth state', () => {
+        jest.spyOn(auth.authStateManager, 'updateAuthState');
+        auth.start();
+        expect(auth.authStateManager.updateAuthState).toHaveBeenCalled(); 
+      });
+    });
+
+    describe('stop', () => {
+      it('stops the token service', () => {
+        jest.spyOn(auth.tokenManager, 'stop');
+        auth.start();
+        auth.stop();
+        expect(auth.tokenManager.stop).toHaveBeenCalled(); 
+      });
+    });
+
+  });
   describe('signInWithCredentials', () => {
     let options;
     beforeEach(() => {

--- a/test/spec/OktaAuth/browser.ts
+++ b/test/spec/OktaAuth/browser.ts
@@ -516,6 +516,7 @@ describe('OktaAuth (browser)', function() {
       jest.spyOn(auth.authStateManager, 'unsubscribe');
       jest.spyOn(auth, 'getOriginalUri').mockReturnValue('/fakeuri');
       jest.spyOn(auth, 'removeOriginalUri');
+      jest.spyOn(auth.tokenManager, 'hasExpired').mockReturnValue(false);
     });
 
     it('should redirect to originalUri when tokens are provided', async () => {

--- a/test/spec/TokenManager/browser.ts
+++ b/test/spec/TokenManager/browser.ts
@@ -51,11 +51,14 @@ describe('TokenManager (browser)', function() {
     });
   }
 
-  function setupSync(options = {}) {
+  function setupSync(options = {}, start = false) {
     client = createAuth(options);
     // clear downstream listeners
     client.tokenManager.off('added');
     client.tokenManager.off('removed');
+    if (start) {
+      client.tokenManager.start();
+    }
     return client;
   }
   
@@ -65,6 +68,12 @@ describe('TokenManager (browser)', function() {
     sessionStorage.clear();
   });
   
+  afterEach(() => {
+    if (client && client.tokenManager) {
+      client.tokenManager.stop();
+    }
+  });
+
   describe('options', () => {
     it('defaults to localStorage', function() {
       setupSync();
@@ -150,7 +159,7 @@ describe('TokenManager (browser)', function() {
         expireEarlySeconds: 60
       };
       const instance = new TokenManager(client, options);
-      expect(instance._getOptions().expireEarlySeconds).toBe(30);
+      expect(instance.getOptions().expireEarlySeconds).toBe(30);
     });
     it('should be able to set expireEarlySeconds for dev env', () => {
       jest.spyOn(mocked.features, 'isLocalhost').mockReturnValue(true);
@@ -159,14 +168,14 @@ describe('TokenManager (browser)', function() {
         expireEarlySeconds: 60
       };
       const instance = new TokenManager(client, options);
-      expect(instance._getOptions().expireEarlySeconds).toBe(60);
+      expect(instance.getOptions().expireEarlySeconds).toBe(60);
     });
   });
 
   describe('renew', () => {
     beforeEach(() => {
       jest.spyOn(mocked.features, 'isLocalhost').mockReturnValue(true);
-      setupSync();
+      setupSync({}, true);
     });
 
     it('allows renewing an idToken, without renewing accessToken', function() {

--- a/test/spec/TokenManager/core.ts
+++ b/test/spec/TokenManager/core.ts
@@ -4,6 +4,7 @@ import util from '@okta/test.support/util';
 import oauthUtil from '@okta/test.support/oauthUtil';
 import SdkClock from '../../../lib/clock';
 import * as features from '../../../lib/features';
+import { TokenService } from '../../../lib/services/TokenService';
 
 const Emitter = require('tiny-emitter');
 
@@ -66,6 +67,54 @@ describe('TokenManager', function() {
       client.tokenManager.clear();
     }
     jest.useRealTimers();
+  });
+
+  describe('service methods', () => {
+    beforeEach(() => {
+      setupSync();
+    });
+    describe('start', () => {
+      it('instantiates the token service', () => {
+        expect(client.tokenManager.service).not.toBeTruthy();
+        client.tokenManager.start();
+        expect(client.tokenManager.service).toBeTruthy();
+      });
+      it('starts the token service', () => {
+        jest.spyOn(TokenService.prototype, 'start');
+        client.tokenManager.start();
+        expect(TokenService.prototype.start).toHaveBeenCalled();
+      });
+      it('stops existing service', () => {
+        const myService = client.tokenManager.service = {
+          stop: jest.fn()
+        };
+        client.tokenManager.start();
+        expect(myService.stop).toHaveBeenCalled();
+        expect(myService).not.toBe(client.tokenManager.service); 
+      });
+    });
+
+    describe('stop', () => {
+      it('stops the token service, if it exists', () => {
+        const myService = client.tokenManager.service = {
+          stop: jest.fn()
+        };
+        client.tokenManager.stop();
+        expect(myService.stop).toHaveBeenCalled();
+      });
+      it('sets service instance to null', () => {
+        client.tokenManager.service = {
+          stop: jest.fn()
+        };
+        client.tokenManager.stop();
+        expect(client.tokenManager.service).toBe(null); 
+      });
+      it('does not error if there is no service instance', () => {
+        expect(client.tokenManager.service).toBe(undefined); 
+        client.tokenManager.stop();
+      });
+    });
+
   });
 
   describe('Event emitter', function() {

--- a/test/spec/TokenManager/crossTabs.ts
+++ b/test/spec/TokenManager/crossTabs.ts
@@ -8,13 +8,17 @@ const Emitter = require('tiny-emitter');
 
 describe('cross tabs communication', () => {
   let sdkMock;
+  let instance;
   beforeEach(function() {
     jest.useFakeTimers();
+    instance = null;
     const emitter = new Emitter();
     sdkMock = {
       options: {},
       storageManager: {
-        getTokenStorage: jest.fn()
+        getTokenStorage: jest.fn().mockReturnValue({
+          getStorage: jest.fn().mockReturnValue({})
+        })
       },
       emitter
     };
@@ -23,39 +27,49 @@ describe('cross tabs communication', () => {
   });
   afterEach(() => {
     jest.useRealTimers();
+    if (instance) {
+      instance.stop();
+    }
   });
+
+  function createInstance(options = null) {
+    instance = new TokenManager(sdkMock, options);
+    instance.start();
+    return instance;
+  }
+
   it('should emit events and reset timeouts when storage event happen with token storage key', () => {
-    const instance = new TokenManager(sdkMock);
-    instance._resetExpireEventTimeoutAll = jest.fn();
-    instance._emitEventsForCrossTabsStorageUpdate = jest.fn();
+    createInstance();
+    instance.resetExpireEventTimeoutAll = jest.fn();
+    instance.emitEventsForCrossTabsStorageUpdate = jest.fn();
     window.dispatchEvent(new StorageEvent('storage', {
       key: 'okta-token-storage', 
       newValue: 'fake_new_value',
       oldValue: 'fake_old_value'
     }));
     jest.runAllTimers();
-    expect(instance._resetExpireEventTimeoutAll).toHaveBeenCalled();
-    expect(instance._emitEventsForCrossTabsStorageUpdate).toHaveBeenCalledWith('fake_new_value', 'fake_old_value');
+    expect(instance.resetExpireEventTimeoutAll).toHaveBeenCalled();
+    expect(instance.emitEventsForCrossTabsStorageUpdate).toHaveBeenCalledWith('fake_new_value', 'fake_old_value');
   });
   it('should set options._storageEventDelay default to 1000 in isIE11OrLess env', () => {
     jest.spyOn(features, 'isIE11OrLess').mockReturnValue(true);
-    const instance = new TokenManager(sdkMock);
-    expect(instance._getOptions()._storageEventDelay).toBe(1000);
+    createInstance();
+    expect(instance.getOptions()._storageEventDelay).toBe(1000);
   });
   it('should use options._storageEventDelay from passed options', () => {
-    const instance = new TokenManager(sdkMock, { _storageEventDelay: 100 });
-    expect(instance._getOptions()._storageEventDelay).toBe(100);
+    createInstance({ _storageEventDelay: 100 });
+    expect(instance.getOptions()._storageEventDelay).toBe(100);
   });
   it('should use options._storageEventDelay from passed options in isIE11OrLess env', () => {
     jest.spyOn(features, 'isIE11OrLess').mockReturnValue(true);
-    const instance = new TokenManager(sdkMock, { _storageEventDelay: 100 });
-    expect(instance._getOptions()._storageEventDelay).toBe(100);
+    createInstance({ _storageEventDelay: 100 });
+    expect(instance.getOptions()._storageEventDelay).toBe(100);
   });
   it('should handle storage change based on _storageEventDelay option', () => {
     jest.spyOn(window, 'setTimeout');
-    const instance = new TokenManager(sdkMock, { _storageEventDelay: 500 });
-    instance._resetExpireEventTimeoutAll = jest.fn();
-    instance._emitEventsForCrossTabsStorageUpdate = jest.fn();
+    createInstance({ _storageEventDelay: 500 });
+    instance.resetExpireEventTimeoutAll = jest.fn();
+    instance.emitEventsForCrossTabsStorageUpdate = jest.fn();
     window.dispatchEvent(new StorageEvent('storage', {
       key: 'okta-token-storage', 
       newValue: 'fake_new_value',
@@ -63,13 +77,13 @@ describe('cross tabs communication', () => {
     }));
     expect(window.setTimeout).toHaveBeenCalledWith(expect.any(Function), 500);
     jest.runAllTimers();
-    expect(instance._resetExpireEventTimeoutAll).toHaveBeenCalled();
-    expect(instance._emitEventsForCrossTabsStorageUpdate).toHaveBeenCalledWith('fake_new_value', 'fake_old_value');
+    expect(instance.resetExpireEventTimeoutAll).toHaveBeenCalled();
+    expect(instance.emitEventsForCrossTabsStorageUpdate).toHaveBeenCalledWith('fake_new_value', 'fake_old_value');
   });
   it('should emit events and reset timeouts when localStorage.clear() has been called from other tabs', () => {
-    const instance = new TokenManager(sdkMock);
-    instance._resetExpireEventTimeoutAll = jest.fn();
-    instance._emitEventsForCrossTabsStorageUpdate = jest.fn();
+    createInstance();
+    instance.resetExpireEventTimeoutAll = jest.fn();
+    instance.emitEventsForCrossTabsStorageUpdate = jest.fn();
     // simulate localStorage.clear()
     window.dispatchEvent(new StorageEvent('storage', {
       key: null,
@@ -77,11 +91,11 @@ describe('cross tabs communication', () => {
       oldValue: null
     }));
     jest.runAllTimers();
-    expect(instance._resetExpireEventTimeoutAll).toHaveBeenCalled();
-    expect(instance._emitEventsForCrossTabsStorageUpdate).toHaveBeenCalledWith(null, null);
+    expect(instance.resetExpireEventTimeoutAll).toHaveBeenCalled();
+    expect(instance.emitEventsForCrossTabsStorageUpdate).toHaveBeenCalledWith(null, null);
   });
   it('should not call localStorage.setItem when token storage changed', () => {
-    new TokenManager(sdkMock); // eslint-disable-line no-new
+    createInstance();
     // https://github.com/facebook/jest/issues/6798#issuecomment-440988627
     jest.spyOn(window.localStorage.__proto__, 'setItem');
     window.dispatchEvent(new StorageEvent('storage', {
@@ -92,78 +106,78 @@ describe('cross tabs communication', () => {
     expect(localStorage.setItem).not.toHaveBeenCalled();
   });
   it('should not emit events or reset timeouts if the key is not token storage key', () => {
-    const instance = new TokenManager(sdkMock);
-    instance._resetExpireEventTimeoutAll = jest.fn();
-    instance._emitEventsForCrossTabsStorageUpdate = jest.fn();
+    createInstance();
+    instance.resetExpireEventTimeoutAll = jest.fn();
+    instance.emitEventsForCrossTabsStorageUpdate = jest.fn();
     window.dispatchEvent(new StorageEvent('storage', {
       key: 'fake-key', 
       newValue: 'fake_new_value',
       oldValue: 'fake_old_value'
     }));
-    expect(instance._resetExpireEventTimeoutAll).not.toHaveBeenCalled();
-    expect(instance._emitEventsForCrossTabsStorageUpdate).not.toHaveBeenCalled();
+    expect(instance.resetExpireEventTimeoutAll).not.toHaveBeenCalled();
+    expect(instance.emitEventsForCrossTabsStorageUpdate).not.toHaveBeenCalled();
   });
   it('should not emit events or reset timeouts if oldValue === newValue', () => {
-    const instance = new TokenManager(sdkMock);
-    instance._resetExpireEventTimeoutAll = jest.fn();
-    instance._emitEventsForCrossTabsStorageUpdate = jest.fn();
+    createInstance();
+    instance.resetExpireEventTimeoutAll = jest.fn();
+    instance.emitEventsForCrossTabsStorageUpdate = jest.fn();
     window.dispatchEvent(new StorageEvent('storage', {
       key: 'okta-token-storage', 
       newValue: 'fake_unchanged_value',
       oldValue: 'fake_unchanged_value'
     }));
-    expect(instance._resetExpireEventTimeoutAll).not.toHaveBeenCalled();
-    expect(instance._emitEventsForCrossTabsStorageUpdate).not.toHaveBeenCalled();
+    expect(instance.resetExpireEventTimeoutAll).not.toHaveBeenCalled();
+    expect(instance.emitEventsForCrossTabsStorageUpdate).not.toHaveBeenCalled();
   });
   
   describe('_emitEventsForCrossTabsStorageUpdate', () => {
     it('should emit "added" event if new token is added', () => {
-      const instance = new TokenManager(sdkMock);
+      createInstance();
       const newValue = '{"idToken": "fake-idToken"}';
       const oldValue = null;
       jest.spyOn(sdkMock.emitter, 'emit');
-      instance._emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
+      instance.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
       expect(sdkMock.emitter.emit).toHaveBeenCalledWith('added', 'idToken', 'fake-idToken');
     });
     it('should emit "added" event if token is changed', () => {
-      const instance = new TokenManager(sdkMock);
+      createInstance();
       const newValue = '{"idToken": "fake-idToken"}';
       const oldValue = '{"idToken": "old-fake-idToken"}';
       jest.spyOn(sdkMock.emitter, 'emit');
-      instance._emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
+      instance.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
       expect(sdkMock.emitter.emit).toHaveBeenCalledWith('added', 'idToken', 'fake-idToken');
     });
     it('should emit two "added" event if two token are added', () => {
-      const instance = new TokenManager(sdkMock);
+      createInstance();
       const newValue = '{"idToken": "fake-idToken", "accessToken": "fake-accessToken"}';
       const oldValue = null;
       jest.spyOn(sdkMock.emitter, 'emit');
-      instance._emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
+      instance.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
       expect(sdkMock.emitter.emit).toHaveBeenNthCalledWith(1, 'added', 'idToken', 'fake-idToken');
       expect(sdkMock.emitter.emit).toHaveBeenNthCalledWith(2, 'added', 'accessToken', 'fake-accessToken');
     });
     it('should not emit "added" event if oldToken equal to newToken', () => {
-      const instance = new TokenManager(sdkMock);
+      createInstance();
       const newValue = '{"idToken": "fake-idToken"}';
       const oldValue = '{"idToken": "fake-idToken"}';
       jest.spyOn(sdkMock.emitter, 'emit');
-      instance._emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
+      instance.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
       expect(sdkMock.emitter.emit).not.toHaveBeenCalled();
     });
     it('should emit "removed" event if token is removed', () => {
-      const instance = new TokenManager(sdkMock);
+      createInstance();
       const newValue = null;
       const oldValue = '{"idToken": "old-fake-idToken"}';
       jest.spyOn(sdkMock.emitter, 'emit');
-      instance._emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
+      instance.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
       expect(sdkMock.emitter.emit).toHaveBeenCalledWith('removed', 'idToken', 'old-fake-idToken');
     });
     it('should emit two "removed" event if two token are removed', () => {
-      const instance = new TokenManager(sdkMock);
+      createInstance();
       const newValue = null;
       const oldValue = '{"idToken": "fake-idToken", "accessToken": "fake-accessToken"}';
       jest.spyOn(sdkMock.emitter, 'emit');
-      instance._emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
+      instance.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
       expect(sdkMock.emitter.emit).toHaveBeenNthCalledWith(1, 'removed', 'idToken', 'fake-idToken');
       expect(sdkMock.emitter.emit).toHaveBeenNthCalledWith(2, 'removed', 'accessToken', 'fake-accessToken');
     });

--- a/test/spec/oidc/getUserInfo.ts
+++ b/test/spec/oidc/getUserInfo.ts
@@ -95,7 +95,7 @@ describe('token.getUserInfo', function() {
   it('throws an error if no arguments are passed', function() {
     return Promise.resolve(setupSync())
     .then(function(oa) {
-      jest.spyOn(oa.tokenManager, 'get').mockReturnValue(Promise.resolve(undefined));
+      jest.spyOn(oa.tokenManager, 'getTokens').mockReturnValue(Promise.resolve({}));
       return oa.token.getUserInfo();
     })
     .then(function() {
@@ -125,7 +125,7 @@ describe('token.getUserInfo', function() {
   it('throws an error if no idTokenObject is passed', function() {
     return Promise.resolve(setupSync())
     .then(function(oa) {
-      jest.spyOn(oa.tokenManager, 'get').mockReturnValue(Promise.resolve(undefined));
+      jest.spyOn(oa.tokenManager, 'getTokens').mockReturnValue(Promise.resolve({}));
       return oa.token.getUserInfo(tokens.standardAccessTokenParsed);
     })
     .then(function() {

--- a/test/support/oauthUtil.js
+++ b/test/support/oauthUtil.js
@@ -185,6 +185,10 @@ oauthUtil.setup = function(opts) {
   // Mock the well-known and keys request
   oauthUtil.loadWellKnownAndKeysCache(authClient);
 
+  if (opts.autoRenew) {
+    authClient.tokenManager.start();
+  }
+
   if (opts.tokenManagerAddKeys) {
     for (var key in opts.tokenManagerAddKeys) {
       if (!Object.prototype.hasOwnProperty.call(opts.tokenManagerAddKeys, key)) {
@@ -211,7 +215,7 @@ oauthUtil.setup = function(opts) {
       promise = authClient.token.getWithPopup(opts.getWithPopupArgs);
     }
   } else if (opts.tokenManagerRenewArgs) {
-    promise = authClient.tokenManager.renew.apply(this, opts.tokenManagerRenewArgs);
+    promise = authClient.tokenManager.renew.apply(authClient.tokenManager, opts.tokenManagerRenewArgs);
   } else if (opts.tokenRenewArgs) {
     promise = authClient.token.renew.apply(this, opts.tokenRenewArgs);
   } else if (opts.tokenRenewTokensArgs) {
@@ -228,7 +232,7 @@ oauthUtil.setup = function(opts) {
           tokenTypesTobeRenewed.splice(index, 1);
         }
         if (!tokenTypesTobeRenewed.length) {
-          authClient.tokenManager._clearExpireEventTimeoutAll();
+          authClient.tokenManager.clearExpireEventTimeoutAll();
           resolve();
         } 
       });
@@ -271,6 +275,9 @@ oauthUtil.setup = function(opts) {
     .finally(function() {
       if (authClient && authClient._tokenQueue) {
         expect(authClient._tokenQueue.queue.length).toBe(0);
+      }
+      if (authClient && authClient.tokenManager) {
+        authClient.tokenManager.stop();
       }
     });
 };


### PR DESCRIPTION
- the default value for `autoRenew` of true is left unchanged 
- new methods `start` and `stop` are added to `OktaAuth` and `TokenManager`. user must explicitly call a method to start the service behavior.
- creating an instance of `OktaAuth` promises not to cause async side effects
- `start` on `OktaAuth` will call `updateAuthState` on the `AuthStateManager` and call `start` on the `TokenManager`
- `start` on `TokenManager` will create an instance of `TokenService` and pass the current token manager options.
- `TokenService`: existing options are respected: `autoRenew`, `autoRemove`
- new option added `syncStorage` to control the cross tabs behavior
- `TokenManager` is refactored into a class, service logic moved to `TokenService` class
- README update