### PR TITLE
OIE direct auth: e2e scenario 4.1.4

### DIFF
--- a/samples/test/features/self-service-registration.feature
+++ b/samples/test/features/self-service-registration.feature
@@ -68,3 +68,27 @@ Scenario: Mary signs up with an invalid Email
   And she submits the registration form
   Then she sees an error message "'Email' must be in the form of an email address"
   And she sees an error message "Provided value for property 'Email' does not match required pattern"
+
+Scenario: Mary signs up for an account with Password, sets up required Email factor, And sets up optional SMS with an invalid phone number
+  Given Mary navigates to the Self Service Registration View
+  When she fills out her First Name
+  And she fills out her Last Name
+  And she fills out her Email
+    And she submits the registration form
+  Then she sees the Select Authenticator page with password as the only option
+  When she chooses password factor option
+  # And she submits the select authenticator form
+  Then she sees the set new password form
+  And she fills out her Password
+  And she confirms her Password
+  And she submits the registration form
+  Then she sees a list of available factors to setup
+  When she selects Email
+  Then she sees a page to input a code for email authenticator enrollment
+  When she inputs the correct code from her email
+    And she submits the form
+  Then she sees a list of factors to register
+  When She selects Phone from the list
+  And she inputs an invalid phone number
+  And submits the enrollment form
+  Then she should see an error message "Unable to initiate factor enrollment: Invalid Phone Number."

--- a/samples/test/steps/then.ts
+++ b/samples/test/steps/then.ts
@@ -160,6 +160,11 @@ Then(
 );
 
 Then(
+  /^she should see an error message "(?<message>.+?)"$/,
+  checkFormMessage
+);
+
+Then(
   /^she sees a field to re-enter another code$/,
   checkIsOnPage.bind(null, 'Challenge phone authenticator')
 );

--- a/samples/test/steps/when.ts
+++ b/samples/test/steps/when.ts
@@ -38,6 +38,7 @@ import enterCorrectPhoneNumber from '../support/action/live-user/enterCorrectPho
 import selectVerifyBySms from '../support/action/selectVerifyBySms';
 import skipForm from '../support/action/skipForm';
 import inputInvalidEmailFormat from '../support/action/inputInvalidEmailFormat';
+import enterIncorrectPhoneNumberFormat from '../support/action/enterIncorrectPhoneNumberFormat';
 
 When(
   /^User enters (username|password) into the form$/,
@@ -145,6 +146,11 @@ When(
 );
 
 When(
+  /^submits the enrollment form$/,
+  submitAnyForm
+);
+
+When(
   /^she fills a password that fits within the password policy$/,
   enterValidPassword
 );
@@ -207,6 +213,11 @@ When(
 When(
   /^she selects "Skip" .*$/,
   skipForm
+);
+
+When(
+  /^she inputs an invalid phone number$/,
+  enterIncorrectPhoneNumberFormat
 );
 
 // When(

--- a/samples/test/support/action/enterIncorrectPhoneNumberFormat.ts
+++ b/samples/test/support/action/enterIncorrectPhoneNumberFormat.ts
@@ -1,0 +1,6 @@
+import EnrollPhoneAuthenticator from '../selectors/EnrollPhoneAuthenticator';
+import setInputField from './setInputField';
+
+export default async function () {
+  await setInputField('set', 'incorrectnumber', EnrollPhoneAuthenticator.phoneNumber);
+}


### PR DESCRIPTION
[OKTA-397411](https://oktainc.atlassian.net/browse/OKTA-397411)

```gherkin
Scenario: Mary signs up for an account with Password, sets up required Email factor, And sets up optional SMS with an invalid phone number
  Given Mary navigates to the Self Service Registration View
  When she fills out her First Name
  And she fills out her Last Name
  And she fills out her Email
    And she submits the registration form
  Then she sees the Select Authenticator page with password as the only option
  When she chooses password factor option
  # And she submits the select authenticator form
  Then she sees the set new password form
  And she fills out her Password
  And she confirms her Password
  And she submits the registration form
  Then she sees a list of available factors to setup
  When she selects Email
  Then she sees a page to input a code for email authenticator enrollment
  When she inputs the correct code from her email
    And she submits the form
  Then she sees a list of factors to register
  When She selects Phone from the list
  And she inputs an invalid phone number
  And submits the enrollment form
  Then she should see an error message "Unable to initiate factor enrollment: Invalid Phone Number."
  ```