### PR TITLE
fix: verify token using issuer from .well-known endpoint

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,7 @@
       "name": "sdk: e2e spec",
       "type": "node",
       "request": "launch",
-      "args": ["wdio.conf.ts", "--spec", "${file}"],
+      "args": ["wdio.conf.js", "--spec", "${file}"],
       "cwd": "${workspaceFolder}/test/e2e",
       "autoAttachChildProcesses": true,
       "program": "${workspaceRoot}/test/e2e/node_modules/@wdio/cli/bin/wdio.js",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.2.2
 
 - [#862](https://github.com/okta/okta-auth-js/pull/862) Fixes issue with untranspiled `class` keyword
+- [#858](https://github.com/okta/okta-auth-js/pull/858) Fixes issue with verifying tokens when using a proxied issuer
 
 ## 5.2.1
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ require('@okta/okta-auth-js/polyfill');
 The built polyfill bundle is also available on our global CDN. Include the following script in your HTML file to load before any other scripts:
 
 ```html
-<script src="https://global.oktacdn.com/okta-auth-js/4.0.0/okta-auth-js.polyfill.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-auth-js/5.2.2/okta-auth-js.polyfill.js" type="text/javascript"></script>
 ```
 
 > :warning: The version shown in this sample may be older than the current version. We recommend using the highest version available
@@ -168,7 +168,7 @@ If you are using the JS on a web page from the browser, you can copy the `node_m
 The built library bundle is also available on our global CDN. Include the following script in your HTML file to load before your application script:
 
 ```html
-<script src="https://global.oktacdn.com/okta-auth-js/4.0.0/okta-auth-js.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-auth-js/5.2.2/okta-auth-js.min.js" type="text/javascript"></script>
 ```
 
 > :warning: The version shown in this sample may be older than the current version. We recommend using the highest version available

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -31,7 +31,8 @@ import {
   StorageProvider,
   TokenManagerErrorEventHandler,
   TokenManagerEventHandler,
-  TokenManagerInterface
+  TokenManagerInterface,
+  RefreshToken
 } from './types';
 import { ID_TOKEN_STORAGE_KEY, ACCESS_TOKEN_STORAGE_KEY, REFRESH_TOKEN_STORAGE_KEY } from './constants';
 import { TokenService } from './services/TokenService';
@@ -426,6 +427,17 @@ export class TokenManager implements TokenManagerInterface {
     }
     return tokens;
   }
+
+  updateRefreshToken(token: RefreshToken) {
+    const key = this.getStorageKeyByType('refreshToken') || REFRESH_TOKEN_STORAGE_KEY;
+
+    // do not emit any event
+    var tokenStorage = this.storage.getStorage();
+    validateToken(token);
+    tokenStorage[key] = token;
+    this.storage.setStorage(tokenStorage);
+  }
+  
 }
 
 if (isLocalhost()) {

--- a/lib/oidc/renewTokensWithRefresh.ts
+++ b/lib/oidc/renewTokensWithRefresh.ts
@@ -12,7 +12,7 @@
  */
 import { AuthSdkError } from '../errors';
 import { getOAuthUrls } from './util/oauth';
-import { isSameRefreshToken, updateRefreshToken } from './util/refreshToken';
+import { isSameRefreshToken } from './util/refreshToken';
 import { OktaAuth, TokenParams, RefreshToken, Tokens } from '../types';
 import { handleOAuthResponse } from './handleOAuthResponse';
 import { postRefreshToken } from './endpoints/token';
@@ -37,7 +37,7 @@ export async function renewTokensWithRefresh(
   // Support rotating refresh tokens
   const { refreshToken } = tokens;
   if (refreshToken && !isSameRefreshToken(refreshToken, refreshTokenObject)) {
-    updateRefreshToken(sdk, refreshToken);
+    sdk.tokenManager.updateRefreshToken(refreshToken);
   }
 
   return tokens;

--- a/lib/oidc/util/refreshToken.ts
+++ b/lib/oidc/util/refreshToken.ts
@@ -1,21 +1,5 @@
-import { RefreshToken, OktaAuth } from '../../types';
+import { RefreshToken } from '../../types';
 import { isAuthApiError } from '../../errors';
-import { REFRESH_TOKEN_STORAGE_KEY } from '../../constants';
-
-export function updateRefreshToken(sdk: OktaAuth, refreshToken: RefreshToken) {
-  const refreshTokenKey = sdk.tokenManager.getStorageKeyByType('refreshToken') || REFRESH_TOKEN_STORAGE_KEY;
-  sdk.tokenManager.add(refreshTokenKey, refreshToken);
-}
-
-export function getRefreshToken(sdk: OktaAuth) {
-  const tokens = sdk.tokenManager.getTokensSync();
-  return tokens.refreshToken;
-}
-
-export function hasRefreshToken(sdk: OktaAuth) {
-  return !!getRefreshToken(sdk);
-}
-
 
 export function isSameRefreshToken(a: RefreshToken, b: RefreshToken) {
   return (a.refreshToken === b.refreshToken);

--- a/lib/types/TokenManager.ts
+++ b/lib/types/TokenManager.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { Token, Tokens, TokenType } from './Token';
+import { RefreshToken, Token, Tokens, TokenType } from './Token';
 
 export interface TokenManagerError {
   errorSummary: string;
@@ -20,4 +20,5 @@ export interface TokenManagerInterface {
   setTokens({ accessToken, idToken, refreshToken }: Tokens, accessTokenCb?: Function, idTokenCb?: Function, refreshTokenCb?: Function): void;
   getStorageKeyByType(type: TokenType): string;
   add(key: any, token: Token): void;
+  updateRefreshToken(token: RefreshToken);
 }

--- a/test/app/package.json
+++ b/test/app/package.json
@@ -22,6 +22,7 @@
     "babel-loader": "^8.0.6",
     "btoa": "^1.2.1",
     "express": "^4.17.1",
+    "http-proxy-middleware": "^2.0.1",
     "js-cookie": "2.2.1",
     "source-map-loader": "^0.2.4",
     "webpack": "^4.29.6",

--- a/test/app/server/index.js
+++ b/test/app/server/index.js
@@ -15,6 +15,7 @@
 
 require('@okta/env').setEnvironmentVarsFromTestEnv(); // Set environment variables from "testenv" file
 
+const createProxyMiddleware = require('./proxyMiddleware');
 const loginMiddleware = require('./loginMiddleware');
 const callbackMiddleware = require('./callbackMiddleware');
 const renderWidget = require('./renderWidget');
@@ -30,10 +31,15 @@ const app = express();
 const config = require('../webpack.config.js');
 const compiler = webpack(config);
 
+// Set a proxy in front of Okta
+const proxyMiddleware = createProxyMiddleware();
+app.use('/oauth2', proxyMiddleware);
+app.use('/app', proxyMiddleware);
+
 // Tell express to use the webpack-dev-middleware and use the webpack.config.js
 // configuration file as a base.
 app.use(webpackDevMiddleware(compiler, {
-  publicPath: config.output.publicPath,
+  publicPath: config.output.publicPath
 }));
 
 app.use(express.static('./public'));

--- a/test/app/server/proxyMiddleware.js
+++ b/test/app/server/proxyMiddleware.js
@@ -1,0 +1,10 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function proxyMiddlewareFactory(options) {
+  const { origin } = new URL(process.env.ISSUER);
+  return createProxyMiddleware(Object.assign({
+    target: origin,
+    secure: false,
+    changeOrigin: true,
+  }, options));
+};

--- a/test/e2e/pageobjects/TestApp.js
+++ b/test/e2e/pageobjects/TestApp.js
@@ -25,6 +25,7 @@ class TestApp {
   get logoutXHRBtn() { return $('#logout-xhr'); }
   get logoutAppBtn() { return $('#logout-app'); }
   get renewTokenBtn() { return $('#renew-token'); }
+  get renewTokensBtn() { return $('#renew-tokens'); }
   get revokeTokenBtn() { return $('#revoke-token'); }
   get revokeRefreshTokenBtn() { return $('#revoke-refresh-token'); }
   get getTokenBtn() { return $('#get-token'); }
@@ -107,11 +108,19 @@ class TestApp {
     await this.loginDirectBtn.then(el => el.click());
   }
 
+  // renew the accessToken, using refreshToken if available
   async renewToken() {
     const btn = await this.renewTokenBtn;
     await btn.click();
   }
 
+  // renew all tokens, using refreshToken if available
+  async renewTokens() {
+    const btn = await this.renewTokensBtn;
+    await btn.click();
+  }
+
+  // get all tokens using getWithoutPrompt. Requires 3rd-party cookies
   async getToken() {
     return this.getTokenBtn.then(el => el.click());
   }
@@ -261,6 +270,11 @@ class TestApp {
     assert(txt === msg);
   }
 
+  async assertIssuer(issuer) {
+    await this.issuer.then(el => el.getText()).then(txt => {
+      assert(txt === issuer);
+    });
+  }
 }
 
 export default new TestApp();

--- a/test/e2e/specs/proxy.js
+++ b/test/e2e/specs/proxy.js
@@ -1,0 +1,78 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import assert from 'assert';
+import TestApp from '../pageobjects/TestApp';
+import { openPKCE } from '../util/appUtils';
+import { loginRedirect } from '../util/loginUtils';
+import { getIssuer, getBaseUrl } from '../util/browserUtils';
+
+describe('E2E through proxy', () => {
+  beforeEach(async function bootstrap() {
+    const issuer = getIssuer().replace(getBaseUrl(), 'http://localhost:8080');
+    await openPKCE({
+      issuer
+    });
+    await TestApp.issuer.then(el => el.getValue()).then(val => {
+      assert(val.indexOf('http://localhost') === 0);
+    });
+    await loginRedirect('pkce');
+  });
+
+  afterEach(async function teardown() {
+    await TestApp.logoutRedirect();
+  });
+
+  it('can login and receive tokens', async () => {
+    await TestApp.assertLoggedIn();
+  });
+
+  it('can renew all tokens (using refresh token)', async () => {
+    if (!process.env.REFRESH_TOKEN) {
+      return;
+    }
+    const prev = {
+      idToken: await TestApp.idToken.then(el => el.getText()),
+      accessToken: await TestApp.accessToken.then(el => el.getText())
+    };
+    await TestApp.renewTokens();
+    await browser.waitUntil(async () => {
+      const idToken = await TestApp.idToken.then(el => el.getText());
+      const accessToken = await TestApp.accessToken.then(el => el.getText());
+      return (
+        idToken !== prev.idToken &&
+        accessToken !== prev.accessToken
+      );
+    }, 10000);
+    await TestApp.assertLoggedIn();
+  });
+  
+  // TODO: is this possible?
+  // eslint-disable-next-line jasmine/no-disabled-tests
+  xit('can refresh all tokens using getWithoutPrompt', async () => {
+    const prev = {
+      idToken: await TestApp.idToken.then(el => el.getText()),
+      accessToken: await TestApp.accessToken.then(el => el.getText())
+    };
+    await TestApp.getToken();
+    await browser.waitUntil(async () => {
+      const idToken = await TestApp.idToken.then(el => el.getText());
+      const accessToken = await TestApp.accessToken.then(el => el.getText());
+      return (
+        idToken !== prev.idToken &&
+        accessToken !== prev.accessToken
+      );
+    }, 10000);
+    await TestApp.assertLoggedIn();
+  });
+
+});

--- a/test/e2e/specs/refreshTokens.js
+++ b/test/e2e/specs/refreshTokens.js
@@ -54,7 +54,7 @@ describe('E2E token flows', () => {
     await TestApp.logoutRedirect();
   });
   
-  it('can refresh all tokens', async () => {
+  it('can refresh all tokens using getWithoutPrompt', async () => {
     await loginPopup(flow);
     const prev = {
       idToken: await TestApp.idToken.then(el => el.getText()),
@@ -62,6 +62,28 @@ describe('E2E token flows', () => {
       refreshToken: await TestApp.refreshToken.then(el => el.getText())
     };
     await TestApp.getToken();
+    await browser.waitUntil(async () => {
+      const idToken = await TestApp.idToken.then(el => el.getText());
+      const accessToken = await TestApp.accessToken.then(el => el.getText());
+      const refreshToken = await TestApp.refreshToken.then(el => el.getText());
+      return (
+        idToken !== prev.idToken &&
+        accessToken !== prev.accessToken && 
+        refreshToken !== prev.refreshToken 
+      );
+    }, 10000);
+    await TestApp.assertLoggedIn();
+    await TestApp.logoutRedirect();
+  });
+
+  it('can renew all tokens', async () => {
+    await loginPopup(flow);
+    const prev = {
+      idToken: await TestApp.idToken.then(el => el.getText()),
+      accessToken: await TestApp.accessToken.then(el => el.getText()),
+      refreshToken: await TestApp.refreshToken.then(el => el.getText())
+    };
+    await TestApp.renewTokens();
     await browser.waitUntil(async () => {
       const idToken = await TestApp.idToken.then(el => el.getText());
       const accessToken = await TestApp.accessToken.then(el => el.getText());

--- a/test/e2e/util/appUtils.js
+++ b/test/e2e/util/appUtils.js
@@ -33,15 +33,16 @@ async function openImplicit(options) {
 }
 
 async function openPKCE(options) {
-  await TestApp.open(Object.assign({ issuer: ISSUER, clientId: CLIENT_ID, pkce: true }, options));
+  options = Object.assign({ issuer: ISSUER, clientId: CLIENT_ID, pkce: true }, options);
+  await TestApp.open(options);
   await TestApp.pkceOption.then(el => el.isSelected()).then(isSelected => {
     assert(isSelected);
   });
   await TestApp.issuer.then(el => el.getValue()).then(val => {
-    assert(val === ISSUER);
+    assert(val === options.issuer);
   });
   await TestApp.clientId.then(el => el.getValue()).then(val => {
-    assert(val === CLIENT_ID);
+    assert(val === options.clientId);
   });
 }
 

--- a/test/e2e/util/browserUtils.js
+++ b/test/e2e/util/browserUtils.js
@@ -18,6 +18,14 @@ const ISSUER = process.env.ISSUER;
 const issuer = URL.parse(ISSUER);
 const BASE_URL = issuer.protocol + '//' + issuer.host;
 
+function getIssuer() {
+  return ISSUER;
+}
+
+function getBaseUrl() {
+  return BASE_URL;
+}
+
 async function openOktaHome() {
   return browser.newWindow(BASE_URL, 'Okta-hosted page');
 }
@@ -42,6 +50,8 @@ async function switchToLastFocusedWindow() {
 }
 
 export { 
+  getIssuer,
+  getBaseUrl,
   openOktaHome, 
   switchToMainWindow, 
   switchToPopupWindow,

--- a/test/e2e/wdio.conf.js
+++ b/test/e2e/wdio.conf.js
@@ -26,8 +26,18 @@ const browserOptions = {
 };
 
 /* eslint-disable max-len */
-const specs = (REFRESH_TOKEN && !ORG_OIE_ENABLED) ? ['./specs/**/refreshTokens.js', './specs/**/crossTabs.js'] : ['./specs/**/*.js'];
-const excludeSpecs = (REFRESH_TOKEN || ORG_OIE_ENABLED) ? [] : ['./specs/**/refreshTokens.js'];
+const specs = (REFRESH_TOKEN && !ORG_OIE_ENABLED) ? [
+// refresh token on classic
+  './specs/**/refreshTokens.js',
+  './specs/**/crossTabs.js',
+  './specs/**/proxy.js'
+] : [
+// all other cases, classic or OIE (with or w/out refresh token)
+  './specs/**/*.js'
+];
+
+// exclude refreshTokens spec from classic org w/out refresh token flag
+const excludeSpecs = (!REFRESH_TOKEN && !ORG_OIE_ENABLED) ? ['./specs/**/refreshTokens.js'] : [];
 
 if (CI) {
     browserOptions.args = browserOptions.args.concat([
@@ -44,7 +54,7 @@ if (CI) {
 
 // driver version must match installed chrome version
 // https://chromedriver.storage.googleapis.com/index.html
-const CHROMEDRIVER_VERSION = '89.0.4389.23';
+const CHROMEDRIVER_VERSION = process.env.CHROMEDRIVER_VERSION || '89.0.4389.23';
 const drivers = {
   chrome: { version: CHROMEDRIVER_VERSION }
 };

--- a/test/spec/oidc/renewTokensWithRefresh.ts
+++ b/test/spec/oidc/renewTokensWithRefresh.ts
@@ -93,14 +93,14 @@ describe('renewTokensWithRefresh', function () {
       'A clientId must be specified in the OktaAuth constructor to renew tokens');
   });
 
-  it('saves refresh token if a different refresh token is returned', async () => {
+  it('saves refresh token if a different refresh token is returned, but does not trigger "add" event', async () => {
     const { authInstance } = testContext;
     authInstance.tokenManager.add('refreshToken', tokens.standardRefreshTokenParsed);
     let refreshToken = await authInstance.tokenManager.get('refreshToken');
     expect(refreshToken).toEqual(tokens.standardRefreshTokenParsed);
     jest.spyOn(authInstance.tokenManager, 'add');
     await authInstance.token.renewTokens();
-    expect(authInstance.tokenManager.add).toHaveBeenCalledWith('refreshToken', tokens.standardRefreshToken2Parsed);
+    expect(authInstance.tokenManager.add).not.toHaveBeenCalled();
     refreshToken = await authInstance.tokenManager.get('refreshToken');
     expect(refreshToken).toEqual(tokens.standardRefreshToken2Parsed);
   });
@@ -131,14 +131,14 @@ describe('renewTokensWithRefresh', function () {
     expect(refreshToken).toEqual(tokens.standardRefreshTokenParsed);
   });
 
-  it('supports rotating refresh tokens with custom key names', async () => {
+  it('supports rotating refresh tokens with custom key names (and does not fire "add" event)', async () => {
     const { authInstance } = testContext;
     authInstance.tokenManager.add('refreshToken2', tokens.standardRefreshTokenParsed);
     let refreshToken = await authInstance.tokenManager.get('refreshToken2');
     expect(refreshToken).toEqual(tokens.standardRefreshTokenParsed);
     jest.spyOn(authInstance.tokenManager, 'add');
     await authInstance.token.renewTokens();
-    expect(authInstance.tokenManager.add).toHaveBeenCalledWith('refreshToken2', tokens.standardRefreshToken2Parsed);
+    expect(authInstance.tokenManager.add).not.toHaveBeenCalled();
     refreshToken = await authInstance.tokenManager.get('refreshToken2');
     expect(refreshToken).toEqual(tokens.standardRefreshToken2Parsed);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2067,6 +2067,13 @@
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
   integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
 
+"@types/http-proxy@^1.17.5":
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.7.tgz#30ea85cc2c868368352a37f0d0d3581e24834c6f"
+  integrity sha512-9hdj6iXH64tHSLTY+Vt2eYOGzSogC+JQ2H7bdPWkuh7KXP5qLllWx++t+K9Wk556c3dkDdPws/SpMRi0sdCT1w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/inquirer@^7.3.1":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-7.3.2.tgz#35d2ef4d98dd42feeb4e1256cdeb9f13f457d420"
@@ -8237,7 +8244,18 @@ http-proxy-middleware@0.19.1:
     lodash "^4.17.11"
     micromatch "^3.1.10"
 
-http-proxy@^1.17.0:
+http-proxy-middleware@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz#7ef3417a479fb7666a571e09966c66a39bd2c15f"
+  integrity sha512-cfaXRVoZxSed/BmkA7SwBVNI9Kj7HFltaE5rqYOub5kWzWZ+gofV2koVN1j2rMW7pEfSSlCHGJ31xmuyFyfLOg==
+  dependencies:
+    "@types/http-proxy" "^1.17.5"
+    http-proxy "^1.18.1"
+    is-glob "^4.0.1"
+    is-plain-obj "^3.0.0"
+    micromatch "^4.0.2"
+
+http-proxy@^1.17.0, http-proxy@^1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
   integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
@@ -8864,6 +8882,11 @@ is-plain-obj@^2.0.0, is-plain-obj@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
+is-plain-obj@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
+  integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
 
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
- also fixes duplicate "add" event fired from updating rotating refresh token
- adds a proxy to test/app e2e and proxy specs