### PR TITLE
feat: check if flow is supported - OKTA-406094

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#831](https://github.com/okta/okta-auth-js/pull/831) Calculates ID token expiry time based on local clock
 - [#832](https://github.com/okta/okta-auth-js/pull/832) Supports rotating refresh tokens
+- [#838](https://github.com/okta/okta-auth-js/pull/838) `idx.recoverPassword` - checks if flow is supported
 
 ### Bug Fixes
 

--- a/env/index.js
+++ b/env/index.js
@@ -1,3 +1,16 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
 const dotenv = require('dotenv');
 const yaml = require('js-yaml');
 const fs = require('fs');

--- a/lib/idx/authenticate.ts
+++ b/lib/idx/authenticate.ts
@@ -61,7 +61,7 @@ export type AuthenticationOptions = IdxOptions
 export async function authenticate(
   authClient: OktaAuth, options: AuthenticationOptions
 ): Promise<IdxTransaction> {
-  const flowMonitor = new AuthenticationFlowMonitor();
+  const flowMonitor = new AuthenticationFlowMonitor(authClient);
   return run(authClient, { 
     ...options, 
     flow,

--- a/lib/idx/flowMonitors/PasswordRecoveryFlowMonitor.ts
+++ b/lib/idx/flowMonitors/PasswordRecoveryFlowMonitor.ts
@@ -12,6 +12,7 @@
 
 
 import { FlowMonitor } from './FlowMonitor';
+import { getTransactionMeta } from '../transactionMeta';
 
 export class PasswordRecoveryFlowMonitor extends FlowMonitor {
   isRemediatorCandidate(remediator, remediations?, values?) {
@@ -32,5 +33,14 @@ export class PasswordRecoveryFlowMonitor extends FlowMonitor {
     }
 
     return super.isRemediatorCandidate(remediator, remediations, values);
+  }
+
+  async isFinished() {
+    const { remediations }  = await getTransactionMeta(this.authClient);
+    if (!remediations.includes('reset-authenticator')) {
+      return false;
+    }
+
+    return await super.isFinished();
   }
 }

--- a/lib/idx/recoverPassword.ts
+++ b/lib/idx/recoverPassword.ts
@@ -54,7 +54,7 @@ export type PasswordRecoveryOptions = IdxOptions
 export async function recoverPassword(
   authClient: OktaAuth, options: PasswordRecoveryOptions
 ): Promise<IdxTransaction> {
-  const flowMonitor = new PasswordRecoveryFlowMonitor();
+  const flowMonitor = new PasswordRecoveryFlowMonitor(authClient);
   return run(
     authClient, 
     { 

--- a/lib/idx/register.ts
+++ b/lib/idx/register.ts
@@ -65,7 +65,7 @@ export async function register(
     }
   }
   
-  const flowMonitor = new RegistrationFlowMonitor();
+  const flowMonitor = new RegistrationFlowMonitor(authClient);
   return run(authClient, { 
     ...options, 
     flow,

--- a/lib/idx/remediate.ts
+++ b/lib/idx/remediate.ts
@@ -174,7 +174,7 @@ export async function remediate(
     `);
   }
 
-  if (flowMonitor.shouldBreak(remediator)) {
+  if (flowMonitor.loopDetected(remediator)) {
     throw new AuthSdkError(`
       Remediation run into loop, break!!! remediation: ${remediator.getName()}
     `);
@@ -191,6 +191,9 @@ export async function remediate(
   const data = remediator.getData();
   try {
     idxResponse = await idxResponse.proceed(name, data);
+
+    // Track succeed remediations in the current transaction
+    await flowMonitor.trackRemediations(name);
     
     // Successfully get interaction code
     if (idxResponse.interactionCode) {

--- a/lib/types/Transaction.ts
+++ b/lib/types/Transaction.ts
@@ -48,6 +48,7 @@ export interface PKCETransactionMeta extends OAuthTransactionMeta {
 
 export interface IdxTransactionMeta extends PKCETransactionMeta {
   interactionHandle?: string;
+  remediations?: string[];
 }
 
 export type CustomAuthTransactionMeta = Record<string, string | undefined>;

--- a/samples/generated/express-embedded-auth-with-sdk/env/index.js
+++ b/samples/generated/express-embedded-auth-with-sdk/env/index.js
@@ -19,6 +19,7 @@ module.exports = function () {
     if (err.code === 'MODULE_NOT_FOUND') {
       // try local env module
       oktaEnv = require('./okta-env');
+      return oktaEnv;
     }
 
     throw err;

--- a/samples/generated/express-embedded-sign-in-widget/env/index.js
+++ b/samples/generated/express-embedded-sign-in-widget/env/index.js
@@ -19,6 +19,7 @@ module.exports = function () {
     if (err.code === 'MODULE_NOT_FOUND') {
       // try local env module
       oktaEnv = require('./okta-env');
+      return oktaEnv;
     }
 
     throw err;

--- a/samples/templates/partials/env.js
+++ b/samples/templates/partials/env.js
@@ -1,16 +1,3 @@
-/*!
- * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
- * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
- *
- * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * 
- * See the License for the specific language governing permissions and limitations under the License.
- */
-
-
 module.exports = function () {
   let oktaEnv;
   try {

--- a/samples/templates/partials/env.js
+++ b/samples/templates/partials/env.js
@@ -6,6 +6,7 @@ module.exports = function () {
     if (err.code === 'MODULE_NOT_FOUND') {
       // try local env module
       oktaEnv = require('./okta-env');
+      return oktaEnv;
     }
 
     throw err;

--- a/samples/templates/partials/express/oidc-middleware.js
+++ b/samples/templates/partials/express/oidc-middleware.js
@@ -1,16 +1,3 @@
-/*!
- * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
- * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
- *
- * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * 
- * See the License for the specific language governing permissions and limitations under the License.
- */
-
-
 // Handle OIDC callback. The request query will contain a code and state
 app.get('{{ redirectPath }}', function(req, res) {
   // also known as "authorization_code"

--- a/samples/templates/partials/spa/app.js
+++ b/samples/templates/partials/spa/app.js
@@ -1,16 +1,3 @@
-/*!
- * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
- * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
- *
- * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * 
- * See the License for the specific language governing permissions and limitations under the License.
- */
-
-
 // Begin sample SPA application
 
 // Default config. Properties here match the names of query parameters in the URL

--- a/scripts/maintain-banners.js
+++ b/scripts/maintain-banners.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 const bannerSourcePath = path.join(__dirname, 'license-template');
 // eslint-disable-next-line max-len
-const files = globby.sync(path.join(__dirname, '..','{lib/**/*.{js,ts},polyfill/**/*.{js,ts},test/**/*.{js,ts},samples/**/*.{js,ts},build/dist/*.js}'));
+const files = globby.sync(path.join(__dirname, '..','{lib/**/*.{js,ts},polyfill/**/*.{js,ts},test/**/*.{js,ts},samples/generated/**/*.{js,ts},build/dist/*.js,env/**/*.{js,ts}}'));
 const bannerSource = fs.readFileSync(bannerSourcePath).toString();
 const copyrightRegex = /(Copyright \(c\) )([0-9]+)-?([0-9]+)?/;
 

--- a/test/spec/idx/run.ts
+++ b/test/spec/idx/run.ts
@@ -210,7 +210,7 @@ describe('idx/run', () => {
       const { authClient, options } = testContext; 
       options.flowMonitor = {
         isFinished: jest.fn().mockResolvedValue(false)
-      }
+      };
 
       jest.spyOn(authClient.transactionManager, 'load');
       jest.spyOn(authClient.transactionManager, 'clear');


### PR DESCRIPTION
**This PR addresses:**
When using `idx.recoverPassword` method, tokens might be returned without ask the user to reset the password (basically just authentication flow has been executed), this behaviour confuses devs.

**Solution:**
Check if the key remediation (reset-authenticator) is proceeded before exchanging code for tokens. AuthSDKError is thrown if the key remediation is not called.
 
