### PR TITLE
fix: State not being returned when using getWithRedirect

### DIFF
--- a/lib/oidc/exchangeCodeForTokens.ts
+++ b/lib/oidc/exchangeCodeForTokens.ts
@@ -32,6 +32,7 @@ export function exchangeCodeForTokens(sdk: OktaAuth, tokenParams: TokenParams, u
     redirectUri,
     scopes,
     ignoreSignature,
+    state
   } = tokenParams;
 
   var getTokenOptions = {
@@ -52,12 +53,14 @@ export function exchangeCodeForTokens(sdk: OktaAuth, tokenParams: TokenParams, u
       if (scopes.indexOf('openid') !== -1) {
         responseType.push('id_token'); // an idToken will be returned if "openid" is in the scopes
       }
+      response.state = state;
       const handleResponseOptions: TokenParams = {
         clientId,
         redirectUri,
         scopes,
         responseType,
         ignoreSignature,
+        state,
       };
       return handleOAuthResponse(sdk, handleResponseOptions, response, urls)
         .then((response: TokenResponse) => {

--- a/lib/oidc/exchangeCodeForTokens.ts
+++ b/lib/oidc/exchangeCodeForTokens.ts
@@ -53,19 +53,18 @@ export function exchangeCodeForTokens(sdk: OktaAuth, tokenParams: TokenParams, u
       if (scopes.indexOf('openid') !== -1) {
         responseType.push('id_token'); // an idToken will be returned if "openid" is in the scopes
       }
-      response.state = state;
       const handleResponseOptions: TokenParams = {
         clientId,
         redirectUri,
         scopes,
         responseType,
         ignoreSignature,
-        state,
       };
       return handleOAuthResponse(sdk, handleResponseOptions, response, urls)
         .then((response: TokenResponse) => {
           // For compatibility, "code" is returned in the TokenResponse. OKTA-326091
           response.code = authorizationCode;
+          response.state = state;
           return response;
         });
     })

--- a/lib/oidc/handleOAuthResponse.ts
+++ b/lib/oidc/handleOAuthResponse.ts
@@ -55,8 +55,7 @@ export function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res
             authorizationCode: res.code,
             interactionCode: res.interaction_code
           }), urls);
-        })
-
+        });
   }
 
   tokenParams = tokenParams || getDefaultTokenParams(sdk);

--- a/lib/oidc/handleOAuthResponse.ts
+++ b/lib/oidc/handleOAuthResponse.ts
@@ -48,10 +48,15 @@ export function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res
   // The result contains an authorization_code and PKCE is enabled 
   // `exchangeCodeForTokens` will call /token then call `handleOauthResponse` recursively with the result
   if (pkce && (res.code || res.interaction_code)) {
-    return exchangeCodeForTokens(sdk, Object.assign({}, tokenParams, {
-      authorizationCode: res.code,
-      interactionCode: res.interaction_code
-    }), urls);
+    return Promise.resolve()
+        .then(function () {
+          validateResponse(res, tokenParams);
+          return exchangeCodeForTokens(sdk, Object.assign({}, tokenParams, {
+            authorizationCode: res.code,
+            interactionCode: res.interaction_code
+          }), urls);
+        })
+
   }
 
   tokenParams = tokenParams || getDefaultTokenParams(sdk);

--- a/test/spec/oidc/util/handleOAuthResponse.ts
+++ b/test/spec/oidc/util/handleOAuthResponse.ts
@@ -167,7 +167,7 @@ describe('handleOAuthResponse', () => {
 
     describe('Authorization code flow', () => {
       it('calls `exchangeCodeForTokens` if response contains "code"', async () => {
-        const res = await handleOAuthResponse(sdk, undefined, { code: 'blah' }, undefined);
+        const res = await handleOAuthResponse(sdk, {}, { code: 'blah' }, undefined);
         expect(exchangeCodeForTokens).toHaveBeenCalledWith(sdk, {
           authorizationCode: 'blah',
           interactionCode: undefined
@@ -178,7 +178,7 @@ describe('handleOAuthResponse', () => {
 
     describe('Interaction code flow', () => {
       it('calls `exchangeCodeForTokens` if response contains "interaction_code"', async () => {
-        const res = await handleOAuthResponse(sdk, undefined, { 'interaction_code': 'blah' }, undefined);
+        const res = await handleOAuthResponse(sdk, {}, { 'interaction_code': 'blah' }, undefined);
         expect(exchangeCodeForTokens).toHaveBeenCalledWith(sdk, {
           authorizationCode: undefined,
           interactionCode: 'blah'


### PR DESCRIPTION
The state that you passed in to `getWithRedirect` was not being returned, making it impossible to implement in the recommended way redirecting to the original URI the user was on. This resolves the issue by putting validation back in before exchanging the code for a token, and putting the `state` onto the response returned by `getWithRedirect`.

This seems like an Obvious Fix to me.