### PR TITLE
feat: isAuthenticated will renew/remove  expired tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Breaking Changes
 
-- [#689](https://github.com/okta/okta-auth-js/pull/689) New methods `start` and `stop` are added to control `OktaAuth` as a service. TokenManager options `autoRenew`, and  `autoRemove` will only take effect after calling `start`.
+- [#689](https://github.com/okta/okta-auth-js/pull/689) New methods `start` and `stop` are added to control `OktaAuth` as a service.
 - [#515](https://github.com/okta/okta-auth-js/pull/515) Removes `token.value` field
 - [#540](https://github.com/okta/okta-auth-js/pull/540) Locks `tokenManager.expireEarlySeconds` option with the default value (30s) for non-dev environment
 - [#677](https://github.com/okta/okta-auth-js/pull/677) Http requests will not send cookies by default
@@ -17,7 +17,8 @@
 ### Other
 
 - [#675](https://github.com/okta/okta-auth-js/pull/675) Removes warning when calling `updateAuthState` when there are no subscribers
-  
+- [#706](https://github.com/okta/okta-auth-js/pull/706) calling `isAuthenticated` will renew expired tokens when `autoRenew` is true
+
 ## 4.9.0
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#540](https://github.com/okta/okta-auth-js/pull/540) Locks `tokenManager.expireEarlySeconds` option with the default value (30s) for non-dev environment
 - [#677](https://github.com/okta/okta-auth-js/pull/677) Http requests will not send cookies by default
 - [#678](https://github.com/okta/okta-auth-js/pull/678) Default value for `originalUri` is null.
+- [#706](https://github.com/okta/okta-auth-js/pull/706) Removes `isPending` from `AuthState`
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -2576,7 +2576,6 @@ authClient.tokenManager.off('renewed', myRenewedCallback);
 
 The emitted `AuthState` object includes:
 
-* `isPending`: true in the time after page load (first render) but before the asynchronous methods to see if the tokenManager is aware of a current authentication.
 * `isAuthenticated`: true if the user is considered authenticated. Normally this is true if both an idToken and an accessToken are present in the tokenManager, but this behavior can be overridden if you passed a [transformAuthState](#transformauthstate) callback in the [configuration](#configuration-reference).
 * `accessToken`: the JWT accessToken for the currently authenticated user (if provided by the scopes).
 * `idToken`: the JWT idToken for the currently authenticated user (if provided by the scopes).

--- a/README.md
+++ b/README.md
@@ -2591,7 +2591,7 @@ authClient.authStateManager.subscribe((authState) => {
 
 #### `authStateManager.getAuthState()`
 
-Gets latest evaluated `authState` from the `authStateManager`. The `authState` (a unique new object) is re-evaluated when `authStateManager.updateAuthState()` is called.
+Gets latest evaluated `authState` from the `authStateManager`. The `authState` (a unique new object) is re-evaluated when `authStateManager.updateAuthState()` is called. If `updateAuthState` has not been called, or it has not finished calculating an initial state, `getAuthState` will return `null`.
 
 #### `authStateManager.updateAuthState()`
 
@@ -2725,7 +2725,9 @@ The [CHANGELOG](CHANGELOG.md) contains details for all changes and links to the 
 
 ### From 4.x to 5.x
 
-* Token auto renew requires [running OktaAuth as a service](#running-as-a-service). To start the service, call [start()](#start).
+* Token auto renew requires [running OktaAuth as a service](#running-as-a-service). To start the service, call [start()](#start). `start` will also call [updateAuthState](#authstatemanagerupdateauthstate) to set an initial [AuthState](#authstatemanager)
+* [getAuthState](#authstatemanagergetauthstate) will return `null` until an [AuthState](#authstatemanager) has been calculated.
+* `isPending` has been removed from [AuthState](#authstatemanager).
 
 ### From 3.x to 4.x
 

--- a/lib/types/AuthState.ts
+++ b/lib/types/AuthState.ts
@@ -5,7 +5,6 @@ export interface AuthState {
   idToken?: IDToken;
   refreshToken?: RefreshToken;
   isAuthenticated?: boolean;
-  isPending?: boolean;
   error?: Error;
 }
 

--- a/samples/templates/partials/spa/app.js
+++ b/samples/templates/partials/spa/app.js
@@ -103,16 +103,17 @@ function main() {
 }
 
 function startApp() {
-  // Calculate initial auth state and fire change event for listeners
-  authClient.authStateManager.updateAuthState();
+  // Calculates initial auth state and fires change event for listeners
+  // Also starts the token auto-renew service
+  authClient.start();
 }
 
 function renderApp() {
   const authState = authClient.authStateManager.getAuthState();
   document.getElementById('authState').innerText = stringify(authState);
 
-  // If auth state is "pending", render in the loading state
-  if (authState.isPending) {
+  // Setting auth state is an asynchronous operation. If authState is not available yet, render in the loading state
+  if (!authState) {
     return renderLoading();
   }
 
@@ -288,7 +289,7 @@ function submitSigninForm() {
 {{/if}}
 
 function shouldRedirectToGetTokens(authState) {
-  if (authState.isAuthenticated || authState.isPending) {
+  if (authState.isAuthenticated) {
     return false;
   }
 

--- a/test/spec/AuthStateManager.js
+++ b/test/spec/AuthStateManager.js
@@ -1,7 +1,7 @@
 /* global window, StorageEvent */
 
 import Emitter from 'tiny-emitter';
-import { AuthStateManager, DEFAULT_AUTH_STATE } from '../../lib/AuthStateManager';
+import { AuthStateManager, INITIAL_AUTH_STATE } from '../../lib/AuthStateManager';
 import { OktaAuth, AuthSdkError } from '@okta/okta-auth-js';
 import tokens from '@okta/test.support/tokens';
 import waitFor from '@okta/test.support/waitFor';
@@ -27,7 +27,14 @@ describe('AuthStateManager', () => {
     sdkMock = {
       options: {},
       emitter,
+      isAuthenticated: () => Promise.resolve(true),
       tokenManager: {
+        getTokensSync: () => {
+          return {
+            accessToken: 'fakeAccessToken0',
+            idToken: 'fakeIdToken0'
+          };
+        },
         on: jest.fn().mockImplementation((event, handler) => {
           sdkMock.emitter.on(event, handler);
         }),
@@ -80,30 +87,21 @@ describe('AuthStateManager', () => {
       }
     });
 
-    it('should initial with default authState', () => {
+    it('should initialize authState', () => {
       const instance = new AuthStateManager(sdkMock);
-      expect(instance._authState).toMatchObject(DEFAULT_AUTH_STATE);
+      expect(instance._authState).toBe(INITIAL_AUTH_STATE);
     });
   });
 
   describe('getAuthState', () => {
     it('should return authState', () => {
       const instance = new AuthStateManager(sdkMock);
-      expect(instance.getAuthState()).toMatchObject(DEFAULT_AUTH_STATE);
+      instance._authState = { fake: true };
+      expect(instance.getAuthState()).toBe(instance._authState);
     });
   });
 
   describe('updateAuthState', () => {
-    beforeEach(() => {
-      sdkMock.tokenManager.getTokens = jest.fn()
-        .mockResolvedValueOnce({ accessToken: 'fakeAccessToken0', idToken: 'fakeIdToken0' })
-        .mockResolvedValueOnce({ accessToken: 'fakeAccessToken1', idToken: 'fakeIdToken1' });
-      sdkMock.tokenManager.getOptions = jest.fn().mockReturnValue({ 
-        autoRenew: true, 
-        autoRemove: true 
-      });
-      sdkMock.tokenManager.hasExpired = jest.fn().mockReturnValue(false);
-    });
 
     describe('browser', () => {
       if (typeof window === 'undefined') {
@@ -127,7 +125,8 @@ describe('AuthStateManager', () => {
       });
     });
 
-    it('should emit an authState with isAuthenticated === true', () => {
+    it('should emit an authState with isAuthenticated', () => {
+      jest.spyOn(sdkMock, 'isAuthenticated').mockResolvedValue('fake');
       expect.assertions(2);
       return new Promise(resolve => {
         const instance = new AuthStateManager(sdkMock);
@@ -138,8 +137,7 @@ describe('AuthStateManager', () => {
         setTimeout(() => {
           expect(handler).toHaveBeenCalledTimes(1);
           expect(handler).toHaveBeenCalledWith({
-
-            isAuthenticated: true,
+            isAuthenticated: 'fake',
             idToken: 'fakeIdToken0',
             accessToken: 'fakeAccessToken0'
           });
@@ -149,7 +147,8 @@ describe('AuthStateManager', () => {
     });
 
     it('should emit only latest authState', () => {
-      expect.assertions(2);
+      jest.spyOn(sdkMock, 'isAuthenticated');
+      expect.assertions(3);
       return new Promise(resolve => {
         const instance = new AuthStateManager(sdkMock);
         const handler = jest.fn();
@@ -158,11 +157,12 @@ describe('AuthStateManager', () => {
         instance.updateAuthState();
 
         setTimeout(() => {
+          expect(sdkMock.isAuthenticated).toHaveBeenCalledTimes(2);
           expect(handler).toHaveBeenCalledTimes(1);
           expect(handler).toHaveBeenCalledWith({
             isAuthenticated: true,
-            idToken: 'fakeIdToken1',
-            accessToken: 'fakeAccessToken1'
+            idToken: 'fakeIdToken0',
+            accessToken: 'fakeAccessToken0'
           });
           resolve();
         }, 100);
@@ -170,6 +170,9 @@ describe('AuthStateManager', () => {
     });
 
     it('should handle both updateAuthState if the previous one has finished before the second one start', () => {
+      jest.spyOn(sdkMock.tokenManager, 'getTokensSync')
+        .mockReturnValueOnce({ accessToken: 'fakeAccessToken0', idToken: 'fakeIdToken0' })
+        .mockReturnValueOnce({ accessToken: 'fakeAccessToken1', idToken: 'fakeIdToken1' });
       expect.assertions(3);
       return new Promise(resolve => {
         const instance = new AuthStateManager(sdkMock);
@@ -220,58 +223,6 @@ describe('AuthStateManager', () => {
       });
     });
 
-    it('should evaluate expired token as null with isPending state as true', () => {
-      expect.assertions(2);
-      jest.spyOn(sdkMock.tokenManager, 'hasExpired')
-        .mockReturnValueOnce(false)
-        .mockReturnValueOnce(true);
-
-      const instance = new AuthStateManager(sdkMock);
-      const handler = jest.fn();
-      instance.subscribe(handler);
-      instance.updateAuthState();
-      
-      return waitFor(() => {
-        return handler.mock.calls.length > 0;
-      }).then(() => {
-        expect(handler).toHaveBeenCalledTimes(1);
-        expect(handler).toHaveBeenCalledWith({
-          accessToken: 'fakeAccessToken0',
-          idToken: null,
-          isAuthenticated: false,
-          isPending: true,
-        });
-      });
-    });
-
-    it('should evaluate expired token as null with isPending state as false if both autoRenew and autoRemove are off', () => {
-      expect.assertions(2);
-      sdkMock.tokenManager.hasExpired = jest.fn()
-        .mockReturnValueOnce(false)
-        .mockReturnValueOnce(true);
-      sdkMock.tokenManager.getOptions = jest.fn().mockReturnValue({ 
-        autoRenew: false, 
-        autoRemove: false 
-      });
-      return new Promise(resolve => {
-        const instance = new AuthStateManager(sdkMock);
-        const handler = jest.fn();
-        instance.subscribe(handler);
-        instance.updateAuthState();
-        
-        setTimeout(() => {
-          expect(handler).toHaveBeenCalledTimes(1);
-          expect(handler).toHaveBeenCalledWith({
-            accessToken: 'fakeAccessToken0',
-            idToken: null,
-            isAuthenticated: false,
-            isPending: false,
-          });
-          resolve();
-        }, 100);
-      });
-    });
-
     it('should emit error in authState if transformAuthState throws error', () => {
       expect.assertions(2);
       const error = new Error('fake error');
@@ -279,7 +230,6 @@ describe('AuthStateManager', () => {
         accessToken: 'fakeAccessToken0',
         idToken: 'fakeIdToken0',
         isAuthenticated: false,
-        isPending: false,
         error
       };
       sdkMock.options.transformAuthState = jest.fn().mockRejectedValue(error);
@@ -298,15 +248,8 @@ describe('AuthStateManager', () => {
     });
 
     it('should stop and evaluate at the 10th update if too many updateAuthState happen concurrently', () => {
-      sdkMock.tokenManager.getTokens = jest.fn();
-      for (let i = 0; i < 100; i++) {
-        sdkMock.tokenManager.getTokens = sdkMock.tokenManager.getTokens
-          .mockResolvedValueOnce({ 
-            accessToken: `fakeAccessToken${i}`,
-            idToken: `fakeIdToken${i}`,
-          });
-      }
-
+      jest.spyOn(sdkMock, 'isAuthenticated');
+      expect.assertions(3);
       return new Promise(resolve => {
         const instance = new AuthStateManager(sdkMock);
         const handler = jest.fn();
@@ -316,12 +259,12 @@ describe('AuthStateManager', () => {
         }
 
         setTimeout(() => {
+          expect(sdkMock.isAuthenticated).toHaveBeenCalledTimes(11); // 10 times cancelled + 1 time resolved
           expect(handler).toHaveBeenCalledTimes(1);
           expect(handler).toHaveBeenCalledWith({
-            accessToken: 'fakeAccessToken10',
-            idToken: 'fakeIdToken10',
-            isAuthenticated: true,
-            isPending: false,
+            accessToken: 'fakeAccessToken0',
+            idToken: 'fakeIdToken0',
+            isAuthenticated: true
           });
           resolve();
         }, 100);
@@ -329,10 +272,10 @@ describe('AuthStateManager', () => {
     });
 
     it('should emit unique authState object', () => {
+      jest.spyOn(sdkMock.tokenManager, 'getTokensSync')
+        .mockReturnValueOnce({ accessToken: 'fakeAccessToken0', idToken: 'fakeIdToken0' })
+        .mockReturnValueOnce({ accessToken: 'fakeAccessToken1', idToken: 'fakeIdToken1' });
       expect.assertions(2);
-      sdkMock.tokenManager.getTokens = jest.fn()
-        .mockResolvedValueOnce({ accessToken: 'fakeAccessToken0', idToken: 'fakeIdToken0' })
-        .mockResolvedValueOnce({ accessToken: 'fakeAccessToken1', idToken: 'fakeIdToken1' });
       return new Promise(resolve => {
         const instance = new AuthStateManager(sdkMock);
         let prevAuthState;
@@ -357,8 +300,6 @@ describe('AuthStateManager', () => {
 
     it('should only emit same authState once', () => {
       expect.assertions(1);
-      sdkMock.tokenManager.getTokens = jest.fn()
-        .mockResolvedValue({ accessToken: 'fakeAccessToken0', idToken: 'fakeIdToken0' });
       return new Promise(resolve => {
         const instance = new AuthStateManager(sdkMock);
         const handler = jest.fn();

--- a/test/spec/AuthStateManager.js
+++ b/test/spec/AuthStateManager.js
@@ -138,7 +138,7 @@ describe('AuthStateManager', () => {
         setTimeout(() => {
           expect(handler).toHaveBeenCalledTimes(1);
           expect(handler).toHaveBeenCalledWith({
-            isPending: false,
+
             isAuthenticated: true,
             idToken: 'fakeIdToken0',
             accessToken: 'fakeAccessToken0'
@@ -160,7 +160,6 @@ describe('AuthStateManager', () => {
         setTimeout(() => {
           expect(handler).toHaveBeenCalledTimes(1);
           expect(handler).toHaveBeenCalledWith({
-            isPending: false,
             isAuthenticated: true,
             idToken: 'fakeIdToken1',
             accessToken: 'fakeAccessToken1'
@@ -184,13 +183,11 @@ describe('AuthStateManager', () => {
         setTimeout(() => {
           expect(handler).toHaveBeenCalledTimes(2);
           expect(handler).toHaveBeenCalledWith({
-            isPending: false,
             isAuthenticated: true,
             idToken: 'fakeIdToken0',
             accessToken: 'fakeAccessToken0'
           });
           expect(handler).toHaveBeenCalledWith({
-            isPending: false,
             isAuthenticated: true,
             idToken: 'fakeIdToken1',
             accessToken: 'fakeAccessToken1'
@@ -205,7 +202,6 @@ describe('AuthStateManager', () => {
         accessToken: 'fakeAccessToken0',
         idToken: 'fakeIdToken0',
         isAuthenticated: false,
-        isPending: false,
       };
       sdkMock.options.transformAuthState = jest.fn().mockResolvedValue(fakeAuthState);
       expect.assertions(3);

--- a/test/spec/AuthStateManager.js
+++ b/test/spec/AuthStateManager.js
@@ -4,7 +4,6 @@ import Emitter from 'tiny-emitter';
 import { AuthStateManager, INITIAL_AUTH_STATE } from '../../lib/AuthStateManager';
 import { OktaAuth, AuthSdkError } from '@okta/okta-auth-js';
 import tokens from '@okta/test.support/tokens';
-import waitFor from '@okta/test.support/waitFor';
 
 function createAuth() {
   return new OktaAuth({

--- a/test/types/auth.test-d.ts
+++ b/test/types/auth.test-d.ts
@@ -104,7 +104,6 @@ const authorizeOptions2: TokenParams = {
 
   // User
   expectType<boolean>(await authClient.isAuthenticated());
-  expectType<boolean>(await authClient.isAuthenticated(10));
   expectType<UserClaims>(await authClient.getUser());
 
   // Redirect

--- a/test/types/authStateManager.test-d.ts
+++ b/test/types/authStateManager.test-d.ts
@@ -36,6 +36,5 @@ const authClient = new OktaAuth({});
   expectType<IDToken>(authState.idToken);
   expectType<RefreshToken>(authState.refreshToken);
   expectType<boolean>(authState.isAuthenticated);
-  expectType<boolean>(authState.isPending);
   expectType<string>(authState.error.message);
 })();


### PR DESCRIPTION
Fixes a gap caused by not starting the token manager service. If the service is not running, but `autoRenew` is on, the tokens will be renewed when calling `isAuthenticated`