### PR TITLE
#768 Moves atob from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
+    "atob": "^2.1.2",
     "Base64": "1.1.0",
     "core-js": "^3.6.5",
     "cross-fetch": "^3.0.6",
@@ -97,7 +98,6 @@
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
     "@wdio/junit-reporter": "^6.7.0",
-    "atob": "^2.1.2",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.2",
     "babel-plugin-add-module-exports": "^1.0.2",


### PR DESCRIPTION
Some changes in 5.x appear to have made atob a runtime dependency, leading to a runtime error when importing the okta-auth-js library.