### PR TITLE
[idx] Added skip support for Self-Service Registration flow

### DIFF
--- a/lib/idx/register.ts
+++ b/lib/idx/register.ts
@@ -14,6 +14,7 @@ import {
   SelectAuthenticatorValues,
   EnrollOrChallengeAuthenticator,
   EnrollOrChallengeAuthenticatorValues,
+  Skip,
 } from './remediators';
 
 const flow: RemediationFlow = {
@@ -21,6 +22,7 @@ const flow: RemediationFlow = {
   'enroll-profile': EnrollProfile,
   'select-authenticator-enroll': SelectAuthenticator,
   'enroll-authenticator': EnrollOrChallengeAuthenticator,
+  'skip': Skip,
 };
 
 export interface RegistrationOptions extends 

--- a/lib/idx/remediate.ts
+++ b/lib/idx/remediate.ts
@@ -28,26 +28,34 @@ export async function remediate(
   values: RemediationValues
 ): Promise<RemediationResponse> {
   const { neededToProceed } = idxResponse;
-  const idxRemediation = getIdxRemediation(flow, neededToProceed);
+  let idxRemediation = getIdxRemediation(flow, neededToProceed);
   if (!idxRemediation) {
     throw new AuthSdkError('No remediation in the idxResponse can be match current flow');
   }
-  const name = idxRemediation.name;
-  const T = flow[name];
+  let name = idxRemediation.name;
+  let T = flow[name];
   if (!T) {
     throw new AuthSdkError('No remediator is registered');
   }
 
-  const remediator = new T(idxRemediation, values);
+  let remediator = new T(idxRemediation, values);
 
   // Recursive loop breaker
-  // Three states are handled here:
+  // Four states are handled here:
   // 1. can remediate -> the engine keep running remediation with provided data
   // 2. cannot remediate due to need user interaction -> return nextStep data back to client
-  // 3. cannot remediate due to unsupported inputs or policies -> throw error
+  // 3. cannot remediate due to missing data but can skip -> process skip remediation
+  // 4. cannot remediate due to unsupported inputs or policies -> throw error
   if (!remediator.canRemediate()) {
     const nextStep = remediator.getNextStep();
-    return { idxResponse, nextStep };
+    if (remediator.canSkip() && neededToProceed.find(n => n.name == 'skip')) {
+      idxRemediation = getIdxRemediation(flow, neededToProceed.filter(r => r.name == 'skip'));
+      name = 'skip';
+      T = flow[name];
+      remediator = new T(idxRemediation, values);
+    } else {
+      return { idxResponse, nextStep };
+    }
   }
 
   const data = remediator.getData();

--- a/lib/idx/remediate.ts
+++ b/lib/idx/remediate.ts
@@ -40,6 +40,9 @@ export async function remediate(
 
   let remediator = new T(idxRemediation, values);
 
+  const skipRemediation = neededToProceed.find(r => r.name == 'skip');
+  remediator.setCanSkip(!!skipRemediation);
+  
   // Recursive loop breaker
   // Four states are handled here:
   // 1. can remediate -> the engine keep running remediation with provided data
@@ -48,8 +51,8 @@ export async function remediate(
   // 4. cannot remediate due to unsupported inputs or policies -> throw error
   if (!remediator.canRemediate()) {
     const nextStep = remediator.getNextStep();
-    if (remediator.canSkip() && neededToProceed.find(n => n.name == 'skip')) {
-      idxRemediation = getIdxRemediation(flow, neededToProceed.filter(r => r.name == 'skip'));
+    if (remediator.canSkip()) {
+      idxRemediation = skipRemediation;
       name = 'skip';
       T = flow[name];
       remediator = new T(idxRemediation, values);

--- a/lib/idx/remediators/Base.ts
+++ b/lib/idx/remediators/Base.ts
@@ -16,10 +16,12 @@ export class Base {
   remediation: IdxRemediation;
   values: RemediationValues;
   map?: IdxToRemediationValueMap;
+  _canSkip: boolean;
 
   constructor(remediation: IdxRemediation, values: RemediationValues) {
     this.remediation = remediation;
     this.values = values;
+    this._canSkip = false;
   }
 
   // Override this method to provide custom check
@@ -35,8 +37,16 @@ export class Base {
     return true; // all required fields have available data
   }
 
-  canSkip(): boolean {
+  isSkipable() {
     return false;
+  }
+
+  canSkip() {
+    return this.isSkipable() && this._canSkip;
+  }
+
+  setCanSkip(value: boolean) {
+    this._canSkip = value;
   }
 
   getRequiredValues() {

--- a/lib/idx/remediators/Base.ts
+++ b/lib/idx/remediators/Base.ts
@@ -102,13 +102,6 @@ export class Base {
     key: string // idx name
   ): boolean 
   {
-    // Map value by "map${Property}" function in each subClass
-    if (typeof this[`map${titleCase(key)}`] === 'function') {
-      return !!this[`map${titleCase(key)}`](
-        this.remediation.value.find(({name}) => name === key)
-      );
-    }
-
     // no attempt to format, we want simple true/false
     if (!this.map || !this.map[key] || !Array.isArray(this.map[key])) {
       return !!this.values[key];

--- a/lib/idx/remediators/Base.ts
+++ b/lib/idx/remediators/Base.ts
@@ -27,12 +27,20 @@ export class Base {
     if (!this.map) {
       return false;
     }
-    const required = getRequiredValues(this.remediation);
+    const required = this.getRequiredValues();
     const needed = required.find((key) => !this.hasData(key));
     if (needed) {
       return false; // missing data for a required field
     }
     return true; // all required fields have available data
+  }
+
+  canSkip(): boolean {
+    return false;
+  }
+
+  getRequiredValues() {
+    return getRequiredValues(this.remediation);
   }
 
   // returns an object for the entire remediation form, or just a part
@@ -84,6 +92,13 @@ export class Base {
     key: string // idx name
   ): boolean 
   {
+    // Map value by "map${Property}" function in each subClass
+    if (typeof this[`map${titleCase(key)}`] === 'function') {
+      return !!this[`map${titleCase(key)}`](
+        this.remediation.value.find(({name}) => name === key)
+      );
+    }
+
     // no attempt to format, we want simple true/false
     if (!this.map || !this.map[key] || !Array.isArray(this.map[key])) {
       return !!this.values[key];

--- a/lib/idx/remediators/SelectAuthenticator.ts
+++ b/lib/idx/remediators/SelectAuthenticator.ts
@@ -52,12 +52,7 @@ export class SelectAuthenticator extends Base {
     // Terminate idx interaction if provided authenticators are not supported
     throw new AuthSdkError('Provided authenticators are not supported, please check your org configuration');
   }
-
-  getRequiredValues() {
-    // authenticator is required to proceed
-    return [...super.getRequiredValues(), 'authenticator'];
-  }
-
+  
   isSkipable() {
     return true;
   }

--- a/lib/idx/remediators/SelectAuthenticator.ts
+++ b/lib/idx/remediators/SelectAuthenticator.ts
@@ -49,6 +49,15 @@ export class SelectAuthenticator extends Base {
     throw new AuthSdkError('Provided authenticators are not supported, please check your org configuration');
   }
 
+  getRequiredValues() {
+    // authenticator is required to proceed
+    return [...super.getRequiredValues(), 'authenticator'];
+  }
+
+  canSkip() {
+    return true;
+  }
+
   getNextStep() {
     const authenticators = this.remediationValue.options.map(option => {
       const { 

--- a/lib/idx/remediators/SelectAuthenticator.ts
+++ b/lib/idx/remediators/SelectAuthenticator.ts
@@ -45,6 +45,10 @@ export class SelectAuthenticator extends Base {
     if (matchedOption) {
       return true;
     }
+    // Can skip
+    if (this.canSkip()) {
+      return false;
+    }
     // Terminate idx interaction if provided authenticators are not supported
     throw new AuthSdkError('Provided authenticators are not supported, please check your org configuration');
   }
@@ -54,7 +58,7 @@ export class SelectAuthenticator extends Base {
     return [...super.getRequiredValues(), 'authenticator'];
   }
 
-  canSkip() {
+  isSkipable() {
     return true;
   }
 

--- a/lib/idx/remediators/Skip.ts
+++ b/lib/idx/remediators/Skip.ts
@@ -1,0 +1,7 @@
+import { Base } from './Base';
+
+export class Skip extends Base {
+  canRemediate() {
+    return true;
+  }
+}

--- a/lib/idx/remediators/index.ts
+++ b/lib/idx/remediators/index.ts
@@ -7,3 +7,4 @@ export * from './RedirectIdp';
 export * from './SelectAuthenticator';
 export * from './SelectEnrollProfile';
 export * from './AuthenticatorVerificationData';
+export * from './Skip';

--- a/samples/generated/express-direct-auth/web-server/routes/signup.js
+++ b/samples/generated/express-direct-auth/web-server/routes/signup.js
@@ -10,10 +10,10 @@ const router = express.Router();
 
 const authenticators = ['email', 'password']; // ordered authenticators
 
-const next = ({ nextStep, res, req }) => {
+const next = ({ nextStep, res }) => {
   const { name, type } = nextStep;
   if (name === 'enroll-authenticator') {
-    res.redirect(`/signup/enroll-${type}-authenticator?transactionId=${req.transactionId}`);
+    res.redirect(`/signup/enroll-${type}-authenticator`);
     return true;
   }
   return false;
@@ -47,7 +47,7 @@ router.get(`/signup/enroll-email-authenticator`, (req, res) => {
   if (status === IdxStatus.PENDING) {
     res.render('authenticator', {
       title: 'Enroll email authenticator',
-      action: `/signup/enroll-email-authenticator?transactionId=${req.transactionId}`,
+      action: '/signup/enroll-email-authenticator',
     });
   } else {
     res.redirect('/signup');
@@ -77,7 +77,7 @@ router.get(`/signup/enroll-password-authenticator`, (req, res) => {
   if (status === IdxStatus.PENDING) {
     res.render('enroll-or-reset-password-authenticator', {
       title: 'Set up password',
-      action: `/signup/enroll-password-authenticator?transactionId=${req.transactionId}`,
+      action: '/signup/enroll-password-authenticator',
     });
   } else {
     res.redirect('/signup');

--- a/samples/generated/express-direct-auth/web-server/routes/signup.js
+++ b/samples/generated/express-direct-auth/web-server/routes/signup.js
@@ -10,10 +10,10 @@ const router = express.Router();
 
 const authenticators = ['email', 'password']; // ordered authenticators
 
-const next = ({ nextStep, res }) => {
+const next = ({ nextStep, res, req }) => {
   const { name, type } = nextStep;
   if (name === 'enroll-authenticator') {
-    res.redirect(`/signup/enroll-${type}-authenticator`);
+    res.redirect(`/signup/enroll-${type}-authenticator?transactionId=${req.transactionId}`);
     return true;
   }
   return false;
@@ -47,7 +47,7 @@ router.get(`/signup/enroll-email-authenticator`, (req, res) => {
   if (status === IdxStatus.PENDING) {
     res.render('authenticator', {
       title: 'Enroll email authenticator',
-      action: '/signup/enroll-email-authenticator',
+      action: `/signup/enroll-email-authenticator?transactionId=${req.transactionId}`,
     });
   } else {
     res.redirect('/signup');
@@ -77,7 +77,7 @@ router.get(`/signup/enroll-password-authenticator`, (req, res) => {
   if (status === IdxStatus.PENDING) {
     res.render('enroll-or-reset-password-authenticator', {
       title: 'Set up password',
-      action: '/signup/enroll-password-authenticator',
+      action: `/signup/enroll-password-authenticator?transactionId=${req.transactionId}`,
     });
   } else {
     res.redirect('/signup');

--- a/samples/templates/express-direct-auth/web-server/routes/signup.js
+++ b/samples/templates/express-direct-auth/web-server/routes/signup.js
@@ -10,10 +10,10 @@ const router = express.Router();
 
 const authenticators = ['email', 'password']; // ordered authenticators
 
-const next = ({ nextStep, res }) => {
+const next = ({ nextStep, res, req }) => {
   const { name, type } = nextStep;
   if (name === 'enroll-authenticator') {
-    res.redirect(`/signup/enroll-${type}-authenticator`);
+    res.redirect(`/signup/enroll-${type}-authenticator?transactionId=${req.transactionId}`);
     return true;
   }
   return false;
@@ -47,7 +47,7 @@ router.get(`/signup/enroll-email-authenticator`, (req, res) => {
   if (status === IdxStatus.PENDING) {
     res.render('authenticator', {
       title: 'Enroll email authenticator',
-      action: '/signup/enroll-email-authenticator',
+      action: `/signup/enroll-email-authenticator?transactionId=${req.transactionId}`,
     });
   } else {
     res.redirect('/signup');
@@ -77,7 +77,7 @@ router.get(`/signup/enroll-password-authenticator`, (req, res) => {
   if (status === IdxStatus.PENDING) {
     res.render('enroll-or-reset-password-authenticator', {
       title: 'Set up password',
-      action: '/signup/enroll-password-authenticator',
+      action: `/signup/enroll-password-authenticator?transactionId=${req.transactionId}`,
     });
   } else {
     res.redirect('/signup');


### PR DESCRIPTION
- Fixed inf loop of SSR flow in `express-direct-auth` sample app because of lacking `transactionId` param in url
- Added support for skip remediation
 
Without skip, sample app will throw `Unable to handle next step` during SSR flow after email confirmation, if security question authenticator is configured in okta org (as optional), but not used in sample app.

