### PR TITLE
e2e: set environment for root page feature

### DIFF
--- a/env/index.js
+++ b/env/index.js
@@ -16,7 +16,9 @@ if (fs.existsSync(TESTENV)) {
 
 function setEnvironmentVars(envConfig) {
   Object.keys(envConfig).forEach((k) => {
-    console.log(envConfig[k]);
+    if (process.env[k] !== envConfig[k]) {
+      console.log(`Setting a new value for environment variable "${k}"`);
+    }
     process.env[k] = envConfig[k];
   });  
 }

--- a/samples/test/features/root-page.feature
+++ b/samples/test/features/root-page.feature
@@ -1,6 +1,7 @@
 Feature: Root page for Direct Auth Demo Application
 
   Background:
+    Given an APP
 
     Scenario: Mary visits the Root View WITHOUT an authentcation session (no tokens)
       Given Mary navigates to the Root View

--- a/samples/test/steps/given.ts
+++ b/samples/test/steps/given.ts
@@ -26,6 +26,12 @@ import navigateTo from '../support/action/navigateTo';
 import navigateToLoginAndAuthenticate from '../support/action/navigateToLoginAndAuthenticate';
 import createAndStoreUserInContext from '../support/action/live-user/createAndStoreUserInContext';
 
+Given(
+  /^an APP$/,
+  async function() {
+    return await setEnvironment('default');
+  }
+);
 
 Given(
   /^an APP Sign On Policy (.*)$/,


### PR DESCRIPTION
small adjustment so that `setEnvironment` is called for the root page feature
this ensures that variables will be loaded from `testenv.yml`, if it exists

also sanitize console.log output to only show when values of environment variables are changing (not the actual values)