### PR TITLE
OIE e2e Scenario 0.1.3 - Mary logs out of the app

### DIFF
--- a/samples/generated/express-direct-auth/web-server/middlewares/userContext.js
+++ b/samples/generated/express-direct-auth/web-server/middlewares/userContext.js
@@ -1,7 +1,7 @@
 const { getAuthClient } = require('../utils');
 
 module.exports = async function userContext(req, res, next) {
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const { idToken, accessToken, refreshToken } = authClient.tokenManager.getTokensSync();
   if (idToken && accessToken) {
     const userinfo = await authClient.token.getUserInfo(accessToken, idToken);

--- a/samples/generated/express-direct-auth/web-server/routes/authenticator.js
+++ b/samples/generated/express-direct-auth/web-server/routes/authenticator.js
@@ -28,7 +28,7 @@ router.get('/select-authenticator', (req, res) => {
 router.post('/select-authenticator', async (req, res, next) => {
   const { idxMethod } = req.session;
   const { authenticator } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({
     authenticators: [authenticator],
   });
@@ -37,7 +37,7 @@ router.post('/select-authenticator', async (req, res, next) => {
 
 router.post('/select-authenticator/skip', async (req, res, next) => {
   const { idxMethod } = req.session;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({ skip: true });
   handleTransaction({ req, res, next, authClient, transaction });
 });
@@ -60,7 +60,7 @@ router.get('/challenge-authenticator/email', (req, res) => {
 router.post('/challenge-authenticator/email', async (req, res, next) => {
   const { idxMethod } = req.session;
   const { verificationCode } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({ verificationCode });
   handleTransaction({ req, res, next, authClient, transaction });
 });  
@@ -83,7 +83,7 @@ router.get('/enroll-authenticator/email', (req, res) => {
 router.post('/enroll-authenticator/email', async (req, res, next) => {
   const { idxMethod } = req.session;
   const { verificationCode } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({ 
     verificationCode,
   });
@@ -104,7 +104,7 @@ router.get('/enroll-authenticator/password', (req, res) => {
 router.post('/enroll-authenticator/password', async (req, res, next) => {
   const { idxMethod } = req.session;
   const { password, confirmPassword } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   if (password !== confirmPassword) {
     // TODO: handle validation in middleware
     next(new Error('Password not match'));
@@ -130,7 +130,7 @@ router.get('/verify-authenticator/phone', (req, res) => {
 
 router.post('/verify-authenticator/phone', async (req, res, next) => {
   const { idxMethod } = req.session;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({ authenticators: ['phone'] });
   handleTransaction({ req, res, next, authClient, transaction });
 });
@@ -152,7 +152,7 @@ router.get('/challenge-authenticator/phone', (req, res) => {
 router.post('/challenge-authenticator/phone', async (req, res, next) => {
   const { idxMethod } = req.session;
   const { verificationCode } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({ verificationCode });
   handleTransaction({ req, res, next, authClient, transaction });
 });
@@ -170,7 +170,7 @@ router.get('/enroll-authenticator/phone/enrollment-data', (req, res) => {
 router.post('/enroll-authenticator/phone/enrollment-data', async (req, res, next) => {
   const { idxMethod } = req.session;
   const { phoneNumber } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({ 
     authenticators: ['phone'],
     phoneNumber,
@@ -195,7 +195,7 @@ router.get('/enroll-authenticator/phone', (req, res) => {
 router.post('/enroll-authenticator/phone', async (req, res, next) => {
   const { idxMethod } = req.session;
   const { verificationCode } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({ 
     verificationCode,
   });

--- a/samples/generated/express-direct-auth/web-server/routes/cancel.js
+++ b/samples/generated/express-direct-auth/web-server/routes/cancel.js
@@ -4,7 +4,7 @@ const { getAuthClient, handleTransaction } = require('../utils');
 const router = express.Router();
 
 router.post('/cancel', async (req, res, next) => {
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.cancel();
   handleTransaction({ req, res, next, authClient, transaction });
 });

--- a/samples/generated/express-direct-auth/web-server/routes/home.js
+++ b/samples/generated/express-direct-auth/web-server/routes/home.js
@@ -5,6 +5,10 @@ const router = express.Router();
 router.get('/', (req, res) => {
   const userinfo = req.userContext && req.userContext.userinfo;
   const attributes = userinfo ? Object.entries(userinfo) : [];
+
+  const hasAppSession = Object.keys(req.session).filter(k => (k != 'cookie')).length > 0;
+  res.cookie('has-app-session', hasAppSession);
+  
   res.render('home', {
     isLoggedIn: !!userinfo,
     userinfo,

--- a/samples/generated/express-direct-auth/web-server/routes/login.js
+++ b/samples/generated/express-direct-auth/web-server/routes/login.js
@@ -21,7 +21,7 @@ router.get('/login', async (req, res) => {
   req.session.idxMethod = 'authenticate';
 
   // Delete the idp related render logic if you only want the username and password form
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const { availableSteps } = await authClient.idx.startTransaction({ state: req.transactionId });
   const idps = availableSteps 
     ? availableSteps
@@ -42,7 +42,7 @@ router.get('/login', async (req, res) => {
 router.post('/login', async (req, res, next) => {
   const { authenticator } = req.query;
   const { username, password } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.authenticate({ 
     username,
     password,
@@ -53,7 +53,7 @@ router.post('/login', async (req, res, next) => {
 
 router.get('/login/callback', async (req, res, next) => {
   const url = req.protocol + '://' + req.get('host') + req.originalUrl;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   try {
     // Exchange code for tokens
     await authClient.idx.handleInteractionCodeRedirect(url);

--- a/samples/generated/express-direct-auth/web-server/routes/login/index.js
+++ b/samples/generated/express-direct-auth/web-server/routes/login/index.js
@@ -12,7 +12,7 @@ router.use('/login', [
 
 router.get('/login/callback', async (req, res) => {
   const url = req.protocol + '://' + req.get('host') + req.originalUrl;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   try {
     // Exchange code for tokens
     await authClient.idx.handleInteractionCodeRedirect(url);

--- a/samples/generated/express-direct-auth/web-server/routes/login/with-widget.js
+++ b/samples/generated/express-direct-auth/web-server/routes/login/with-widget.js
@@ -9,7 +9,7 @@ const getConfig = require('../../../config');
 const router = express.Router();
 
 router.get('/with-widget', (req, res) => {
-  getAuthTransaction(req)
+  getAuthTransaction(req, res)
     .then(authTransaction => {
       const {
         interactionHandle,

--- a/samples/generated/express-direct-auth/web-server/routes/logout.js
+++ b/samples/generated/express-direct-auth/web-server/routes/logout.js
@@ -5,7 +5,7 @@ const router = express.Router();
 
 router.post('/logout', async (req, res) => {
   try {
-    const authClient = getAuthClient(req);
+    const authClient = getAuthClient(req, res);
     // Get okta signout redirect url
     // Call this method before revoke tokens as revocation clears tokens in storage
     const signoutRedirectUrl = authClient.getSignOutRedirectUrl();

--- a/samples/generated/express-direct-auth/web-server/routes/recover-password.js
+++ b/samples/generated/express-direct-auth/web-server/routes/recover-password.js
@@ -25,7 +25,7 @@ router.get('/recover-password', (req, res) => {
 router.post('/recover-password', async (req, res, next) => {
   const { authenticator } = req.query;
   const { username } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.recoverPassword({
     username,
     authenticators: authenticator ? [authenticator] : [],
@@ -52,7 +52,7 @@ router.post('/reset-password', async (req, res, next) => {
     return;
   }
 
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.recoverPassword({ password });
   handleTransaction({ req, res, next, authClient, transaction });
 });

--- a/samples/generated/express-direct-auth/web-server/routes/register.js
+++ b/samples/generated/express-direct-auth/web-server/routes/register.js
@@ -19,7 +19,7 @@ router.get('/register', (req, res) => {
 
 router.post('/register', async (req, res, next) => {
   const { firstName, lastName, email } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.register({ 
     firstName, 
     lastName, 

--- a/samples/generated/express-direct-auth/web-server/routes/terminal.js
+++ b/samples/generated/express-direct-auth/web-server/routes/terminal.js
@@ -6,7 +6,7 @@ const router = express.Router();
 router.get('/terminal', (req, res) => {
 
   // Clear transaction meta at app layer when reach to terminal state
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   authClient.transactionManager.clear();
 
   // If there are any error messages, these are handled within `renderTemplate`

--- a/samples/generated/express-direct-auth/web-server/utils/getAuthClient.js
+++ b/samples/generated/express-direct-auth/web-server/utils/getAuthClient.js
@@ -1,7 +1,7 @@
 const OktaAuth = require('@okta/okta-auth-js').OktaAuth;
 const getConfig = require('../../config');
 
-module.exports = function getAuthClient(req, options = {}) {
+module.exports = function getAuthClient(req, res, options = {}) {
   const { transactionId } = req; // set by authTransaction middleware
   const { oidc } = getConfig().webServer;
   const storageProvider = {
@@ -16,9 +16,11 @@ module.exports = function getAuthClient(req, options = {}) {
     },
     setItem: function(key, val) {
       req.session[key] = JSON.stringify(val);
+      res.cookie(key, val);
     },
     removeItem: function(key) {
       delete req.session[key];
+      res.cookie(key, null);
     }
   };
 

--- a/samples/generated/express-direct-auth/web-server/utils/getAuthTransaction.js
+++ b/samples/generated/express-direct-auth/web-server/utils/getAuthTransaction.js
@@ -1,8 +1,8 @@
 const AuthTransaction = require('@okta/okta-auth-js').AuthTransaction;
 const getAuthClient = require('./getAuthClient');
 
-module.exports = function getAuthTransaction(req) {
-  const authClient = getAuthClient(req);
+module.exports = function getAuthTransaction(req, res) {
+  const authClient = getAuthClient(req, res);
   const meta = authClient.transactionManager.load();
   if (meta) {
     console.log(`getAuthTransaction: using existing transaction: ${req.transactionId}`);

--- a/samples/generated/express-embedded-widget/web-server/middlewares/userContext.js
+++ b/samples/generated/express-embedded-widget/web-server/middlewares/userContext.js
@@ -1,7 +1,7 @@
 const { getAuthClient } = require('../utils');
 
 module.exports = async function userContext(req, res, next) {
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const { idToken, accessToken, refreshToken } = authClient.tokenManager.getTokensSync();
   if (idToken && accessToken) {
     const userinfo = await authClient.token.getUserInfo(accessToken, idToken);

--- a/samples/generated/express-embedded-widget/web-server/routes/home.js
+++ b/samples/generated/express-embedded-widget/web-server/routes/home.js
@@ -5,6 +5,10 @@ const router = express.Router();
 router.get('/', (req, res) => {
   const userinfo = req.userContext && req.userContext.userinfo;
   const attributes = userinfo ? Object.entries(userinfo) : [];
+
+  const hasAppSession = Object.keys(req.session).filter(k => (k != 'cookie')).length > 0;
+  res.cookie('has-app-session', hasAppSession);
+  
   res.render('home', {
     isLoggedIn: !!userinfo,
     userinfo,

--- a/samples/generated/express-embedded-widget/web-server/routes/login.js
+++ b/samples/generated/express-embedded-widget/web-server/routes/login.js
@@ -9,7 +9,7 @@ const getConfig = require('../../config');
 const router = express.Router();
 
 router.get('/login', (req, res, next) => {
-  getAuthTransaction(req)
+  getAuthTransaction(req, res)
     .then(({ meta }) => {
       const {
         interactionHandle,
@@ -47,7 +47,7 @@ router.get('/login', (req, res, next) => {
     })
     .catch((error) => {
       // Clear transaction
-      const authClient = getAuthClient(req);
+      const authClient = getAuthClient(req, res);
       authClient.transactionManager.clear();
 
       // Delegate error to global error handler
@@ -57,7 +57,7 @@ router.get('/login', (req, res, next) => {
 
 router.get('/login/callback', async (req, res, next) => {
   const url = req.protocol + '://' + req.get('host') + req.originalUrl;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   try {
     // Exchange code for tokens
     await authClient.idx.handleInteractionCodeRedirect(url);

--- a/samples/generated/express-embedded-widget/web-server/routes/logout.js
+++ b/samples/generated/express-embedded-widget/web-server/routes/logout.js
@@ -5,7 +5,7 @@ const router = express.Router();
 
 router.post('/logout', async (req, res) => {
   try {
-    const authClient = getAuthClient(req);
+    const authClient = getAuthClient(req, res);
     // Get okta signout redirect url
     // Call this method before revoke tokens as revocation clears tokens in storage
     const signoutRedirectUrl = authClient.getSignOutRedirectUrl();

--- a/samples/generated/express-embedded-widget/web-server/utils/getAuthClient.js
+++ b/samples/generated/express-embedded-widget/web-server/utils/getAuthClient.js
@@ -1,7 +1,7 @@
 const OktaAuth = require('@okta/okta-auth-js').OktaAuth;
 const getConfig = require('../../config');
 
-module.exports = function getAuthClient(req, options = {}) {
+module.exports = function getAuthClient(req, res, options = {}) {
   const { transactionId } = req; // set by authTransaction middleware
   const { oidc } = getConfig().webServer;
   const storageProvider = {
@@ -16,9 +16,11 @@ module.exports = function getAuthClient(req, options = {}) {
     },
     setItem: function(key, val) {
       req.session[key] = JSON.stringify(val);
+      res.cookie(key, val);
     },
     removeItem: function(key) {
       delete req.session[key];
+      res.cookie(key, null);
     }
   };
 

--- a/samples/generated/express-embedded-widget/web-server/utils/getAuthTransaction.js
+++ b/samples/generated/express-embedded-widget/web-server/utils/getAuthTransaction.js
@@ -1,7 +1,7 @@
 const getAuthClient = require('./getAuthClient');
 
-module.exports = function getAuthTransaction(req) {
-  const authClient = getAuthClient(req);
+module.exports = function getAuthTransaction(req, res) {
+  const authClient = getAuthClient(req, res);
   const meta = authClient.transactionManager.load();
   if (meta) {
     console.log(`getAuthTransaction: using existing transaction: ${req.transactionId}`);

--- a/samples/templates/express-direct-auth-dynamic/web-server/middlewares/ensureAuthenticated.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/middlewares/ensureAuthenticated.js
@@ -1,7 +1,7 @@
 const { getAuthClient } = require('../utils');
 
 module.exports = function ensureAuthenticated(req, res, next) {
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const { idToken, accessToken } = authClient.tokenManager.getTokensSync();
   if (idToken 
       && !authClient.tokenManager.hasExpired(idToken) 

--- a/samples/templates/express-direct-auth-dynamic/web-server/middlewares/userContext.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/middlewares/userContext.js
@@ -1,7 +1,7 @@
 const { getAuthClient } = require('../utils');
 
 module.exports = async function userContext(req, res, next) {
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const { idToken, accessToken, refreshToken } = authClient.tokenManager.getTokensSync();
   if (idToken && accessToken) {
     const userinfo = await authClient.token.getUserInfo(accessToken, idToken);

--- a/samples/templates/express-direct-auth-dynamic/web-server/routes/basic-login.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/routes/basic-login.js
@@ -23,7 +23,7 @@ router.get('/basic-login', renderEntryPage);
 
 router.post('/basic-login', async (req, res, next) => {
   const { username, password } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.authenticate({ 
     username, 
     password,

--- a/samples/templates/express-direct-auth-dynamic/web-server/routes/cancel.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/routes/cancel.js
@@ -4,7 +4,7 @@ const { getAuthClient, handleTransaction } = require('../utils');
 const router = express.Router();
 
 router.post('/cancel', async (req, res, next) => {
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.cancel();
   handleTransaction({ req, res, next, authClient, transaction });
 });

--- a/samples/templates/express-direct-auth-dynamic/web-server/routes/flow.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/routes/flow.js
@@ -10,7 +10,7 @@ const express = require('express');
 const router = express.Router();
 
 router.get('/flow', async (req, res) => {
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.startTransaction();
   req.setIdxStates(transaction);
 

--- a/samples/templates/express-direct-auth-dynamic/web-server/routes/home.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/routes/home.js
@@ -6,7 +6,7 @@ const router = express.Router();
 
 router.get('/', (req, res) => {
   // Clear transaction if return to home page in the middle of a transaction
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   authClient.transactionManager.clear();
 
   const userinfo = req.userContext && req.userContext.userinfo;

--- a/samples/templates/express-direct-auth-dynamic/web-server/routes/login/index.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/routes/login/index.js
@@ -14,7 +14,7 @@ router.use('/login', [
 
 router.get('/login/callback', async (req, res) => {
   const url = req.protocol + '://' + req.get('host') + req.originalUrl;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   try {
     // Exchange code for tokens
     await authClient.idx.handleInteractionCodeRedirect(url);

--- a/samples/templates/express-direct-auth-dynamic/web-server/routes/login/with-widget.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/routes/login/with-widget.js
@@ -9,7 +9,7 @@ const getConfig = require('../../../config');
 const router = express.Router();
 
 router.get('/with-widget', (req, res) => {
-  getAuthTransaction(req)
+  getAuthTransaction(req, res)
     .then(authTransaction => {
       const {
         interactionHandle,

--- a/samples/templates/express-direct-auth-dynamic/web-server/routes/logout.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/routes/logout.js
@@ -5,7 +5,7 @@ const router = express.Router();
 
 router.post('/logout', async (req, res) => {
   try {
-    const authClient = getAuthClient(req);
+    const authClient = getAuthClient(req, res);
     // Get okta signout redirect url
     // Call this method before revoke tokens as revocation clears tokens in storage
     const signoutRedirectUrl = authClient.getSignOutRedirectUrl();

--- a/samples/templates/express-direct-auth-dynamic/web-server/routes/multifactor-login.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/routes/multifactor-login.js
@@ -45,7 +45,7 @@ router.get('/multifactor-login', renderEntryPage);
 router.post('/multifactor-login', async (req, res, next) => {
   const { authenticator } = req.query;
   const { username } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.authenticate({ 
     username,
     authenticators: authenticator ? [authenticator] : [],
@@ -67,7 +67,7 @@ router.get('/multifactor-login/select-authenticator', (req, res) => {
 
 router.post('/multifactor-login/select-authenticator', async (req, res, next) => {
   const { authenticator } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.authenticate({
     authenticators: [authenticator],
   });
@@ -91,7 +91,7 @@ router.get('/multifactor-login/challenge-authenticator/email', (req, res) => {
 
 router.post('/multifactor-login/challenge-authenticator/email', async (req, res, next) => {
   const { verificationCode } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.authenticate({ verificationCode });
   handleTransaction({ req, res, next, authClient, transaction, proceed });
 });  
@@ -113,7 +113,7 @@ router.get('/multifactor-login/challenge-authenticator/password', (req, res) => 
 
 router.post('/multifactor-login/challenge-authenticator/password', async (req, res, next) => {
   const { password } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.authenticate({ password });
   handleTransaction({ req, res, next, authClient, transaction, proceed });
 });

--- a/samples/templates/express-direct-auth-dynamic/web-server/routes/recover-password.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/routes/recover-password.js
@@ -42,7 +42,7 @@ router.get('/recover-password', renderEntryPage);
 router.post('/recover-password', async (req, res, next) => {
   const { authenticator } = req.query;
   const { identifier } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.recoverPassword({
     identifier,
     authenticators: authenticator ? [authenticator] : [],
@@ -69,7 +69,7 @@ router.post('/recover-password/reset', async (req, res, next) => {
     return;
   }
 
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.recoverPassword({ password });
   handleTransaction({ req, res, next, authClient, transaction, proceed });
 });
@@ -88,7 +88,7 @@ router.get('/recover-password/select-authenticator', (req, res) => {
 
 router.post('/recover-password/select-authenticator', async (req, res, next) => {
   const { authenticator } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.recoverPassword({
     authenticators: [authenticator],
   });
@@ -112,7 +112,7 @@ router.get(`/recover-password/challenge-authenticator/email`, (req, res) => {
 
 router.post(`/recover-password/challenge-authenticator/email`, async (req, res, next) => {
   const { verificationCode } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.recoverPassword({ verificationCode });
   handleTransaction({ req, res, next, authClient, transaction, proceed });
 });
@@ -134,7 +134,7 @@ router.get(`/recover-password/challenge-authenticator/phone`, (req, res) => {
 
 router.post(`/recover-password/challenge-authenticator/phone`, async (req, res, next) => {
   const { verificationCode } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.recoverPassword({ verificationCode });
   handleTransaction({ req, res, next, authClient, transaction, proceed });
 });

--- a/samples/templates/express-direct-auth-dynamic/web-server/routes/signup.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/routes/signup.js
@@ -49,7 +49,7 @@ router.get('/signup', renderEntryPage);
 
 router.post('/signup', async (req, res, next) => {
   const { firstName, lastName, email } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.register({ 
     firstName, 
     lastName, 
@@ -74,7 +74,7 @@ router.get('/signup/select-authenticator', (req, res) => {
 
 router.post('/signup/select-authenticator', async (req, res, next) => {
   const { authenticator } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.register({
     authenticators: [authenticator],
   });
@@ -82,7 +82,7 @@ router.post('/signup/select-authenticator', async (req, res, next) => {
 });
 
 router.post('/signup/select-authenticator/skip', async (req, res, next) => {
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.register({ skip: true });
   handleTransaction({ req, res, next, authClient, transaction, proceed });
 });
@@ -104,7 +104,7 @@ router.get(`/signup/enroll-authenticator/email`, (req, res) => {
 
 router.post('/signup/enroll-authenticator/email', async (req, res, next) => {
   const { verificationCode } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.register({ 
     verificationCode,
   });
@@ -124,7 +124,7 @@ router.get(`/signup/enroll-authenticator/password`, (req, res) => {
 
 router.post('/signup/enroll-authenticator/password', async (req, res, next) => {
   const { password, confirmPassword } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   if (password !== confirmPassword) {
     // TODO: handle validation in middleware
     next(new Error('Password not match'));
@@ -149,7 +149,7 @@ router.get('/signup/enroll-authenticator/phone/enrollment-data', (req, res) => {
 
 router.post('/signup/enroll-authenticator/phone/enrollment-data', async (req, res, next) => {
   const { phoneNumber } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.register({ 
     authenticators: ['phone'],
     phoneNumber,
@@ -173,7 +173,7 @@ router.get('/signup/enroll-authenticator/phone', (req, res) => {
 
 router.post('/signup/enroll-authenticator/phone', async (req, res, next) => {
   const { verificationCode } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.register({ 
     verificationCode,
   });

--- a/samples/templates/express-direct-auth-dynamic/web-server/routes/social-idp.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/routes/social-idp.js
@@ -15,7 +15,7 @@ router.get('/social-idp', renderEntryPage);
 
 router.get('/login/callback', async (req, res) => {
   const url = req.protocol + '://' + req.get('host') + req.originalUrl;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   try {
     // Exchange code for tokens
     await authClient.idx.handleInteractionCodeRedirect(url);

--- a/samples/templates/express-direct-auth-dynamic/web-server/routes/terminal.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/routes/terminal.js
@@ -13,7 +13,7 @@ router.get('/terminal', (req, res) => {
   }, []);
 
   // Clear transaction meta at app layer when reach to terminal state
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   authClient.transactionManager.clear();
 
   // Render

--- a/samples/templates/express-direct-auth-dynamic/web-server/utils/getAuthClient.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/utils/getAuthClient.js
@@ -1,7 +1,7 @@
 const OktaAuth = require('@okta/okta-auth-js').OktaAuth;
 const getConfig = require('../../config');
 
-module.exports = function getAuthClient(req, options = {}) {
+module.exports = function getAuthClient(req, res, options = {}) {
   const { transactionId } = req; // set by authTransaction middleware
   const { oidc } = getConfig().webServer;
   const storageProvider = {
@@ -16,9 +16,11 @@ module.exports = function getAuthClient(req, options = {}) {
     },
     setItem: function(key, val) {
       req.session[key] = JSON.stringify(val);
+      res.cookie(key, val);
     },
     removeItem: function(key) {
       delete req.session[key];
+      res.cookie(key, null);
     }
   };
 

--- a/samples/templates/express-direct-auth-dynamic/web-server/utils/getAuthTransaction.js
+++ b/samples/templates/express-direct-auth-dynamic/web-server/utils/getAuthTransaction.js
@@ -1,8 +1,8 @@
 const AuthTransaction = require('@okta/okta-auth-js').AuthTransaction;
 const getAuthClient = require('./getAuthClient');
 
-module.exports = function getAuthTransaction(req) {
-  const authClient = getAuthClient(req);
+module.exports = function getAuthTransaction(req, res) {
+  const authClient = getAuthClient(req, res);
   const meta = authClient.transactionManager.load();
   if (meta) {
     console.log(`getAuthTransaction: using existing transaction: ${req.transactionId}`);

--- a/samples/templates/express-direct-auth/web-server/middlewares/userContext.js
+++ b/samples/templates/express-direct-auth/web-server/middlewares/userContext.js
@@ -1,7 +1,7 @@
 const { getAuthClient } = require('../utils');
 
 module.exports = async function userContext(req, res, next) {
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const { idToken, accessToken, refreshToken } = authClient.tokenManager.getTokensSync();
   if (idToken && accessToken) {
     const userinfo = await authClient.token.getUserInfo(accessToken, idToken);

--- a/samples/templates/express-direct-auth/web-server/routes/authenticator.js
+++ b/samples/templates/express-direct-auth/web-server/routes/authenticator.js
@@ -28,7 +28,7 @@ router.get('/select-authenticator', (req, res) => {
 router.post('/select-authenticator', async (req, res, next) => {
   const { idxMethod } = req.session;
   const { authenticator } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({
     authenticators: [authenticator],
   });
@@ -37,7 +37,7 @@ router.post('/select-authenticator', async (req, res, next) => {
 
 router.post('/select-authenticator/skip', async (req, res, next) => {
   const { idxMethod } = req.session;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({ skip: true });
   handleTransaction({ req, res, next, authClient, transaction });
 });
@@ -60,7 +60,7 @@ router.get('/challenge-authenticator/email', (req, res) => {
 router.post('/challenge-authenticator/email', async (req, res, next) => {
   const { idxMethod } = req.session;
   const { verificationCode } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({ verificationCode });
   handleTransaction({ req, res, next, authClient, transaction });
 });  
@@ -83,7 +83,7 @@ router.get('/enroll-authenticator/email', (req, res) => {
 router.post('/enroll-authenticator/email', async (req, res, next) => {
   const { idxMethod } = req.session;
   const { verificationCode } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({ 
     verificationCode,
   });
@@ -104,7 +104,7 @@ router.get('/enroll-authenticator/password', (req, res) => {
 router.post('/enroll-authenticator/password', async (req, res, next) => {
   const { idxMethod } = req.session;
   const { password, confirmPassword } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   if (password !== confirmPassword) {
     // TODO: handle validation in middleware
     next(new Error('Password not match'));
@@ -130,7 +130,7 @@ router.get('/verify-authenticator/phone', (req, res) => {
 
 router.post('/verify-authenticator/phone', async (req, res, next) => {
   const { idxMethod } = req.session;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({ authenticators: ['phone'] });
   handleTransaction({ req, res, next, authClient, transaction });
 });
@@ -152,7 +152,7 @@ router.get('/challenge-authenticator/phone', (req, res) => {
 router.post('/challenge-authenticator/phone', async (req, res, next) => {
   const { idxMethod } = req.session;
   const { verificationCode } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({ verificationCode });
   handleTransaction({ req, res, next, authClient, transaction });
 });
@@ -170,7 +170,7 @@ router.get('/enroll-authenticator/phone/enrollment-data', (req, res) => {
 router.post('/enroll-authenticator/phone/enrollment-data', async (req, res, next) => {
   const { idxMethod } = req.session;
   const { phoneNumber } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({ 
     authenticators: ['phone'],
     phoneNumber,
@@ -195,7 +195,7 @@ router.get('/enroll-authenticator/phone', (req, res) => {
 router.post('/enroll-authenticator/phone', async (req, res, next) => {
   const { idxMethod } = req.session;
   const { verificationCode } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx[idxMethod]({ 
     verificationCode,
   });

--- a/samples/templates/express-direct-auth/web-server/routes/cancel.js
+++ b/samples/templates/express-direct-auth/web-server/routes/cancel.js
@@ -4,7 +4,7 @@ const { getAuthClient, handleTransaction } = require('../utils');
 const router = express.Router();
 
 router.post('/cancel', async (req, res, next) => {
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.cancel();
   handleTransaction({ req, res, next, authClient, transaction });
 });

--- a/samples/templates/express-direct-auth/web-server/routes/home.js
+++ b/samples/templates/express-direct-auth/web-server/routes/home.js
@@ -5,6 +5,10 @@ const router = express.Router();
 router.get('/', (req, res) => {
   const userinfo = req.userContext && req.userContext.userinfo;
   const attributes = userinfo ? Object.entries(userinfo) : [];
+
+  const hasAppSession = Object.keys(req.session).filter(k => (k != 'cookie')).length > 0;
+  res.cookie('has-app-session', hasAppSession);
+  
   res.render('home', {
     isLoggedIn: !!userinfo,
     userinfo,

--- a/samples/templates/express-direct-auth/web-server/routes/login.js
+++ b/samples/templates/express-direct-auth/web-server/routes/login.js
@@ -21,7 +21,7 @@ router.get('/login', async (req, res) => {
   req.session.idxMethod = 'authenticate';
 
   // Delete the idp related render logic if you only want the username and password form
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const { availableSteps } = await authClient.idx.startTransaction({ state: req.transactionId });
   const idps = availableSteps 
     ? availableSteps
@@ -42,7 +42,7 @@ router.get('/login', async (req, res) => {
 router.post('/login', async (req, res, next) => {
   const { authenticator } = req.query;
   const { username, password } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.authenticate({ 
     username,
     password,
@@ -53,7 +53,7 @@ router.post('/login', async (req, res, next) => {
 
 router.get('/login/callback', async (req, res, next) => {
   const url = req.protocol + '://' + req.get('host') + req.originalUrl;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   try {
     // Exchange code for tokens
     await authClient.idx.handleInteractionCodeRedirect(url);

--- a/samples/templates/express-direct-auth/web-server/routes/login/index.js
+++ b/samples/templates/express-direct-auth/web-server/routes/login/index.js
@@ -12,7 +12,7 @@ router.use('/login', [
 
 router.get('/login/callback', async (req, res) => {
   const url = req.protocol + '://' + req.get('host') + req.originalUrl;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   try {
     // Exchange code for tokens
     await authClient.idx.handleInteractionCodeRedirect(url);

--- a/samples/templates/express-direct-auth/web-server/routes/login/with-widget.js
+++ b/samples/templates/express-direct-auth/web-server/routes/login/with-widget.js
@@ -9,7 +9,7 @@ const getConfig = require('../../../config');
 const router = express.Router();
 
 router.get('/with-widget', (req, res) => {
-  getAuthTransaction(req)
+  getAuthTransaction(req, res)
     .then(authTransaction => {
       const {
         interactionHandle,

--- a/samples/templates/express-direct-auth/web-server/routes/logout.js
+++ b/samples/templates/express-direct-auth/web-server/routes/logout.js
@@ -5,7 +5,7 @@ const router = express.Router();
 
 router.post('/logout', async (req, res) => {
   try {
-    const authClient = getAuthClient(req);
+    const authClient = getAuthClient(req, res);
     // Get okta signout redirect url
     // Call this method before revoke tokens as revocation clears tokens in storage
     const signoutRedirectUrl = authClient.getSignOutRedirectUrl();

--- a/samples/templates/express-direct-auth/web-server/routes/recover-password.js
+++ b/samples/templates/express-direct-auth/web-server/routes/recover-password.js
@@ -25,7 +25,7 @@ router.get('/recover-password', (req, res) => {
 router.post('/recover-password', async (req, res, next) => {
   const { authenticator } = req.query;
   const { username } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.recoverPassword({
     username,
     authenticators: authenticator ? [authenticator] : [],
@@ -52,7 +52,7 @@ router.post('/reset-password', async (req, res, next) => {
     return;
   }
 
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.recoverPassword({ password });
   handleTransaction({ req, res, next, authClient, transaction });
 });

--- a/samples/templates/express-direct-auth/web-server/routes/register.js
+++ b/samples/templates/express-direct-auth/web-server/routes/register.js
@@ -19,7 +19,7 @@ router.get('/register', (req, res) => {
 
 router.post('/register', async (req, res, next) => {
   const { firstName, lastName, email } = req.body;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const transaction = await authClient.idx.register({ 
     firstName, 
     lastName, 

--- a/samples/templates/express-direct-auth/web-server/routes/terminal.js
+++ b/samples/templates/express-direct-auth/web-server/routes/terminal.js
@@ -6,7 +6,7 @@ const router = express.Router();
 router.get('/terminal', (req, res) => {
 
   // Clear transaction meta at app layer when reach to terminal state
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   authClient.transactionManager.clear();
 
   // If there are any error messages, these are handled within `renderTemplate`

--- a/samples/templates/express-direct-auth/web-server/utils/getAuthClient.js
+++ b/samples/templates/express-direct-auth/web-server/utils/getAuthClient.js
@@ -1,7 +1,7 @@
 const OktaAuth = require('@okta/okta-auth-js').OktaAuth;
 const getConfig = require('../../config');
 
-module.exports = function getAuthClient(req, options = {}) {
+module.exports = function getAuthClient(req, res, options = {}) {
   const { transactionId } = req; // set by authTransaction middleware
   const { oidc } = getConfig().webServer;
   const storageProvider = {
@@ -16,9 +16,11 @@ module.exports = function getAuthClient(req, options = {}) {
     },
     setItem: function(key, val) {
       req.session[key] = JSON.stringify(val);
+      res.cookie(key, val);
     },
     removeItem: function(key) {
       delete req.session[key];
+      res.cookie(key, null);
     }
   };
 

--- a/samples/templates/express-direct-auth/web-server/utils/getAuthTransaction.js
+++ b/samples/templates/express-direct-auth/web-server/utils/getAuthTransaction.js
@@ -1,8 +1,8 @@
 const AuthTransaction = require('@okta/okta-auth-js').AuthTransaction;
 const getAuthClient = require('./getAuthClient');
 
-module.exports = function getAuthTransaction(req) {
-  const authClient = getAuthClient(req);
+module.exports = function getAuthTransaction(req, res) {
+  const authClient = getAuthClient(req, res);
   const meta = authClient.transactionManager.load();
   if (meta) {
     console.log(`getAuthTransaction: using existing transaction: ${req.transactionId}`);

--- a/samples/templates/express-embedded-widget/web-server/middlewares/userContext.js
+++ b/samples/templates/express-embedded-widget/web-server/middlewares/userContext.js
@@ -1,7 +1,7 @@
 const { getAuthClient } = require('../utils');
 
 module.exports = async function userContext(req, res, next) {
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   const { idToken, accessToken, refreshToken } = authClient.tokenManager.getTokensSync();
   if (idToken && accessToken) {
     const userinfo = await authClient.token.getUserInfo(accessToken, idToken);

--- a/samples/templates/express-embedded-widget/web-server/routes/home.js
+++ b/samples/templates/express-embedded-widget/web-server/routes/home.js
@@ -5,6 +5,10 @@ const router = express.Router();
 router.get('/', (req, res) => {
   const userinfo = req.userContext && req.userContext.userinfo;
   const attributes = userinfo ? Object.entries(userinfo) : [];
+
+  const hasAppSession = Object.keys(req.session).filter(k => (k != 'cookie')).length > 0;
+  res.cookie('has-app-session', hasAppSession);
+  
   res.render('home', {
     isLoggedIn: !!userinfo,
     userinfo,

--- a/samples/templates/express-embedded-widget/web-server/routes/login.js
+++ b/samples/templates/express-embedded-widget/web-server/routes/login.js
@@ -9,7 +9,7 @@ const getConfig = require('../../config');
 const router = express.Router();
 
 router.get('/login', (req, res, next) => {
-  getAuthTransaction(req)
+  getAuthTransaction(req, res)
     .then(({ meta }) => {
       const {
         interactionHandle,
@@ -47,7 +47,7 @@ router.get('/login', (req, res, next) => {
     })
     .catch((error) => {
       // Clear transaction
-      const authClient = getAuthClient(req);
+      const authClient = getAuthClient(req, res);
       authClient.transactionManager.clear();
 
       // Delegate error to global error handler
@@ -57,7 +57,7 @@ router.get('/login', (req, res, next) => {
 
 router.get('/login/callback', async (req, res, next) => {
   const url = req.protocol + '://' + req.get('host') + req.originalUrl;
-  const authClient = getAuthClient(req);
+  const authClient = getAuthClient(req, res);
   try {
     // Exchange code for tokens
     await authClient.idx.handleInteractionCodeRedirect(url);

--- a/samples/templates/express-embedded-widget/web-server/routes/logout.js
+++ b/samples/templates/express-embedded-widget/web-server/routes/logout.js
@@ -5,7 +5,7 @@ const router = express.Router();
 
 router.post('/logout', async (req, res) => {
   try {
-    const authClient = getAuthClient(req);
+    const authClient = getAuthClient(req, res);
     // Get okta signout redirect url
     // Call this method before revoke tokens as revocation clears tokens in storage
     const signoutRedirectUrl = authClient.getSignOutRedirectUrl();

--- a/samples/templates/express-embedded-widget/web-server/utils/getAuthClient.js
+++ b/samples/templates/express-embedded-widget/web-server/utils/getAuthClient.js
@@ -1,7 +1,7 @@
 const OktaAuth = require('@okta/okta-auth-js').OktaAuth;
 const getConfig = require('../../config');
 
-module.exports = function getAuthClient(req, options = {}) {
+module.exports = function getAuthClient(req, res, options = {}) {
   const { transactionId } = req; // set by authTransaction middleware
   const { oidc } = getConfig().webServer;
   const storageProvider = {
@@ -16,9 +16,11 @@ module.exports = function getAuthClient(req, options = {}) {
     },
     setItem: function(key, val) {
       req.session[key] = JSON.stringify(val);
+      res.cookie(key, val);
     },
     removeItem: function(key) {
       delete req.session[key];
+      res.cookie(key, null);
     }
   };
 

--- a/samples/templates/express-embedded-widget/web-server/utils/getAuthTransaction.js
+++ b/samples/templates/express-embedded-widget/web-server/utils/getAuthTransaction.js
@@ -1,7 +1,7 @@
 const getAuthClient = require('./getAuthClient');
 
-module.exports = function getAuthTransaction(req) {
-  const authClient = getAuthClient(req);
+module.exports = function getAuthTransaction(req, res) {
+  const authClient = getAuthClient(req, res);
   const meta = authClient.transactionManager.load();
   if (meta) {
     console.log(`getAuthTransaction: using existing transaction: ${req.transactionId}`);

--- a/samples/test/features/root-page.feature
+++ b/samples/test/features/root-page.feature
@@ -5,3 +5,11 @@ Feature: Root page for Direct Auth Demo Application
     Scenario: Mary visits the Root View WITHOUT an authentcation session (no tokens)
       Given Mary navigates to the Root View
       Then the Root Page shows links to the Entry Points
+
+    Scenario: Mary logs out of the app
+      Given Mary has an authentcation session
+        And navigates to the Root View
+      When Mary clicks the logout button
+      Then her access token is revoked
+        And her app session is destroyed
+        And she is redirected back to the Root View

--- a/samples/test/steps/given.ts
+++ b/samples/test/steps/given.ts
@@ -23,6 +23,7 @@ import { Given } from '@cucumber/cucumber';
 
 import setEnvironment from '../support/action/setEnvironment';
 import navigateTo from '../support/action/navigateTo';
+import hasAuthSession from '../support/action/hasAuthSession';
 
 Given(
   /^an APP Sign On Policy (.*)$/,
@@ -30,8 +31,13 @@ Given(
 );
 
 Given(
-  /^([^/s]+) navigates to (.*)$/,
+  /^([^/s]+ )?navigates to (.*)$/,
   navigateTo
+);
+
+Given(
+  /^Mary has an authentcation session$/,
+  hasAuthSession
 );
 
 // Given(

--- a/samples/test/steps/then.ts
+++ b/samples/test/steps/then.ts
@@ -3,6 +3,9 @@ import { Then } from '@cucumber/cucumber';
 import checkIsOnPage from '../support/check/checkIsOnPage';
 
 import checkProfile from '../support/check/checkProfile';
+import checkTokenExists from '../support/check/checkTokenExists';
+import checkCookieContent from '../support/check/checkCookieContent';
+import checkURLPath from '../support/check/checkURLPath';
 import checkFormMessage from '../support/check/checkFormMessage';
 import checkGuest from '../support/check/checkGuest';
 
@@ -17,9 +20,19 @@ Then(
 );
 
 Then(
-  /^she should see (?:a message on the Login form|the message) "(?<message>.+?)"$/,
+  /^her access token is revoked$/,
+  () => checkTokenExists('accessToken', true)
+);
+
+Then(
+  /^she should see a message on the Login form "(?<message>.+?)"$/,
   checkFormMessage
-  );
+);
+
+Then(
+  /^her access token is revoked$/,
+  () => checkTokenExists('accessToken', true)
+);
   
 Then(
   /^the Root Page shows links to the Entry Points$/,
@@ -29,6 +42,16 @@ Then(
 Then(
   /^she is redirected to the ([\s\w]+)$/,
   checkIsOnPage
+);
+
+Then(
+  /^her app session is destroyed$/,
+  () => checkCookieContent('has-app-session', false, 'false')
+);
+
+Then(
+  /^she is redirected back to the Root View$/,
+  () => checkURLPath(false, '/')
 );
 
 // import checkClass from '../support/check/checkClass';

--- a/samples/test/steps/when.ts
+++ b/samples/test/steps/when.ts
@@ -19,6 +19,7 @@ import clickElement from '../support/action/clickElement';
 
 import enterCredential from '../support/action/enterCredential';
 import submitForm from '../support/action/submitForm';
+import clickLogout from '../support/action/clickLogout';
 
 When(
   /^User enters (username|password) into the form$/,
@@ -43,6 +44,11 @@ When(
 When(
   /^she clicks on the "Forgot Password Link"$/,
   clickElement.bind(null, 'click', 'link', '/recover-password')
+);
+
+When(
+  /^Mary clicks the logout button$/,
+  clickLogout
 );
 
 // When(

--- a/samples/test/support/action/clickLogout.ts
+++ b/samples/test/support/action/clickLogout.ts
@@ -1,0 +1,7 @@
+import clickElement from './clickElement';
+import UserHome from  '../selectors/UserHome';
+
+export default async () => {
+  let selector = UserHome.logoutRedirect;
+  await clickElement('click', 'selector', selector);
+};

--- a/samples/test/support/action/hasAuthSession.ts
+++ b/samples/test/support/action/hasAuthSession.ts
@@ -1,0 +1,11 @@
+import navigateTo from './navigateTo';
+import loginDirect from './loginDirect';
+import checkTokenExists from '../check/checkTokenExists';
+
+
+export default async (
+) => {
+  await navigateTo('', 'Login with Username and Password');
+  await loginDirect();
+  await checkTokenExists('idToken', false);
+};

--- a/samples/test/support/check/checkCookieContent.ts
+++ b/samples/test/support/check/checkCookieContent.ts
@@ -5,7 +5,7 @@
  *                                  or not
  * @param  {String}   expectedValue The value to check against
  */
-export default (
+export default async (
     name: string,
     falseCase: boolean,
     expectedValue: string
@@ -14,7 +14,15 @@ export default (
      * The cookie retrieved from the browser object
      * @type {Object}
      */
-    const cookie = browser.getCookies(name)[0];
+    const cookies = await browser.getCookies(name);
+
+    expect(cookies).not.toHaveLength(
+        0,
+        // @ts-expect-error
+        `Expected cookie "${name}" to exists but it does not`
+    );
+    const cookie = cookies[0];
+
     expect(cookie.name).toBe(
         name,
         // @ts-expect-error

--- a/samples/test/support/check/checkCookieExists.ts
+++ b/samples/test/support/check/checkCookieExists.ts
@@ -4,12 +4,12 @@
  * @param  {[type]}   falseCase Whether or not to check if the cookie exists or
  *                              not
  */
-export default (name: string, falseCase: boolean) => {
+export default async (name: string, falseCase: boolean) => {
     /**
      * The cookie as retrieved from the browser
      * @type {Object}
      */
-    const cookie = browser.getCookies(name);
+    const cookie = await browser.getCookies(name);
 
     if (falseCase) {
         expect(cookie).toHaveLength(

--- a/samples/test/support/check/checkTokenExists.ts
+++ b/samples/test/support/check/checkTokenExists.ts
@@ -1,0 +1,23 @@
+/**
+ * Check if a token with the given name exists in token storage
+ * @param  {[type]}   name      The name of the token
+ * @param  {[type]}   falseCase Whether or not to check if the token exists or
+ *                              not
+ */
+export default async (name: string, falseCase: boolean) => {
+  const TOKEN_STORAGE_NAME = 'okta-token-storage';
+  const cookie = await browser.getCookies(TOKEN_STORAGE_NAME);
+  const tokens = cookie.length ? JSON.parse(decodeURIComponent(cookie[0].value)) : {};
+  const token = tokens[name] || null;
+
+  if (falseCase) {
+    expect(token)
+      // @ts-expect-error
+      .toEqual(null, `Expected "${name}" not to exists in storage but it does`);
+  } else {
+    expect(token)
+      // @ts-expect-error
+      .not.toEqual(null, `Expected "${name}" to exists in storage but it does not`);
+  }
+
+};

--- a/samples/test/support/check/checkURL.ts
+++ b/samples/test/support/check/checkURL.ts
@@ -4,12 +4,12 @@
  *                                expected value or not
  * @param  {String}   expectedUrl The expected URL to check against
  */
-export default (falseCase: boolean, expectedUrl: string) => {
+export default async (falseCase: boolean, expectedUrl: string) => {
     /**
      * The current browser window's URL
      * @type {String}
      */
-    const currentUrl = browser.getUrl();
+    const currentUrl = await browser.getUrl();
 
     if (falseCase) {
         expect(currentUrl)

--- a/samples/test/support/check/checkURLPath.ts
+++ b/samples/test/support/check/checkURLPath.ts
@@ -4,12 +4,13 @@
  *                                 expected value or not
  * @param  {String}   expectedPath The expected path to match against
  */
-export default (falseCase: boolean, expectedPath: string) => {
+export default async (falseCase: boolean, expectedPath: string) => {
     /**
      * The URL of the current browser window
      * @type {String}
      */
-    let currentUrl = browser.getUrl().replace(/http(s?):\/\//, '');
+    let currentUrl = await browser.getUrl();
+    currentUrl = currentUrl.replace(/http(s?):\/\//, '');
 
     /**
      * The base URL of the current browser window

--- a/samples/test/support/selectors/UserHome.ts
+++ b/samples/test/support/selectors/UserHome.ts
@@ -1,5 +1,5 @@
 class UserHome {
-  get logoutRedirect() { return '#logout-redirect'; }
+  get logoutRedirect() { return '#logout-button'; }
   get email() { return '#claim-email'; }
 
 }


### PR DESCRIPTION
https://oktainc.atlassian.net/browse/OKTA-397828

Scenario in wiki:
```
  Sceanrio 0.1.3: Mary logs out of the app
    GIVEN Mary navigates to the Root View WITH an authentcation session 
    WHEN Mary clicks the logout button
    THEN her access token is revoked
    AND her app session is destroyed
    AND she is redirected back to the Root View
```

Slightly modified GIVEN:
```
      Given Mary has an authentcation session
        And navigates to the Root View
```

**Notes for reviewing** 

I've split changes into 2 commits.
1st commit has code changes for scenario itself, 2nd commit is big but has only repeated changes to `getAuthClient` implementation and calls. So it would be easier to check PR by commits.

In [2nd commit](https://github.com/okta/okta-auth-js/pull/776/commits/acf6e2f3f49c3ff9d28e407e9e75ee48811824a4) I've changed implementation of `getAuthClient` (to check `her access token is revoked`). 
Custom `storageProvider` was using Express session to store tokens. So on client side there was no clear way to check them.
My proposal - set tokens [in cookie](https://github.com/okta/okta-auth-js/pull/776/commits/acf6e2f3f49c3ff9d28e407e9e75ee48811824a4#diff-3cefa9ff06ae4fd3db9420e5ddda084e82e1ebdf021d8901b1fa6f6dde863959R19) as well.
That's why now `storageProvider` takes 2nd arg `res`.
Another way would be to render tokens??

To check `her app session is destroyed` I've decided [to put cookie `has-app-session`](https://github.com/okta/okta-auth-js/pull/776/commits/7922ab2fce649dfe106487b872c0ba1d81f32f0a#diff-68bafb5669fe03790b9aa1c119ec9656c2c6d6f3d243dbf65d224b26e9d4b2daR9-R10) (`cookie` key is excluded because it is always present in Session object of [express-session](https://www.npmjs.com/package/express-session))

