### PR TITLE
feat: support password authenticator when password is available - OKTA-393384

### DIFF
--- a/lib/idx/authenticate.ts
+++ b/lib/idx/authenticate.ts
@@ -36,6 +36,17 @@ export interface AuthenticationOptions extends
 export async function authenticate(
   authClient: OktaAuth, options: AuthenticationOptions
 ): Promise<AuthTransaction> {
+  options = options || {};
+
+  // Select password authenticator if password is provided
+  const { password, authenticators = [] } = options;
+  if (password && !authenticators.includes('password')) {
+    options = {
+      ...options,
+      authenticators: ['password', ...authenticators]
+    };
+  }
+
   return run(authClient, { 
     ...options, 
     flow,

--- a/lib/idx/remediators/SelectAuthenticator.ts
+++ b/lib/idx/remediators/SelectAuthenticator.ts
@@ -78,6 +78,6 @@ export class SelectAuthenticator extends Base {
   getValues(): SelectAuthenticatorValues {
     const authenticators = this.values.authenticators
       .filter(authenticator => authenticator !== this.selectedAuthenticator);
-    return { authenticators };
+    return { ...this.values, authenticators };
   }
 }

--- a/lib/idx/util.ts
+++ b/lib/idx/util.ts
@@ -9,8 +9,8 @@ export function createApiError(res): APIError {
     allErrors = res.messages.value.map(o => o.message);
     errorCode = res.messages.value.reduce((acc, curr) => {
       return acc 
-        ? acc + ',' + curr.i18n.key 
-        : curr.i18n.key;
+        ? acc + ',' + curr.i18n?.key 
+        : curr.i18n?.key;
     }, '');
   }
 

--- a/samples/generated/express-direct-auth/web-server/routes/terminal.js
+++ b/samples/generated/express-direct-auth/web-server/routes/terminal.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { renderTemplate } = require('../utils');
+const { renderTemplate, getAuthClient } = require('../utils');
 
 const router = express.Router();
 
@@ -7,6 +7,11 @@ router.get('/terminal', (req, res) => {
   const messages = req.getTerminalMessages();
   req.clearTerminalMessages();
 
+  // Clear transaction meta at app layer when reach to terminal state
+  const authClient = getAuthClient(req);
+  authClient.transactionManager.clear();
+
+  // Render
   if (!messages || !messages.length) {
     res.redirect('/');
   } else {

--- a/samples/generated/express-direct-auth/web-server/utils/handleAuthTransaction.js
+++ b/samples/generated/express-direct-auth/web-server/utils/handleAuthTransaction.js
@@ -41,9 +41,10 @@ module.exports = function handleAuthTransaction({
   if (typeof next === 'function') {
     const supportNextStep = next({ req, res, nextStep });
     if (!supportNextStep) {
-      throw new Error(
-        'Oops! The sample app cannot support the policy configuration in your org'
-      );
+      req.setTerminalMessages([
+        'Oops! The current flow cannot support the policy configuration in your org, try other flows in the sample or change your app/org configuration.'
+      ]);
+      return res.redirect('/terminal');
     }
   }
 };

--- a/samples/generated/express-direct-auth/web-server/utils/handleAuthTransaction.js
+++ b/samples/generated/express-direct-auth/web-server/utils/handleAuthTransaction.js
@@ -42,7 +42,8 @@ module.exports = function handleAuthTransaction({
     const supportNextStep = next({ req, res, nextStep });
     if (!supportNextStep) {
       req.setTerminalMessages([
-        'Oops! The current flow cannot support the policy configuration in your org, try other flows in the sample or change your app/org configuration.'
+        `Oops! The current flow cannot support the policy configuration in your org, 
+        try other flows in the sample or change your app/org configuration.`
       ]);
       return res.redirect('/terminal');
     }

--- a/samples/templates/express-direct-auth/web-server/routes/terminal.js
+++ b/samples/templates/express-direct-auth/web-server/routes/terminal.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { renderTemplate } = require('../utils');
+const { renderTemplate, getAuthClient } = require('../utils');
 
 const router = express.Router();
 
@@ -7,6 +7,11 @@ router.get('/terminal', (req, res) => {
   const messages = req.getTerminalMessages();
   req.clearTerminalMessages();
 
+  // Clear transaction meta at app layer when reach to terminal state
+  const authClient = getAuthClient(req);
+  authClient.transactionManager.clear();
+
+  // Render
   if (!messages || !messages.length) {
     res.redirect('/');
   } else {

--- a/samples/templates/express-direct-auth/web-server/utils/handleAuthTransaction.js
+++ b/samples/templates/express-direct-auth/web-server/utils/handleAuthTransaction.js
@@ -41,9 +41,10 @@ module.exports = function handleAuthTransaction({
   if (typeof next === 'function') {
     const supportNextStep = next({ req, res, nextStep });
     if (!supportNextStep) {
-      throw new Error(
-        'Oops! The sample app cannot support the policy configuration in your org'
-      );
+      req.setTerminalMessages([
+        'Oops! The current flow cannot support the policy configuration in your org, try other flows in the sample or change your app/org configuration.'
+      ]);
+      return res.redirect('/terminal');
     }
   }
 };

--- a/samples/templates/express-direct-auth/web-server/utils/handleAuthTransaction.js
+++ b/samples/templates/express-direct-auth/web-server/utils/handleAuthTransaction.js
@@ -42,7 +42,8 @@ module.exports = function handleAuthTransaction({
     const supportNextStep = next({ req, res, nextStep });
     if (!supportNextStep) {
       req.setTerminalMessages([
-        'Oops! The current flow cannot support the policy configuration in your org, try other flows in the sample or change your app/org configuration.'
+        `Oops! The current flow cannot support the policy configuration in your org, 
+        try other flows in the sample or change your app/org configuration.`
       ]);
       return res.redirect('/terminal');
     }


### PR DESCRIPTION
Add `password` as authenticator by default if the password is available to compatible with identifier first flow when no `authenticators` are passed to `idx.authenticate`.