### PR TITLE
chore: correct parseFromUrl signature in type definitions (#763 copy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - [#852](https://github.com/okta/okta-auth-js/pull/852) Skips non-successful requests cacheing
 
+### Other
+
+- [#853](https://github.com/okta/okta-auth-js/pull/853) Updates `token.parseFromUrl` signature (adds optional parameter)
+
 ## 5.2.0
 
 ### Features

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -124,7 +124,7 @@ export interface ParseFromUrlOptions {
   responseMode?: string;
 }
 
-export type ParseFromUrlFunction = () => Promise<TokenResponse>;
+export type ParseFromUrlFunction = (options?: string | ParseFromUrlOptions) => Promise<TokenResponse>;
 
 export interface ParseFromUrlInterface extends ParseFromUrlFunction {
   _getDocument: () => Document;

--- a/test/types/parseFromUrl.test-d.ts
+++ b/test/types/parseFromUrl.test-d.ts
@@ -1,0 +1,26 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+import {
+  OktaAuth, TokenResponse
+} from '@okta/okta-auth-js';
+import { expectType } from 'tsd';
+
+const authClient = new OktaAuth({});
+(async () => {
+  expectType<TokenResponse>(await authClient.token.parseFromUrl());
+  expectType<TokenResponse>(await authClient.token.parseFromUrl({
+    url: 'http://org.com?token',
+    responseMode: 'query'
+  }));
+})();


### PR DESCRIPTION
Copy of https://github.com/okta/okta-auth-js/pull/763 for internal CI