### PR TITLE
sample: social auth in expressJS

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,6 +42,26 @@
       "autoAttachChildProcesses": true,
       "program": "${workspaceRoot}/node_modules/@wdio/cli/bin/wdio.js",
       "console": "integratedTerminal"
-  }
+    },
+
+    {
+      "name": "sample: express direct auth (web server)",
+      "type": "node",
+      "request": "launch",
+      "autoAttachChildProcesses": true,
+      "console": "integratedTerminal",
+      "cwd": "${workspaceRoot}/samples/generated/express-direct-auth",
+      "program": "web-server/server.js"
+    },
+
+    {
+      "name": "sample: express direct auth (resource server)",
+      "type": "node",
+      "request": "launch",
+      "autoAttachChildProcesses": true,
+      "console": "integratedTerminal",
+      "cwd": "${workspaceRoot}/samples/generated/express-direct-auth",
+      "program": "resource-server/server.js"
+    }
   ]
 }

--- a/babel.cjs.js
+++ b/babel.cjs.js
@@ -1,5 +1,6 @@
 const sdkVersion = require('./package.json').version;
 module.exports = {
+  sourceMaps: true,
   'presets': [
     '@babel/typescript',
     [

--- a/lib/idx/authenticate.ts
+++ b/lib/idx/authenticate.ts
@@ -14,6 +14,7 @@ import {
   EnrollOrChallengeAuthenticatorValues,
   ReEnrollAuthenticator,
   ReEnrollAuthenticatorValues,
+  RedirectIdp
 } from './remediators';
 
 const flow: RemediationFlow = {
@@ -21,6 +22,7 @@ const flow: RemediationFlow = {
   'select-authenticator-authenticate': SelectAuthenticator,
   'challenge-authenticator': EnrollOrChallengeAuthenticator,
   'reenroll-authenticator': ReEnrollAuthenticator,
+  'redirect-idp': RedirectIdp
 };
 
 export interface AuthenticationOptions extends 

--- a/lib/idx/interact.ts
+++ b/lib/idx/interact.ts
@@ -49,7 +49,8 @@ export async function interact (authClient: OktaAuth, options: InteractOptions =
     state = meta.state;
     scopes = meta.scopes;
   }
-
+  meta = Object.assign(meta, { state, scopes }); // save back to meta
+  
   return idx.start({
     // if interactionHandle is undefined here, idx will bootstrap a new interactionHandle
     interactionHandle,

--- a/lib/idx/remediators/RedirectIdp.ts
+++ b/lib/idx/remediators/RedirectIdp.ts
@@ -3,6 +3,17 @@ import { Base } from './Base';
 export class RedirectIdp extends Base {
 
   canRemediate() {
-    return true;
+    return false;
   }
+
+  getNextStep() {
+    const { name, type, idp, href } = this.remediation;
+    return {
+      name,
+      type,
+      idp,
+      href
+    };
+  }
+
 }

--- a/lib/idx/remediators/RedirectIdp.ts
+++ b/lib/idx/remediators/RedirectIdp.ts
@@ -1,0 +1,8 @@
+import { Base } from './Base';
+
+export class RedirectIdp extends Base {
+
+  canRemediate() {
+    return true;
+  }
+}

--- a/lib/idx/remediators/index.ts
+++ b/lib/idx/remediators/index.ts
@@ -3,6 +3,7 @@ export * from './EnrollOrChallengeAuthenticator';
 export * from './EnrollProfile';
 export * from './Identify';
 export * from './ReEnrollAuthenticator';
+export * from './RedirectIdp';
 export * from './SelectAuthenticator';
 export * from './SelectEnrollProfile';
 export * from './AuthenticatorVerificationData';

--- a/lib/idx/startAuthTransaction.ts
+++ b/lib/idx/startAuthTransaction.ts
@@ -7,12 +7,8 @@ export async function startAuthTransaction(
   options: InteractOptions
 ): Promise<AuthTransaction> {
   const {
-    interactionHandle,
     meta,
   } = await interact(authClient, options);
-  const authTransaction = new AuthTransaction(authClient, {
-    interactionHandle,
-    meta
-  });
+  const authTransaction = new AuthTransaction(authClient, meta);
   return authTransaction;
 }

--- a/lib/idx/types.ts
+++ b/lib/idx/types.ts
@@ -49,6 +49,11 @@ export enum IdxStatus {
   FAILED,
 }
 
+export interface IdpConfig {
+  id: string;
+  name: string;
+}
+
 // TODO: remove when idx-js provides type information
 export interface IdxRemeditionValue {
   name: string;
@@ -70,6 +75,10 @@ export interface IdxRemediation {
       type: string;
     };
   };
+  idp?: IdpConfig;
+  href?: string;
+  method?: string;
+  type?: string;
 }
 
 export interface IdxMessage {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build": "node scripts/build.js",
     "build:cdn": "cross-env NODE_ENV=production webpack --config webpack.cdn.config.js -p",
     "build:web": "cross-env NODE_ENV=production webpack --config webpack.config.js --output-library-target=umd -p",
-    "build:cjs": "cross-env babel lib -d build/cjs --config-file ./babel.cjs.js --extensions \".ts\",\".js\"",
+    "build:cjs": "cross-env babel lib -d build/cjs --config-file ./babel.cjs.js --extensions \".ts\",\".js\" --source-maps",
     "build:polyfill": "cross-env NODE_ENV=production webpack --config webpack.polyfill.config.js --output-library-target=umd -p",
     "generate:samples": "yarn --cwd samples build && yarn install --ignore-scripts",
     "dev:samples": "yarn --cwd samples dev",

--- a/samples/generated/express-direct-auth/resource-server/server.js
+++ b/samples/generated/express-direct-auth/resource-server/server.js
@@ -50,6 +50,7 @@ function authenticationRequired(req, res, next) {
 }
 
 const app = express();
+module.exports = app;
 
 /**
  * For local testing only!  Enables CORS for all domains

--- a/samples/generated/express-direct-auth/web-server/middlewares/authTransaction.js
+++ b/samples/generated/express-direct-auth/web-server/middlewares/authTransaction.js
@@ -1,0 +1,19 @@
+const crypto = require('crypto');
+
+function uniqueId() {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+module.exports = function authTransaction(req, res, next) {
+  let transactionId;
+  if (req.query.transactionId) {
+    transactionId = req.query.transactionId;
+  } else if (req.query.state) {
+    transactionId = req.query.state;
+  } else {
+    transactionId = uniqueId();
+  }
+  req.transactionId = transactionId;
+
+  next();
+};

--- a/samples/generated/express-direct-auth/web-server/middlewares/index.js
+++ b/samples/generated/express-direct-auth/web-server/middlewares/index.js
@@ -1,7 +1,11 @@
 const ensureAuthenticated = require('./ensureAuthenticated');
 const userContext = require('./userContext');
+const lastError = require('./lastError');
+const authTransaction = require('./authTransaction');
 
 module.exports = {
   ensureAuthenticated,
   userContext,
+  lastError,
+  authTransaction
 };

--- a/samples/generated/express-direct-auth/web-server/middlewares/lastError.js
+++ b/samples/generated/express-direct-auth/web-server/middlewares/lastError.js
@@ -1,0 +1,16 @@
+module.exports = function lastError(req, res, next) {
+
+  req.getLastError = function getLastError() {
+    return req.session.lastError;
+  };
+  
+  req.setLastError = function setLastError(error) {
+    req.session.lastError = error;
+  };
+  
+  req.clearLastError = function clearLastError() {
+    delete req.session.lastError;
+  };
+
+  next();
+};

--- a/samples/generated/express-direct-auth/web-server/routes/login.js
+++ b/samples/generated/express-direct-auth/web-server/routes/login.js
@@ -95,13 +95,16 @@ const renderLoginWithIDP = async (req, res) => {
 
 router.get('/login', (req, res) => {
   const { widget, idp } = req.query;
+  
   if (widget) {
-    renderLoginWithWidget(req, res);
-  } else if (idp) {
-    renderLoginWithIDP(req, res);
-  } else {
-    renderTemplate(req, res, 'login');
+    return renderLoginWithWidget(req, res);
   }
+  
+  if (idp) {
+    return renderLoginWithIDP(req, res);
+  }
+
+  renderLogin();
 });
 
 router.post('/login', async (req, res) => {

--- a/samples/generated/express-direct-auth/web-server/routes/login.js
+++ b/samples/generated/express-direct-auth/web-server/routes/login.js
@@ -3,7 +3,9 @@ const { IdxStatus } = require('@okta/okta-auth-js');
 const { 
   getAuthClient, 
   renderError, 
-  handleAuthTransaction, 
+  handleAuthTransaction,
+  getAuthTransaction,
+  renderTemplate
 } = require('../utils');
 const { 
   generateSelectAuthenticator, 
@@ -34,27 +36,23 @@ const renderLogin = (req, res) => {
 };
 
 const renderLoginWithWidget = (req, res) => {
-  const authClient = getAuthClient(req);
-  authClient.idx.startAuthTransaction()
+  getAuthTransaction(req)
     .then(authTransaction => {
       const {
-        data: {
-          interactionHandle,
-          meta: {
-            codeChallenge, 
-            codeChallengeMethod, 
-            state,
-          }
-        }
-      } = authTransaction;
+        interactionHandle,
+        codeChallenge, 
+        codeChallengeMethod, 
+        state,
+      } = authTransaction.data;
 
       if (!interactionHandle) {
         throw new Error(
-          'Missing required congifuration "interactionHandle" to initial the widget'
+          'Missing required configuration "interactionHandle" to initialize the widget'
         );
       }
 
-      const widgetConfig = JSON.stringify({
+      console.log('renderLoginWithWidget: using interaction handle: ', interactionHandle);
+      const widgetConfig = {
         baseUrl: sampleConfig.oidc.issuer.split('/oauth2')[0],
         clientId: sampleConfig.oidc.clientId,
         redirectUri: sampleConfig.oidc.redirectUri,
@@ -67,26 +65,50 @@ const renderLoginWithWidget = (req, res) => {
         interactionHandle,
         codeChallenge,
         codeChallengeMethod,
-      });
-      res.render('login-with-widget', {
+      };
+      renderTemplate(req, res, 'login-with-widget', {
         siwVersion: '5.5.2',
-        widgetConfig,
+        widgetConfig: JSON.stringify(widgetConfig),
       });
     })
     .catch(error => {
-      renderError(res, {
-        template: 'login-with-widget',
-        error,
-      });
+      req.setLastError(error);
+      renderTemplate(req, res, 'terminal-error');
     });
 };
 
+const renderLoginWithIDP = (req, res) => {
+  const authClient = getAuthClient(req);
+  try {
+    const { 
+      data: { 
+        tokens, 
+        error,
+      },
+    } = await authClient.idx.authenticate(); // Policy must be configured to return a `redirect-idp` remediation
+    if (error) {
+      throw error;
+    }
+    // Save tokens to storage (req.session)
+    authClient.tokenManager.setTokens(tokens);
+    // Redirect back to home page
+    res.redirect('/');
+  } catch (error) {
+    authClient.transactionManager.clear();
+    req.setLastError(error.message);
+    res.redirect('/login');
+  }
+
+};
+
 router.get('/login', (req, res) => {
-  const { widget } = req.query;
+  const { widget, idp } = req.query;
   if (widget) {
     renderLoginWithWidget(req, res);
+  } else if (idp) {
+    renderLoginWithIDP(req, res);
   } else {
-    renderLogin(req, res); 
+    renderTemplate(req, res, 'login');
   }
 });
 
@@ -101,10 +123,9 @@ router.post('/login', async (req, res) => {
     });
     handleAuthTransaction({ req, res, next, authClient, authTransaction });
   } catch (error) {
-    renderError(res, {
-      template: 'login',
-      error,
-    });
+    authClient.transactionManager.clear();
+    req.setLastError(error.message);
+    res.redirect('/login');
   }
 });
 
@@ -144,7 +165,11 @@ router.get('/login/callback', async (req, res) => {
     // Redirect back to home page
     res.redirect('/');
   } catch (err) {
-    console.log('Failed to handle interaction code callback, error: ', err);
+    if (authClient.isInteractionRequiredError(err) !== true) {
+      console.log('Failed to handle interaction code callback, error: ', err);
+      req.setLastError(err);
+    }
+
     res.redirect('/login?widget=1');
   }
 });

--- a/samples/generated/express-direct-auth/web-server/server.js
+++ b/samples/generated/express-direct-auth/web-server/server.js
@@ -5,8 +5,8 @@ const express = require('express');
 const session = require('express-session');
 const mustacheExpress = require('mustache-express');
 const path = require('path');
-const { userContext } = require('./middlewares');
 const { getAuthClient } = require('./utils');
+const { userContext, lastError, authTransaction } = require('./middlewares');
 
 const templateDir = path.join(__dirname, '', 'views');
 const frontendDir = path.join(__dirname, '', 'assets');
@@ -14,12 +14,16 @@ const frontendDir = path.join(__dirname, '', 'assets');
 const { oidc, port } = require('../config.js').webServer;
 
 const app = express();
+module.exports = app;
+
 app.use(express.urlencoded({ extended: true }));
 app.use(session({ 
   secret: 'this-should-be-very-random', 
   resave: true, 
   saveUninitialized: false
 }));
+app.use(lastError);
+app.use(authTransaction);
 
 // Provide the configuration to the view layer because we show it on the homepage
 const displayConfig = Object.assign(

--- a/samples/generated/express-direct-auth/web-server/utils/getAuthClient.js
+++ b/samples/generated/express-direct-auth/web-server/utils/getAuthClient.js
@@ -1,8 +1,9 @@
 const OktaAuth = require('@okta/okta-auth-js').OktaAuth;
-
 const sampleConfig = require('../../config').webServer;
 
 module.exports = function getAuthClient(req, options = {}) {
+  const { transactionId } = req; // set by authTransaction middleware
+
   const storageProvider = {
     getItem: function(key) {
       let val;
@@ -30,6 +31,7 @@ module.exports = function getAuthClient(req, options = {}) {
           storageProvider
         },
         transaction: {
+          storageKey: `transaction-${transactionId}`, // unique storage per transaction
           storageProvider
         }
       },

--- a/samples/generated/express-direct-auth/web-server/utils/getAuthTransaction.js
+++ b/samples/generated/express-direct-auth/web-server/utils/getAuthTransaction.js
@@ -1,0 +1,14 @@
+const AuthTransaction = require('@okta/okta-auth-js').AuthTransaction;
+const getAuthClient = require('./getAuthClient');
+
+module.exports = function getAuthTransaction(req) {
+  const authClient = getAuthClient(req);
+  const meta = authClient.transactionManager.load();
+  if (meta) {
+    console.log(`getAuthTransaction: using existing transaction: ${req.transactionId}`);
+    return Promise.resolve(new AuthTransaction(authClient, meta));
+  }
+
+  console.log(`getAuthTransaction: starting new transaction: ${req.transactionId}`);
+  return authClient.idx.startAuthTransaction({ state: req.transactionId });
+};

--- a/samples/generated/express-direct-auth/web-server/utils/index.js
+++ b/samples/generated/express-direct-auth/web-server/utils/index.js
@@ -1,11 +1,15 @@
 const getAuthClient = require('./getAuthClient');
+const getAuthTransaction = require('./getAuthTransaction');
 const renderError = require('./renderError');
 const handleAuthTransaction = require('./handleAuthTransaction');
 const getIdxMethod = require('./getIdxMethod');
+const renderTemplate = require('./renderTemplate');
 
 module.exports = {
   getAuthClient,
+  getAuthTransaction,
   renderError,
   handleAuthTransaction,
   getIdxMethod,
+  renderTemplate
 };

--- a/samples/generated/express-direct-auth/web-server/utils/renderTemplate.js
+++ b/samples/generated/express-direct-auth/web-server/utils/renderTemplate.js
@@ -1,0 +1,14 @@
+const renderError = require('./renderError');
+
+module.exports = function renderTemplate(req, res, template, options) {
+  const error = req.getLastError();
+  if (error) {
+    req.clearLastError();
+    renderError(res, {
+      template,
+      error,
+    });
+    return;
+  }
+  res.render(template, options);
+};

--- a/samples/generated/express-direct-auth/web-server/views/home.mustache
+++ b/samples/generated/express-direct-auth/web-server/views/home.mustache
@@ -38,7 +38,8 @@
             <h3>Available flows in the sample:</h3>
             <div>
             <ul>
-              <li><a href="/login">Password factor</a></li>
+              <li><a href="/login">Login using a username and password</a></li>
+              <li><a href="/login?idp=1">Login using an external identity provider</a></li>
               <li><a href="/signup">Self service registration</a></li>
               <li><a href="/login?widget=1">Self hosted widget</a></li>
               <li><a href="/recover-password">Password Recovery</a></li>

--- a/samples/generated/express-direct-auth/web-server/views/login-with-idp.mustache
+++ b/samples/generated/express-direct-auth/web-server/views/login-with-idp.mustache
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    {{>head}}
+  </head>
+  <body id="samples">
+    {{>menu}}
+    <div id="sign-in" class="ui center aligned relaxed grid">
+      <div class="row">
+        <div class="ui header">
+          <h2>Sign In</h2>
+        </div>
+      </div>
+
+      <div class="row">
+        {{>errors}}
+      </div>
+
+      <div class="row">
+
+
+      </div>
+
+    </div>
+  </body>
+</html>

--- a/samples/generated/express-direct-auth/web-server/views/login-with-idp.mustache
+++ b/samples/generated/express-direct-auth/web-server/views/login-with-idp.mustache
@@ -8,7 +8,7 @@
     <div id="sign-in" class="ui center aligned relaxed grid">
       <div class="row">
         <div class="ui header">
-          <h2>Sign In</h2>
+          <h2>Sign In using an external IDP</h2>
         </div>
       </div>
 
@@ -17,8 +17,9 @@
       </div>
 
       <div class="row">
-
-
+        {{#idp}}
+          <a href="{{href}}">{{idp.name}}</a>
+        {{/idp}}
       </div>
 
     </div>

--- a/samples/generated/express-direct-auth/web-server/views/login-with-widget.mustache
+++ b/samples/generated/express-direct-auth/web-server/views/login-with-widget.mustache
@@ -8,22 +8,26 @@
     <link href="https://global.oktacdn.com/okta-signin-widget/{{siwVersion}}/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
   </head>
   <body id="samples">
+    {{>menu}}
+  
+    <div id="content" class="ui padded relaxed">
 
-    {{>errors}}
+      {{>errors}}
 
-    <div id="okta-signin-widget-container"></div>
+      <div id="okta-signin-widget-container"></div>
 
-    <script type="text/javascript">
-      const widgetConfig = {{{widgetConfig}}};
-      const signIn = new OktaSignIn({
-        el: '#okta-signin-widget-container',
-        ...widgetConfig
-      });
-      signIn.showSignInAndRedirect()
-        .catch(err => {
-          console.log('Error happen in showSignInAndRedirect: ', err);
+      <script type="text/javascript">
+        const widgetConfig = {{{widgetConfig}}};
+        const signIn = new OktaSignIn({
+          el: '#okta-signin-widget-container',
+          ...widgetConfig
         });
-    </script>
+        signIn.showSignInAndRedirect()
+          .catch(err => {
+            console.log('Error happen in showSignInAndRedirect: ', err);
+          });
+      </script>
 
+    </div>
   </body>
 </html>

--- a/samples/generated/express-direct-auth/web-server/views/login.mustache
+++ b/samples/generated/express-direct-auth/web-server/views/login.mustache
@@ -5,6 +5,9 @@
   </head>
   <body id="samples">
     <div class="okta-sign-in-form ui center aligned relaxed grid">
+  
+      {{>menu}}
+
       <div class="row">
         <div class="ui header">
           <h2>Sign In</h2>

--- a/samples/generated/express-direct-auth/web-server/views/nav.mustache
+++ b/samples/generated/express-direct-auth/web-server/views/nav.mustache
@@ -1,0 +1,3 @@
+<div>
+  <a href="/">Home</a>
+</div>

--- a/samples/generated/express-direct-auth/web-server/views/recover-password.mustache
+++ b/samples/generated/express-direct-auth/web-server/views/recover-password.mustache
@@ -5,6 +5,9 @@
   </head>
   <body id="samples">
     <div class="okta-sign-in-form ui center aligned relaxed grid">
+    
+      {{>menu}}
+
       <div class="row">
         <div class="ui header">
           <h2>Recover password</h2>

--- a/samples/generated/express-direct-auth/web-server/views/registration.mustache
+++ b/samples/generated/express-direct-auth/web-server/views/registration.mustache
@@ -5,6 +5,9 @@
   </head>
   <body id="samples">
     <div class="okta-sign-in-form ui center aligned relaxed grid">
+      
+      {{>menu}}
+
       <div class="row">
         <div class="ui header">
           <h2>Self Service Registration</h2>

--- a/samples/generated/express-direct-auth/web-server/views/terminal-error.mustache
+++ b/samples/generated/express-direct-auth/web-server/views/terminal-error.mustache
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    {{>head}}
+    
+  </head>
+  <body id="samples">
+    
+    {{>menu}}
+
+    <div id="content" class="ui padded relaxed">
+      {{>errors}}
+    </div>
+
+  </body>
+</html>

--- a/samples/templates/express-direct-auth/resource-server/server.js
+++ b/samples/templates/express-direct-auth/resource-server/server.js
@@ -50,6 +50,7 @@ function authenticationRequired(req, res, next) {
 }
 
 const app = express();
+module.exports = app;
 
 /**
  * For local testing only!  Enables CORS for all domains

--- a/samples/templates/express-direct-auth/web-server/middlewares/authTransaction.js
+++ b/samples/templates/express-direct-auth/web-server/middlewares/authTransaction.js
@@ -1,0 +1,19 @@
+const crypto = require('crypto');
+
+function uniqueId() {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+module.exports = function authTransaction(req, res, next) {
+  let transactionId;
+  if (req.query.transactionId) {
+    transactionId = req.query.transactionId;
+  } else if (req.query.state) {
+    transactionId = req.query.state;
+  } else {
+    transactionId = uniqueId();
+  }
+  req.transactionId = transactionId;
+
+  next();
+};

--- a/samples/templates/express-direct-auth/web-server/middlewares/index.js
+++ b/samples/templates/express-direct-auth/web-server/middlewares/index.js
@@ -1,7 +1,11 @@
 const ensureAuthenticated = require('./ensureAuthenticated');
 const userContext = require('./userContext');
+const lastError = require('./lastError');
+const authTransaction = require('./authTransaction');
 
 module.exports = {
   ensureAuthenticated,
   userContext,
+  lastError,
+  authTransaction
 };

--- a/samples/templates/express-direct-auth/web-server/middlewares/lastError.js
+++ b/samples/templates/express-direct-auth/web-server/middlewares/lastError.js
@@ -1,0 +1,16 @@
+module.exports = function lastError(req, res, next) {
+
+  req.getLastError = function getLastError() {
+    return req.session.lastError;
+  };
+  
+  req.setLastError = function setLastError(error) {
+    req.session.lastError = error;
+  };
+  
+  req.clearLastError = function clearLastError() {
+    delete req.session.lastError;
+  };
+
+  next();
+};

--- a/samples/templates/express-direct-auth/web-server/routes/login.js
+++ b/samples/templates/express-direct-auth/web-server/routes/login.js
@@ -95,13 +95,16 @@ const renderLoginWithIDP = async (req, res) => {
 
 router.get('/login', (req, res) => {
   const { widget, idp } = req.query;
+  
   if (widget) {
-    renderLoginWithWidget(req, res);
-  } else if (idp) {
-    renderLoginWithIDP(req, res);
-  } else {
-    renderTemplate(req, res, 'login');
+    return renderLoginWithWidget(req, res);
   }
+  
+  if (idp) {
+    return renderLoginWithIDP(req, res);
+  }
+
+  renderLogin();
 });
 
 router.post('/login', async (req, res) => {

--- a/samples/templates/express-direct-auth/web-server/routes/login.js
+++ b/samples/templates/express-direct-auth/web-server/routes/login.js
@@ -3,7 +3,9 @@ const { IdxStatus } = require('@okta/okta-auth-js');
 const { 
   getAuthClient, 
   renderError, 
-  handleAuthTransaction, 
+  handleAuthTransaction,
+  getAuthTransaction,
+  renderTemplate
 } = require('../utils');
 const { 
   generateSelectAuthenticator, 
@@ -34,27 +36,23 @@ const renderLogin = (req, res) => {
 };
 
 const renderLoginWithWidget = (req, res) => {
-  const authClient = getAuthClient(req);
-  authClient.idx.startAuthTransaction()
+  getAuthTransaction(req)
     .then(authTransaction => {
       const {
-        data: {
-          interactionHandle,
-          meta: {
-            codeChallenge, 
-            codeChallengeMethod, 
-            state,
-          }
-        }
-      } = authTransaction;
+        interactionHandle,
+        codeChallenge, 
+        codeChallengeMethod, 
+        state,
+      } = authTransaction.data;
 
       if (!interactionHandle) {
         throw new Error(
-          'Missing required congifuration "interactionHandle" to initial the widget'
+          'Missing required configuration "interactionHandle" to initialize the widget'
         );
       }
 
-      const widgetConfig = JSON.stringify({
+      console.log('renderLoginWithWidget: using interaction handle: ', interactionHandle);
+      const widgetConfig = {
         baseUrl: sampleConfig.oidc.issuer.split('/oauth2')[0],
         clientId: sampleConfig.oidc.clientId,
         redirectUri: sampleConfig.oidc.redirectUri,
@@ -67,26 +65,50 @@ const renderLoginWithWidget = (req, res) => {
         interactionHandle,
         codeChallenge,
         codeChallengeMethod,
-      });
-      res.render('login-with-widget', {
+      };
+      renderTemplate(req, res, 'login-with-widget', {
         siwVersion: '{{siwVersion}}',
-        widgetConfig,
+        widgetConfig: JSON.stringify(widgetConfig),
       });
     })
     .catch(error => {
-      renderError(res, {
-        template: 'login-with-widget',
-        error,
-      });
+      req.setLastError(error);
+      renderTemplate(req, res, 'terminal-error');
     });
 };
 
+const renderLoginWithIDP = (req, res) => {
+  const authClient = getAuthClient(req);
+  try {
+    const { 
+      data: { 
+        tokens, 
+        error,
+      },
+    } = await authClient.idx.authenticate(); // Policy must be configured to return a `redirect-idp` remediation
+    if (error) {
+      throw error;
+    }
+    // Save tokens to storage (req.session)
+    authClient.tokenManager.setTokens(tokens);
+    // Redirect back to home page
+    res.redirect('/');
+  } catch (error) {
+    authClient.transactionManager.clear();
+    req.setLastError(error.message);
+    res.redirect('/login');
+  }
+
+};
+
 router.get('/login', (req, res) => {
-  const { widget } = req.query;
+  const { widget, idp } = req.query;
   if (widget) {
     renderLoginWithWidget(req, res);
+  } else if (idp) {
+    renderLoginWithIDP(req, res);
   } else {
-    renderLogin(req, res); 
+    renderTemplate(req, res, 'login');
   }
 });
 
@@ -101,10 +123,9 @@ router.post('/login', async (req, res) => {
     });
     handleAuthTransaction({ req, res, next, authClient, authTransaction });
   } catch (error) {
-    renderError(res, {
-      template: 'login',
-      error,
-    });
+    authClient.transactionManager.clear();
+    req.setLastError(error.message);
+    res.redirect('/login');
   }
 });
 
@@ -144,7 +165,11 @@ router.get('/login/callback', async (req, res) => {
     // Redirect back to home page
     res.redirect('/');
   } catch (err) {
-    console.log('Failed to handle interaction code callback, error: ', err);
+    if (authClient.isInteractionRequiredError(err) !== true) {
+      console.log('Failed to handle interaction code callback, error: ', err);
+      req.setLastError(err);
+    }
+
     res.redirect('/login?widget=1');
   }
 });

--- a/samples/templates/express-direct-auth/web-server/server.js
+++ b/samples/templates/express-direct-auth/web-server/server.js
@@ -5,8 +5,8 @@ const express = require('express');
 const session = require('express-session');
 const mustacheExpress = require('mustache-express');
 const path = require('path');
-const { userContext } = require('./middlewares');
 const { getAuthClient } = require('./utils');
+const { userContext, lastError, authTransaction } = require('./middlewares');
 
 const templateDir = path.join(__dirname, '', 'views');
 const frontendDir = path.join(__dirname, '', 'assets');
@@ -14,12 +14,16 @@ const frontendDir = path.join(__dirname, '', 'assets');
 const { oidc, port } = require('../config.js').webServer;
 
 const app = express();
+module.exports = app;
+
 app.use(express.urlencoded({ extended: true }));
 app.use(session({ 
   secret: 'this-should-be-very-random', 
   resave: true, 
   saveUninitialized: false
 }));
+app.use(lastError);
+app.use(authTransaction);
 
 // Provide the configuration to the view layer because we show it on the homepage
 const displayConfig = Object.assign(

--- a/samples/templates/express-direct-auth/web-server/utils/getAuthClient.js
+++ b/samples/templates/express-direct-auth/web-server/utils/getAuthClient.js
@@ -1,8 +1,9 @@
 const OktaAuth = require('@okta/okta-auth-js').OktaAuth;
-
 const sampleConfig = require('../../config').webServer;
 
 module.exports = function getAuthClient(req, options = {}) {
+  const { transactionId } = req; // set by authTransaction middleware
+
   const storageProvider = {
     getItem: function(key) {
       let val;
@@ -30,6 +31,7 @@ module.exports = function getAuthClient(req, options = {}) {
           storageProvider
         },
         transaction: {
+          storageKey: `transaction-${transactionId}`, // unique storage per transaction
           storageProvider
         }
       },

--- a/samples/templates/express-direct-auth/web-server/utils/getAuthTransaction.js
+++ b/samples/templates/express-direct-auth/web-server/utils/getAuthTransaction.js
@@ -1,0 +1,14 @@
+const AuthTransaction = require('@okta/okta-auth-js').AuthTransaction;
+const getAuthClient = require('./getAuthClient');
+
+module.exports = function getAuthTransaction(req) {
+  const authClient = getAuthClient(req);
+  const meta = authClient.transactionManager.load();
+  if (meta) {
+    console.log(`getAuthTransaction: using existing transaction: ${req.transactionId}`);
+    return Promise.resolve(new AuthTransaction(authClient, meta));
+  }
+
+  console.log(`getAuthTransaction: starting new transaction: ${req.transactionId}`);
+  return authClient.idx.startAuthTransaction({ state: req.transactionId });
+};

--- a/samples/templates/express-direct-auth/web-server/utils/index.js
+++ b/samples/templates/express-direct-auth/web-server/utils/index.js
@@ -1,11 +1,15 @@
 const getAuthClient = require('./getAuthClient');
+const getAuthTransaction = require('./getAuthTransaction');
 const renderError = require('./renderError');
 const handleAuthTransaction = require('./handleAuthTransaction');
 const getIdxMethod = require('./getIdxMethod');
+const renderTemplate = require('./renderTemplate');
 
 module.exports = {
   getAuthClient,
+  getAuthTransaction,
   renderError,
   handleAuthTransaction,
   getIdxMethod,
+  renderTemplate
 };

--- a/samples/templates/express-direct-auth/web-server/utils/renderTemplate.js
+++ b/samples/templates/express-direct-auth/web-server/utils/renderTemplate.js
@@ -1,0 +1,14 @@
+const renderError = require('./renderError');
+
+module.exports = function renderTemplate(req, res, template, options) {
+  const error = req.getLastError();
+  if (error) {
+    req.clearLastError();
+    renderError(res, {
+      template,
+      error,
+    });
+    return;
+  }
+  res.render(template, options);
+};

--- a/samples/templates/express-direct-auth/web-server/views/home.mustache
+++ b/samples/templates/express-direct-auth/web-server/views/home.mustache
@@ -38,7 +38,8 @@
             <h3>Available flows in the sample:</h3>
             <div>
             <ul>
-              <li><a href="/login">Password factor</a></li>
+              <li><a href="/login">Login using a username and password</a></li>
+              <li><a href="/login?idp=1">Login using an external identity provider</a></li>
               <li><a href="/signup">Self service registration</a></li>
               <li><a href="/login?widget=1">Self hosted widget</a></li>
               <li><a href="/recover-password">Password Recovery</a></li>

--- a/samples/templates/express-direct-auth/web-server/views/login-with-idp.mustache
+++ b/samples/templates/express-direct-auth/web-server/views/login-with-idp.mustache
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    {{>head}}
+  </head>
+  <body id="samples">
+    {{>menu}}
+    <div id="sign-in" class="ui center aligned relaxed grid">
+      <div class="row">
+        <div class="ui header">
+          <h2>Sign In</h2>
+        </div>
+      </div>
+
+      <div class="row">
+        {{>errors}}
+      </div>
+
+      <div class="row">
+
+
+      </div>
+
+    </div>
+  </body>
+</html>

--- a/samples/templates/express-direct-auth/web-server/views/login-with-idp.mustache
+++ b/samples/templates/express-direct-auth/web-server/views/login-with-idp.mustache
@@ -8,7 +8,7 @@
     <div id="sign-in" class="ui center aligned relaxed grid">
       <div class="row">
         <div class="ui header">
-          <h2>Sign In</h2>
+          <h2>Sign In using an external IDP</h2>
         </div>
       </div>
 
@@ -17,8 +17,9 @@
       </div>
 
       <div class="row">
-
-
+        {{#idp}}
+          <a href="{{href}}">{{idp.name}}</a>
+        {{/idp}}
       </div>
 
     </div>

--- a/samples/templates/express-direct-auth/web-server/views/login-with-widget.mustache
+++ b/samples/templates/express-direct-auth/web-server/views/login-with-widget.mustache
@@ -8,22 +8,26 @@
     <link href="https://global.oktacdn.com/okta-signin-widget/{{siwVersion}}/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
   </head>
   <body id="samples">
+    {{>menu}}
+  
+    <div id="content" class="ui padded relaxed">
 
-    {{>errors}}
+      {{>errors}}
 
-    <div id="okta-signin-widget-container"></div>
+      <div id="okta-signin-widget-container"></div>
 
-    <script type="text/javascript">
-      const widgetConfig = {{{widgetConfig}}};
-      const signIn = new OktaSignIn({
-        el: '#okta-signin-widget-container',
-        ...widgetConfig
-      });
-      signIn.showSignInAndRedirect()
-        .catch(err => {
-          console.log('Error happen in showSignInAndRedirect: ', err);
+      <script type="text/javascript">
+        const widgetConfig = {{{widgetConfig}}};
+        const signIn = new OktaSignIn({
+          el: '#okta-signin-widget-container',
+          ...widgetConfig
         });
-    </script>
+        signIn.showSignInAndRedirect()
+          .catch(err => {
+            console.log('Error happen in showSignInAndRedirect: ', err);
+          });
+      </script>
 
+    </div>
   </body>
 </html>

--- a/samples/templates/express-direct-auth/web-server/views/login.mustache
+++ b/samples/templates/express-direct-auth/web-server/views/login.mustache
@@ -5,6 +5,9 @@
   </head>
   <body id="samples">
     <div class="okta-sign-in-form ui center aligned relaxed grid">
+  
+      {{>menu}}
+
       <div class="row">
         <div class="ui header">
           <h2>Sign In</h2>

--- a/samples/templates/express-direct-auth/web-server/views/nav.mustache
+++ b/samples/templates/express-direct-auth/web-server/views/nav.mustache
@@ -1,0 +1,3 @@
+<div>
+  <a href="/">Home</a>
+</div>

--- a/samples/templates/express-direct-auth/web-server/views/recover-password.mustache
+++ b/samples/templates/express-direct-auth/web-server/views/recover-password.mustache
@@ -5,6 +5,9 @@
   </head>
   <body id="samples">
     <div class="okta-sign-in-form ui center aligned relaxed grid">
+    
+      {{>menu}}
+
       <div class="row">
         <div class="ui header">
           <h2>Recover password</h2>

--- a/samples/templates/express-direct-auth/web-server/views/registration.mustache
+++ b/samples/templates/express-direct-auth/web-server/views/registration.mustache
@@ -5,6 +5,9 @@
   </head>
   <body id="samples">
     <div class="okta-sign-in-form ui center aligned relaxed grid">
+      
+      {{>menu}}
+
       <div class="row">
         <div class="ui header">
           <h2>Self Service Registration</h2>

--- a/samples/templates/express-direct-auth/web-server/views/terminal-error.mustache
+++ b/samples/templates/express-direct-auth/web-server/views/terminal-error.mustache
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    {{>head}}
+    
+  </head>
+  <body id="samples">
+    
+    {{>menu}}
+
+    <div id="content" class="ui padded relaxed">
+      {{>errors}}
+    </div>
+
+  </body>
+</html>

--- a/samples/test/util/configUtils.js
+++ b/samples/test/util/configUtils.js
@@ -1,10 +1,10 @@
 const sampleName = process.env.SAMPLE_NAME;
 const issuer = process.env.ISSUER;
-const clientId = process.env.CLIENT_ID;
+const clientId = process.env.SPA_CLIENT_ID || process.env.CLIENT_ID;
 const username = process.env.USERNAME;
 const password = process.env.PASSWORD;
-const webClientId = process.env.WEB_CLIENT_ID;
-const clientSecret = process.env.WEB_CLIENT_SECRET;
+const webClientId = process.env.WEB_CLIENT_ID || process.env.CLIENT_ID;
+const clientSecret = process.env.WEB_CLIENT_SECRET || process.env.CLIENT_SECRET;
 
 const samplesConfig = require('../../config');
 const sampleConfig = samplesConfig.getSampleConfig(sampleName);


### PR DESCRIPTION
Also
- adds sourcemaps to cjs build

- various improvements to`express-direct-auth` sample:
 - login page uses res.redirect on error to void re-post
 - transactionId is stored in oauth state
 - adds nav menu to login pages
 - adds vscode launch profile
