### PR TITLE
fix: token renew causes false authState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.2.2
+
+### Bug Fixes
+
+- [#860](https://github.com/okta/okta-auth-js/pull/860) Fixes false-positive `authState.isAuthenticated` during auto renew process
+
 ## 5.2.1
 
 - [#845](https://github.com/okta/okta-auth-js/pull/845) Fixes issue with renewing using refresh tokens

--- a/lib/AuthStateManager.ts
+++ b/lib/AuthStateManager.ts
@@ -11,25 +11,13 @@
  */
 
 
+import { default as debounce } from 'debounce';
 import { AuthSdkError } from './errors';
 import { AuthState, AuthStateLogOptions } from './types';
 import { OktaAuth } from '.';
 import { getConsole } from './util';
 import { EVENT_ADDED, EVENT_REMOVED } from './TokenManager';
 const PCancelable = require('p-cancelable');
-
-function debounce(fn, timeout){
-  let timer;
-  return (...args) => {
-    if (!timer) {
-      fn.apply(this, args);
-    }
-    clearTimeout(timer);
-    timer = setTimeout(() => {
-      timer = undefined;
-    }, timeout);
-  };
-}
 
 export const INITIAL_AUTH_STATE = null;
 const DEFAULT_PENDING = {
@@ -38,6 +26,7 @@ const DEFAULT_PENDING = {
 };
 const EVENT_AUTH_STATE_CHANGE = 'authStateChange';
 const MAX_PROMISE_CANCEL_TIMES = 10;
+const DEBOUNCE_TIMEOUT = 300;
 
 // only compare first level of authState
 const isSameAuthState = (prevState: AuthState, state: AuthState) => {
@@ -78,11 +67,11 @@ export class AuthStateManager {
     sdk.tokenManager.on(EVENT_ADDED, debounce((key, token) => {
       this._setLogOptions({ event: EVENT_ADDED, key, token });
       this.updateAuthState();
-    }, 300));
+    }, DEBOUNCE_TIMEOUT));
     sdk.tokenManager.on(EVENT_REMOVED, debounce((key, token) => {
       this._setLogOptions({ event: EVENT_REMOVED, key, token });
       this.updateAuthState();
-    }, 300));
+    }, DEBOUNCE_TIMEOUT));
   }
 
   _setLogOptions(options) {

--- a/lib/AuthStateManager.ts
+++ b/lib/AuthStateManager.ts
@@ -18,6 +18,19 @@ import { getConsole } from './util';
 import { EVENT_ADDED, EVENT_REMOVED } from './TokenManager';
 const PCancelable = require('p-cancelable');
 
+function debounce(fn, timeout){
+  let timer;
+  return (...args) => {
+    if (!timer) {
+      fn.apply(this, args);
+    }
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = undefined;
+    }, timeout);
+  };
+}
+
 export const INITIAL_AUTH_STATE = null;
 const DEFAULT_PENDING = {
   updateAuthStatePromise: null,
@@ -62,14 +75,14 @@ export class AuthStateManager {
     // Listen on tokenManager events to start updateState process
     // "added" event is emitted in both add and renew process
     // Only listen on "added" event to update auth state
-    sdk.tokenManager.on(EVENT_ADDED, (key, token) => {
+    sdk.tokenManager.on(EVENT_ADDED, debounce((key, token) => {
       this._setLogOptions({ event: EVENT_ADDED, key, token });
       this.updateAuthState();
-    });
-    sdk.tokenManager.on(EVENT_REMOVED, (key, token) => {
+    }, 300));
+    sdk.tokenManager.on(EVENT_REMOVED, debounce((key, token) => {
       this._setLogOptions({ event: EVENT_REMOVED, key, token });
       this.updateAuthState();
-    });
+    }, 300));
   }
 
   _setLogOptions(options) {

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -481,7 +481,7 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
     let { accessToken, idToken } = this.tokenManager.getTokensSync();
     const { autoRenew, autoRemove } = this.options.tokenManager || {};
 
-    if (accessToken && this.tokenManager.hasExpired(accessToken)) {
+    if (accessToken && this.tokenManager.hasExpired(accessToken, false)) {
       accessToken = null;
       if (autoRenew) {
         accessToken = await this.tokenManager.renew('accessToken') as AccessToken;
@@ -490,7 +490,7 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
       }
     }
 
-    if (idToken && this.tokenManager.hasExpired(idToken)) {
+    if (idToken && this.tokenManager.hasExpired(idToken, false)) {
       idToken = null;
       if (autoRenew) {
         idToken = await this.tokenManager.renew('idToken') as IDToken;

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -127,13 +127,15 @@ export class TokenManager implements TokenManagerInterface {
     return clone(this.options);
   }
   
-  getExpireTime(token) {
-    var expireTime = token.expiresAt - this.options.expireEarlySeconds;
+  getExpireTime(token, useExpireEarlyOption = true) {
+    const expireTime = useExpireEarlyOption 
+      ? token.expiresAt - this.options.expireEarlySeconds 
+      : token.expiresAt;
     return expireTime;
   }
   
-  hasExpired(token) {
-    var expireTime = this.getExpireTime(token);
+  hasExpired(token, useExpireEarlyOption = true) {
+    var expireTime = this.getExpireTime(token, useExpireEarlyOption);
     return expireTime <= this.clock.now();
   }
   

--- a/lib/services/TokenService.ts
+++ b/lib/services/TokenService.ts
@@ -29,19 +29,6 @@ function shouldThrottleRenew(renewTimeQueue) {
   return res;
 }
 
-function debounce(fn, timeout){
-  let timer;
-  return (...args) => {
-    if (!timer) {
-      fn.apply(this, args);
-    }
-    clearTimeout(timer);
-    timer = setTimeout(() => {
-      timer = undefined;
-    }, timeout);
-  };
-}
-
 export class TokenService {
   private tokenManager: TokenManager;
   private options: TokenManagerOptions;
@@ -68,7 +55,7 @@ export class TokenService {
         this.tokenManager.remove(key);
       }
     };
-    this.tokenManager.on(EVENT_EXPIRED, debounce(this.onTokenExpiredHandler, 500));
+    this.tokenManager.on(EVENT_EXPIRED, this.onTokenExpiredHandler);
 
     this.tokenManager.setExpireEventTimeoutAll();
 

--- a/lib/services/TokenService.ts
+++ b/lib/services/TokenService.ts
@@ -29,6 +29,19 @@ function shouldThrottleRenew(renewTimeQueue) {
   return res;
 }
 
+function debounce(fn, timeout){
+  let timer;
+  return (...args) => {
+    if (!timer) {
+      fn.apply(this, args);
+    }
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = undefined;
+    }, timeout);
+  };
+}
+
 export class TokenService {
   private tokenManager: TokenManager;
   private options: TokenManagerOptions;
@@ -55,7 +68,7 @@ export class TokenService {
         this.tokenManager.remove(key);
       }
     };
-    this.tokenManager.on(EVENT_EXPIRED, this.onTokenExpiredHandler);
+    this.tokenManager.on(EVENT_EXPIRED, debounce(this.onTokenExpiredHandler, 500));
 
     this.tokenManager.setExpireEventTimeoutAll();
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "btoa": "^1.2.1",
     "core-js": "^3.6.5",
     "cross-fetch": "^3.0.6",
+    "debounce": "^1.2.1",
     "js-cookie": "2.2.1",
     "node-cache": "^5.1.2",
     "p-cancelable": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/test/spec/AuthStateManager.js
+++ b/test/spec/AuthStateManager.js
@@ -290,7 +290,7 @@ describe('AuthStateManager', () => {
       const auth = createAuth();
       jest.spyOn(auth.authStateManager, 'updateAuthState');
       // add tokens async
-      auth.tokenManager.add('idToken', tokens.standardIdTokenParsed)
+      auth.tokenManager.add('idToken', tokens.standardIdTokenParsed);
       await wait(100);
       auth.tokenManager.add('accessToken', tokens.standardAccessTokenParsed);
       auth.authStateManager.subscribe((authState) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5415,6 +5415,11 @@ dateformat@^3.0.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+debounce@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
Fix solution:

* Check token expiration based on raw expiration (w/o expireEarlySeconds) during authState evaluation. This change handles scenario that when tokens renew are triggered at almost the same time (sdk thinks both tokens are expired based on expireEarlySeconds), AuthStateManager emits false-positive state when in the middle of the process only one token is renewed. 
* Add `debounce` logic to AuthStateManager event listener to only emit one `authStateChange` event if multiple token changes happen in a very short time span.