### PR TITLE
Use /.well-known/openid-configuration issuer attribute for id_token validation

### DIFF
--- a/lib/oidc/verifyToken.ts
+++ b/lib/oidc/verifyToken.ts
@@ -35,7 +35,7 @@ export async function verifyToken(sdk: OktaAuth, token: IDToken, validationParam
   }
 
   var validationOptions: TokenVerifyParams = {
-    issuer: openIdConfig.issuer, // sdk.options.issuer may point to a proxy. Use "real" issuer for validation.
+    issuer: openIdConfig.issuer,
     clientId: sdk.options.clientId,
     ignoreSignature: sdk.options.ignoreSignature
   };

--- a/lib/oidc/verifyToken.ts
+++ b/lib/oidc/verifyToken.ts
@@ -30,6 +30,10 @@ export async function verifyToken(sdk: OktaAuth, token: IDToken, validationParam
 
   var openIdConfig = await getWellKnown(sdk); // using sdk.options.issuer
 
+  if (validationParams.issuer !== openIdConfig.issuer) {
+    validationParams.issuer = openIdConfig.issuer;
+  }
+
   var validationOptions: TokenVerifyParams = {
     issuer: openIdConfig.issuer, // sdk.options.issuer may point to a proxy. Use "real" issuer for validation.
     clientId: sdk.options.clientId,


### PR DESCRIPTION
This change is based on a previous pull request made by @scottirvinsonos (https://github.com/okta/okta-auth-js/pull/555), however, his implementation seems to have been lost when the code was refactored.

---

Other Okta SDK's use the issuer URL found in the /.well-known/openid-configuration response body when validating the id_token. This SDK currently uses the URL specified in the config object passed to the constructor at the time the OAuth client object is instantiated. This is not desirable as it makes it impossible to use a proxy with Okta.

The change made uses the issuer attribute found in the /.well-known/openid-configuration response body and compares it to the issuer claim in the id_token to validate the token.