### PR TITLE
Ag okta 408017 fix renew token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.2.1
+
+- [#845](https://github.com/okta/okta-auth-js/pull/845) Fixes issue with renewing using refresh tokens
+
 ## 5.2.0
 
 ### Features

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -195,6 +195,10 @@ export class TokenManager implements TokenManagerInterface {
   }
   
   setExpireEventTimeout(key, token) {
+    if (isRefreshToken(token)) {
+      return;
+    }
+
     var expireTime = this.getExpireTime(token);
     var expireEventWait = Math.max(expireTime - this.clock.now(), 0) * 1000;
   
@@ -216,9 +220,6 @@ export class TokenManager implements TokenManagerInterface {
         continue;
       }
       var token = tokenStorage[key];
-      if (isRefreshToken(token)) {
-        continue;
-      }
       this.setExpireEventTimeout(key, token);
     }
   }

--- a/lib/oidc/handleOAuthResponse.ts
+++ b/lib/oidc/handleOAuthResponse.ts
@@ -99,7 +99,7 @@ export function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res
       if (refreshToken) {
         tokenDict.refreshToken = {
           refreshToken: refreshToken,
-          expiresAt: Number(expiresIn) + now,
+          expiresAt: Number(expiresIn) + now, // should not be used, this is the accessToken expire time
           scopes: scopes,
           tokenUrl: urls.tokenUrl,
           authorizeUrl: urls.authorizeUrl,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/test/app/src/testApp.ts
+++ b/test/app/src/testApp.ts
@@ -329,7 +329,8 @@ class TestApp {
 
   async renewTokens(): Promise<void> {
     return this.oktaAuth.token.renewTokens()
-      .then(() => {
+      .then(tokens => {
+        this.oktaAuth.tokenManager.setTokens(tokens);
         this.render();
       });
   }

--- a/test/spec/TokenManager/expireEvents.ts
+++ b/test/spec/TokenManager/expireEvents.ts
@@ -1,3 +1,10 @@
+jest.mock('../../../lib/features', () => {
+  return {
+    isLocalhost: () => true, // to allow configuring expireEarlySeconds
+    isIE11OrLess: () => false
+  };
+});
+
 import { TokenManager } from '../../../lib/TokenManager';
 
 const Emitter = require('tiny-emitter');
@@ -25,7 +32,48 @@ describe('expire events', () => {
 
   function createInstance(options = null) {
     testContext.instance = new TokenManager(testContext.sdkMock, options);
+    jest.spyOn(testContext.instance.clock, 'now').mockReturnValue(0);
   }
+
+  describe('setExpireEventTimeout', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      createInstance({
+        expireEarlySeconds: 0
+      });
+    });
+    it('calls setTimeout', () => {
+      const expiresAt = testContext.instance.clock.now() + 10;
+      const accessToken = { accessToken: true, expiresAt };
+      testContext.instance.setExpireEventTimeout('accessToken', accessToken);
+      expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 10000);
+    });
+
+    it('does not set event for refresh tokens', () => {
+      const refreshToken = { refreshToken: true };
+      testContext.instance.setExpireEventTimeout('refreshToken', refreshToken);
+      expect(setTimeout).not.toHaveBeenCalled();
+    });
+
+    it('calls `clearExpireEventTimeout`', () => {
+      jest.spyOn(testContext.instance, 'clearExpireEventTimeout');
+      const expiresAt = testContext.instance.clock.now() + 10;
+      const accessToken = { accessToken: true, expiresAt };
+      testContext.instance.setExpireEventTimeout('accessToken', accessToken);
+      expect(testContext.instance.clearExpireEventTimeout).toHaveBeenCalledWith('accessToken');
+    });
+
+    it('calls `emitExpired` after timeout expires', () => {
+      jest.spyOn(testContext.instance, 'emitExpired');
+      const expiresAt = testContext.instance.clock.now() + 10;
+      const accessToken = { accessToken: true, expiresAt };
+      testContext.instance.setExpireEventTimeout('accessToken', accessToken);
+      jest.advanceTimersByTime(9000);
+      expect(testContext.instance.emitExpired).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(1001);
+      expect(testContext.instance.emitExpired).toHaveBeenCalledWith('accessToken', accessToken);
+    });
+  });
 
   describe('setExpireEventTimeoutAll', () => {
     beforeEach(() => {
@@ -44,18 +92,6 @@ describe('expire events', () => {
       expect(testContext.instance.setExpireEventTimeout).toHaveBeenNthCalledWith(1, 'a', a);
       expect(testContext.instance.setExpireEventTimeout).toHaveBeenNthCalledWith(2, 'b', b);
       expect(testContext.instance.setExpireEventTimeout).toHaveBeenNthCalledWith(3, 'c', c);
-    });
-    it('does not call `setExpireEventTimeout` if the value is a refreshToken', () => {
-      const a = { a: true };
-      const b = { b: true };
-      const c = { c: true, refreshToken: true };
-      testContext.storage = {
-        a, b, c
-      };
-      testContext.instance.setExpireEventTimeoutAll();
-      expect(testContext.instance.setExpireEventTimeout).toHaveBeenCalledTimes(2);
-      expect(testContext.instance.setExpireEventTimeout).toHaveBeenNthCalledWith(1, 'a', a);
-      expect(testContext.instance.setExpireEventTimeout).toHaveBeenNthCalledWith(2, 'b', b);
     });
   });
 


### PR DESCRIPTION
refresh token was attempted to be "renewed":
- "expiresAt" was placed on refresh token (but this value belongs to access token)
- refresh token would "renew" right after accessToken (since they had same expiresAt)

adds logic to setExpireEventTimeout to skip refresh tokens - the refresh token is returned when renewing the access token or id token.