### PR TITLE
fix: support both recover flows when policy change

### DIFF
--- a/lib/idx/recoverPassword.ts
+++ b/lib/idx/recoverPassword.ts
@@ -3,6 +3,7 @@ import {
   OktaAuth, 
   IdxOptions, 
   RemediationFlow,
+  IdxStatus,
 } from '../types';
 import { run } from './run';
 import {
@@ -15,8 +16,10 @@ import {
   AuthenticatorVerificationData,
   AuthenticatorVerificationDataValues,
 } from './remediators';
+import { interact } from './interact';
 
 const flow: RemediationFlow = {
+  'identify': Identify,
   'identify-recovery': Identify,
   'select-authenticator-authenticate': SelectAuthenticator,
   'challenge-authenticator': EnrollOrChallengeAuthenticator,
@@ -35,12 +38,46 @@ export interface PasswordRecoveryOptions extends
 export async function recoverPassword(
   authClient: OktaAuth, options: PasswordRecoveryOptions
 ): Promise<AuthTransaction> {
-  return run(authClient, { 
-    ...options, 
-    flow,
-    actions: [
-      'currentAuthenticator-recover', 
-      'currentAuthenticatorEnrollment-recover'
-    ],
+  let error;
+  let status;
+
+  try {
+    const interactResponse = await interact(authClient, options);
+    const idxResponse = interactResponse.idxResponse;
+    const shouldIdentify = idxResponse.neededToProceed.some(({ name }) => name === 'identify') 
+      && !Object.keys(idxResponse.actions).includes('currentAuthenticator-recover');
+    if (shouldIdentify) {
+      options = { 
+        ...options, 
+        // When set any factor as primary factor in policy
+        // Select password authenticator first to start the recovery password flow
+        authenticators: ['password', ...(options.authenticators || [])]
+      };
+    }
+
+    return run(
+      authClient, 
+      { 
+        ...options,
+        flow,
+        actions: [
+          'currentAuthenticator-recover', 
+          'currentAuthenticatorEnrollment-recover'
+        ],
+      },
+      interactResponse,
+    );
+
+  } catch (err) {
+    error = err;
+    status = IdxStatus.FAILED;
+    // Clear transaction meta when error is not handlable
+    authClient.transactionManager.clear();
+  }
+
+  const authTransaction = new AuthTransaction(authClient, {
+    status,
+    error,
   });
+  return authTransaction;
 }

--- a/lib/idx/remediators/Base.ts
+++ b/lib/idx/remediators/Base.ts
@@ -111,4 +111,9 @@ export class Base {
       errorCauses: errors
     });
   }
+
+  // Prepare values for the next remediation
+  getValues() {
+    return this.values;
+  }
 }

--- a/lib/idx/remediators/SelectAuthenticator.ts
+++ b/lib/idx/remediators/SelectAuthenticator.ts
@@ -24,6 +24,8 @@ export class SelectAuthenticator extends Base {
   remediationValue: IdxRemeditionValue;
   matchedOption: IdxRemediation;
   
+  selectedAuthenticator: string;
+  
   map = {
     authenticator: null // value here does not matter, fall to the custom map function
   }
@@ -67,8 +69,15 @@ export class SelectAuthenticator extends Base {
     const { authenticators } = this.values;
     const { options } = remediationValue;
     const selectedOption = findMatchedOption(authenticators, options);
+    this.selectedAuthenticator = selectedOption?.relatesTo.type;
     return {
       id: selectedOption?.value.form.value.find(({ name }) => name === 'id').value
     };
+  }
+
+  getValues(): SelectAuthenticatorValues {
+    const authenticators = this.values.authenticators
+      .filter(authenticator => authenticator !== this.selectedAuthenticator);
+    return { authenticators };
   }
 }

--- a/samples/generated/express-direct-auth/web-server/routes/login/primary.js
+++ b/samples/generated/express-direct-auth/web-server/routes/login/primary.js
@@ -35,7 +35,8 @@ router.post('/primary', async (req, res) => {
     handleAuthTransaction({ req, res, next, authClient, authTransaction });
   } catch (error) {
     req.setLastError(error.message);
-    renderTemplate(req, res, 'login-primary');
+    const action = getFormActionPath(req, '/login/primary');
+    renderTemplate(req, res, 'login-primary', { action });
   }
 });
 
@@ -60,12 +61,16 @@ router.post('/change-password', async (req, res) => {
     const authTransaction = await authClient.idx.authenticate({ newPassword });
     handleAuthTransaction({ req, res, next, authClient, authTransaction });
   } catch (error) {
+    const action = getFormActionPath(req, '/login/change-password');
     req.setLastError(error.message);
     renderTemplate(
       req, 
       res, 
       'enroll-or-reset-password-authenticator', 
-      { title: 'Change password' }
+      { 
+        title: 'Change password',
+        action,
+      }
     );
   }
 });

--- a/samples/generated/express-direct-auth/web-server/routes/recover-password.js
+++ b/samples/generated/express-direct-auth/web-server/routes/recover-password.js
@@ -1,8 +1,11 @@
 const express = require('express');
+const { IdxStatus } = require('@okta/okta-auth-js');
 const { 
   getAuthClient, 
   renderError, 
   handleAuthTransaction, 
+  redirect,
+  getFormActionPath,
 } = require('../utils');
 
 const router = express.Router();
@@ -11,14 +14,14 @@ const next = ({ req, res, nextStep }) => {
   const { name, type, authenticators } = nextStep;
   if (name === 'select-authenticator-authenticate') {
     req.session.authenticators = authenticators;
-    res.redirect('/recover-password/select-authenticator');
+    redirect({ req, res, path: '/recover-password/select-authenticator' });
     return true;
   } else if (name === 'challenge-authenticator' 
       || name === 'authenticator-verification-data') {
-    res.redirect(`/recover-password/challenge-authenticator/${type}`);
+    redirect({ req, res, path: `/recover-password/challenge-authenticator/${type}` });
     return true;
   } else if (name === 'reset-authenticator') {
-    res.redirect('/recover-password/reset');
+    redirect({ req, res, path: '/recover-password/reset' });
     return true;
   }
   return false;
@@ -26,11 +29,13 @@ const next = ({ req, res, nextStep }) => {
 
 router.get('/recover-password', (req, res) => {
   const { authenticator } = req.query;
-  res.render('recover-password', {
-    action: authenticator 
+  const action = getFormActionPath(
+    req, 
+    authenticator 
       ? `/recover-password?authenticator=${authenticator}` 
       : '/recover-password'
-  });
+  );
+  res.render('recover-password', { action });
 });
 
 router.post('/recover-password', async (req, res) => {
@@ -44,20 +49,25 @@ router.post('/recover-password', async (req, res) => {
     });
     handleAuthTransaction({ req, res, next, authClient, authTransaction });
   } catch (error) {
+    const action = getFormActionPath(
+      req,
+      authenticator 
+        ? `/recover-password?authenticator=${authenticator}` 
+        : '/recover-password'
+    );
     renderError(res, {
       template: 'recover-password',
-      action: authenticator 
-        ? `/recover-password?authenticator=${authenticator}` 
-        : '/recover-password',
+      action,
       error,
     });
   }
 });
 
 router.get('/recover-password/reset', (req, res) => {
+  const action = getFormActionPath(req, '/recover-password/reset');
   res.render('enroll-or-reset-password-authenticator', {
     title: 'Reset password',
-    action: '/recover-password/reset',
+    action,
   });
 });
 
@@ -72,28 +82,110 @@ router.post('/recover-password/reset', async (req, res) => {
     const authTransaction = await authClient.idx.recoverPassword({ password });
     handleAuthTransaction({ req, res, next, authClient, authTransaction });
   } catch (error) {
+    const action = getFormActionPath(req, '/recover-password/reset');
     renderError(res, {
       template: 'enroll-or-reset-password-authenticator',
       title: 'Reset password',
+      action,
       error,
     });
   }
 });
 
-// generateSelectAuthenticator({ 
-//   path: '/recover-password/select-authenticator', 
-//   entryPath: '/recover-password',
-//   next, 
-//   router,
-// });
-// ['email', 'phone'].forEach(type => 
-//   generateChallengeAuthenticator({ 
-//     path: `/recover-password/challenge-authenticator/${type}`,
-//     entryPath: '/recover-password',
-//     type, 
-//     next, 
-//     router, 
-//   }));
+// Handle select-authenticator
+router.get('/recover-password/select-authenticator', (req, res) => {
+  const { status, authenticators } = req.session;
+  if (status === IdxStatus.PENDING) {
+    const action = getFormActionPath(req, '/recover-password/select-authenticator');
+    res.render('select-authenticator', {
+      authenticators,
+      action,
+    });
+  } else {
+    redirect({ req, res, path: '/recover-password' });
+  }
+});
 
+router.post('/recover-password/select-authenticator', async (req, res) => {
+  const { authenticator } = req.body;
+  const authClient = getAuthClient(req);
+  try {
+    const authTransaction = await authClient.idx.recoverPassword({
+      authenticators: [authenticator],
+    });
+    handleAuthTransaction({ req, res, next, authClient, authTransaction });
+  } catch (error) {
+    renderError(res, {
+      template: 'select-authenticator',
+      error,
+    });
+  }
+});
+
+// Handle email authenticator
+router.get(`/recover-password/challenge-authenticator/email`, (req, res) => {
+  const { status } = req.session;
+  if (status === IdxStatus.PENDING) {
+    const action = getFormActionPath(req, '/recover-password/challenge-authenticator/email');
+    res.render('authenticator', {
+      title: `Challenge email authenticator`,
+      input: {
+        type: 'text',
+        name: 'verificationCode',
+      },
+      action,
+    });
+  } else {
+    redirect({ req, res, path: '/recover-password' });
+  }
+});
+
+router.post(`/recover-password/challenge-authenticator/email`, async (req, res) => {
+  const { verificationCode } = req.body;
+  const authClient = getAuthClient(req);
+  try {
+    const authTransaction = await authClient.idx.recoverPassword({ verificationCode });
+    handleAuthTransaction({ req, res, next, authClient, authTransaction });
+  } catch (error) {
+    renderError(res, {
+      template: 'authenticator',
+      title: `Challenge email authenticator`,
+      error,
+    });
+  }
+});
+
+// Handle phone (sms) authenticator
+router.get(`/recover-password/challenge-authenticator/phone`, (req, res) => {
+  const { status } = req.session;
+  if (status === IdxStatus.PENDING) {
+    const action = getFormActionPath(req, '/recover-password/challenge-authenticator/phone');
+    res.render('authenticator', {
+      title: `Challenge phone authenticator`,
+      input: {
+        type: 'text',
+        name: 'verificationCode',
+      },
+      action,
+    });
+  } else {
+    redirect({ req, res, path: '/recover-password' });
+  }
+});
+
+router.post(`/recover-password/challenge-authenticator/phone`, async (req, res) => {
+  const { verificationCode } = req.body;
+  const authClient = getAuthClient(req);
+  try {
+    const authTransaction = await authClient.idx.recoverPassword({ verificationCode });
+    handleAuthTransaction({ req, res, next, authClient, authTransaction });
+  } catch (error) {
+    renderError(res, {
+      template: 'authenticator',
+      title: `Challenge phone authenticator`,
+      error,
+    });
+  }
+});
 
 module.exports = router;

--- a/samples/generated/express-direct-auth/web-server/views/enroll-or-reset-password-authenticator.mustache
+++ b/samples/generated/express-direct-auth/web-server/views/enroll-or-reset-password-authenticator.mustache
@@ -4,6 +4,8 @@
     {{>head}}
   </head>
   <body id="samples">
+    {{>menu}}
+
     <div class="okta-sign-in-form ui center aligned relaxed grid">
       <div class="row">
         <div class="ui header">

--- a/samples/generated/static-spa/public/app.js
+++ b/samples/generated/static-spa/public/app.js
@@ -104,16 +104,17 @@ function main() {
 }
 
 function startApp() {
-  // Calculate initial auth state and fire change event for listeners
-  authClient.authStateManager.updateAuthState();
+  // Calculates initial auth state and fires change event for listeners
+  // Also starts the token auto-renew service
+  authClient.start();
 }
 
 function renderApp() {
   const authState = authClient.authStateManager.getAuthState();
   document.getElementById('authState').innerText = stringify(authState);
 
-  // If auth state is "pending", render in the loading state
-  if (authState.isPending) {
+  // Setting auth state is an asynchronous operation. If authState is not available yet, render in the loading state
+  if (!authState) {
     return renderLoading();
   }
 
@@ -279,7 +280,7 @@ function submitSigninForm() {
 }
 
 function shouldRedirectToGetTokens(authState) {
-  if (authState.isAuthenticated || authState.isPending) {
+  if (authState.isAuthenticated) {
     return false;
   }
 

--- a/samples/generated/webpack-spa/src/index.js
+++ b/samples/generated/webpack-spa/src/index.js
@@ -103,16 +103,17 @@ function main() {
 }
 
 function startApp() {
-  // Calculate initial auth state and fire change event for listeners
-  authClient.authStateManager.updateAuthState();
+  // Calculates initial auth state and fires change event for listeners
+  // Also starts the token auto-renew service
+  authClient.start();
 }
 
 function renderApp() {
   const authState = authClient.authStateManager.getAuthState();
   document.getElementById('authState').innerText = stringify(authState);
 
-  // If auth state is "pending", render in the loading state
-  if (authState.isPending) {
+  // Setting auth state is an asynchronous operation. If authState is not available yet, render in the loading state
+  if (!authState) {
     return renderLoading();
   }
 
@@ -278,7 +279,7 @@ function submitSigninForm() {
 }
 
 function shouldRedirectToGetTokens(authState) {
-  if (authState.isAuthenticated || authState.isPending) {
+  if (authState.isAuthenticated) {
     return false;
   }
 

--- a/samples/templates/express-direct-auth/web-server/routes/login/primary.js
+++ b/samples/templates/express-direct-auth/web-server/routes/login/primary.js
@@ -35,7 +35,8 @@ router.post('/primary', async (req, res) => {
     handleAuthTransaction({ req, res, next, authClient, authTransaction });
   } catch (error) {
     req.setLastError(error.message);
-    renderTemplate(req, res, 'login-primary');
+    const action = getFormActionPath(req, '/login/primary');
+    renderTemplate(req, res, 'login-primary', { action });
   }
 });
 
@@ -60,12 +61,16 @@ router.post('/change-password', async (req, res) => {
     const authTransaction = await authClient.idx.authenticate({ newPassword });
     handleAuthTransaction({ req, res, next, authClient, authTransaction });
   } catch (error) {
+    const action = getFormActionPath(req, '/login/change-password');
     req.setLastError(error.message);
     renderTemplate(
       req, 
       res, 
       'enroll-or-reset-password-authenticator', 
-      { title: 'Change password' }
+      { 
+        title: 'Change password',
+        action,
+      }
     );
   }
 });

--- a/samples/templates/express-direct-auth/web-server/routes/recover-password.js
+++ b/samples/templates/express-direct-auth/web-server/routes/recover-password.js
@@ -1,8 +1,11 @@
 const express = require('express');
+const { IdxStatus } = require('@okta/okta-auth-js');
 const { 
   getAuthClient, 
   renderError, 
   handleAuthTransaction, 
+  redirect,
+  getFormActionPath,
 } = require('../utils');
 
 const router = express.Router();
@@ -11,14 +14,14 @@ const next = ({ req, res, nextStep }) => {
   const { name, type, authenticators } = nextStep;
   if (name === 'select-authenticator-authenticate') {
     req.session.authenticators = authenticators;
-    res.redirect('/recover-password/select-authenticator');
+    redirect({ req, res, path: '/recover-password/select-authenticator' });
     return true;
   } else if (name === 'challenge-authenticator' 
       || name === 'authenticator-verification-data') {
-    res.redirect(`/recover-password/challenge-authenticator/${type}`);
+    redirect({ req, res, path: `/recover-password/challenge-authenticator/${type}` });
     return true;
   } else if (name === 'reset-authenticator') {
-    res.redirect('/recover-password/reset');
+    redirect({ req, res, path: '/recover-password/reset' });
     return true;
   }
   return false;
@@ -26,11 +29,13 @@ const next = ({ req, res, nextStep }) => {
 
 router.get('/recover-password', (req, res) => {
   const { authenticator } = req.query;
-  res.render('recover-password', {
-    action: authenticator 
+  const action = getFormActionPath(
+    req, 
+    authenticator 
       ? `/recover-password?authenticator=${authenticator}` 
       : '/recover-password'
-  });
+  );
+  res.render('recover-password', { action });
 });
 
 router.post('/recover-password', async (req, res) => {
@@ -44,20 +49,25 @@ router.post('/recover-password', async (req, res) => {
     });
     handleAuthTransaction({ req, res, next, authClient, authTransaction });
   } catch (error) {
+    const action = getFormActionPath(
+      req,
+      authenticator 
+        ? `/recover-password?authenticator=${authenticator}` 
+        : '/recover-password'
+    );
     renderError(res, {
       template: 'recover-password',
-      action: authenticator 
-        ? `/recover-password?authenticator=${authenticator}` 
-        : '/recover-password',
+      action,
       error,
     });
   }
 });
 
 router.get('/recover-password/reset', (req, res) => {
+  const action = getFormActionPath(req, '/recover-password/reset');
   res.render('enroll-or-reset-password-authenticator', {
     title: 'Reset password',
-    action: '/recover-password/reset',
+    action,
   });
 });
 
@@ -72,28 +82,110 @@ router.post('/recover-password/reset', async (req, res) => {
     const authTransaction = await authClient.idx.recoverPassword({ password });
     handleAuthTransaction({ req, res, next, authClient, authTransaction });
   } catch (error) {
+    const action = getFormActionPath(req, '/recover-password/reset');
     renderError(res, {
       template: 'enroll-or-reset-password-authenticator',
       title: 'Reset password',
+      action,
       error,
     });
   }
 });
 
-// generateSelectAuthenticator({ 
-//   path: '/recover-password/select-authenticator', 
-//   entryPath: '/recover-password',
-//   next, 
-//   router,
-// });
-// ['email', 'phone'].forEach(type => 
-//   generateChallengeAuthenticator({ 
-//     path: `/recover-password/challenge-authenticator/${type}`,
-//     entryPath: '/recover-password',
-//     type, 
-//     next, 
-//     router, 
-//   }));
+// Handle select-authenticator
+router.get('/recover-password/select-authenticator', (req, res) => {
+  const { status, authenticators } = req.session;
+  if (status === IdxStatus.PENDING) {
+    const action = getFormActionPath(req, '/recover-password/select-authenticator');
+    res.render('select-authenticator', {
+      authenticators,
+      action,
+    });
+  } else {
+    redirect({ req, res, path: '/recover-password' });
+  }
+});
 
+router.post('/recover-password/select-authenticator', async (req, res) => {
+  const { authenticator } = req.body;
+  const authClient = getAuthClient(req);
+  try {
+    const authTransaction = await authClient.idx.recoverPassword({
+      authenticators: [authenticator],
+    });
+    handleAuthTransaction({ req, res, next, authClient, authTransaction });
+  } catch (error) {
+    renderError(res, {
+      template: 'select-authenticator',
+      error,
+    });
+  }
+});
+
+// Handle email authenticator
+router.get(`/recover-password/challenge-authenticator/email`, (req, res) => {
+  const { status } = req.session;
+  if (status === IdxStatus.PENDING) {
+    const action = getFormActionPath(req, '/recover-password/challenge-authenticator/email');
+    res.render('authenticator', {
+      title: `Challenge email authenticator`,
+      input: {
+        type: 'text',
+        name: 'verificationCode',
+      },
+      action,
+    });
+  } else {
+    redirect({ req, res, path: '/recover-password' });
+  }
+});
+
+router.post(`/recover-password/challenge-authenticator/email`, async (req, res) => {
+  const { verificationCode } = req.body;
+  const authClient = getAuthClient(req);
+  try {
+    const authTransaction = await authClient.idx.recoverPassword({ verificationCode });
+    handleAuthTransaction({ req, res, next, authClient, authTransaction });
+  } catch (error) {
+    renderError(res, {
+      template: 'authenticator',
+      title: `Challenge email authenticator`,
+      error,
+    });
+  }
+});
+
+// Handle phone (sms) authenticator
+router.get(`/recover-password/challenge-authenticator/phone`, (req, res) => {
+  const { status } = req.session;
+  if (status === IdxStatus.PENDING) {
+    const action = getFormActionPath(req, '/recover-password/challenge-authenticator/phone');
+    res.render('authenticator', {
+      title: `Challenge phone authenticator`,
+      input: {
+        type: 'text',
+        name: 'verificationCode',
+      },
+      action,
+    });
+  } else {
+    redirect({ req, res, path: '/recover-password' });
+  }
+});
+
+router.post(`/recover-password/challenge-authenticator/phone`, async (req, res) => {
+  const { verificationCode } = req.body;
+  const authClient = getAuthClient(req);
+  try {
+    const authTransaction = await authClient.idx.recoverPassword({ verificationCode });
+    handleAuthTransaction({ req, res, next, authClient, authTransaction });
+  } catch (error) {
+    renderError(res, {
+      template: 'authenticator',
+      title: `Challenge phone authenticator`,
+      error,
+    });
+  }
+});
 
 module.exports = router;

--- a/samples/templates/express-direct-auth/web-server/views/enroll-or-reset-password-authenticator.mustache
+++ b/samples/templates/express-direct-auth/web-server/views/enroll-or-reset-password-authenticator.mustache
@@ -4,6 +4,8 @@
     {{>head}}
   </head>
   <body id="samples">
+    {{>menu}}
+
     <div class="okta-sign-in-form ui center aligned relaxed grid">
       <div class="row">
         <div class="ui header">


### PR DESCRIPTION
Currently,  the recover password method only handles the flow when the user selects `Password / IDP` as the primary factor in the policy. This PR changes the method to support both `Password / IDP` and `
Any` as the primary factor. 