### PR TITLE
Fixed Readme yarn paths (copy)

### DIFF
--- a/samples/generated/express-web-no-oidc/README.md
+++ b/samples/generated/express-web-no-oidc/README.md
@@ -9,7 +9,7 @@ By default the app server runs at `http://localhost:8080`.
 
 ## Commands
 
-If running from the workspace directory, add the `--cwd` option: `yarn --cwd samples/express-web-no-oidc start`
+If running from the workspace directory, add the `--cwd` option: `yarn --cwd samples/generated/express-web-no-oidc start`
 
 | Command               | Description                    |
 | --------------------- | ------------------------------ |

--- a/samples/generated/express-web-with-oidc/README.md
+++ b/samples/generated/express-web-with-oidc/README.md
@@ -9,7 +9,7 @@ By default the app server runs at `http://localhost:8080`.
 
 ## Commands
 
-If running from the workspace directory, add the `--cwd` option: `yarn --cwd samples/express-web-with-oidc start`
+If running from the workspace directory, add the `--cwd` option: `yarn --cwd samples/generated/express-web-with-oidc start`
 
 | Command               | Description                    |
 | --------------------- | ------------------------------ |

--- a/samples/generated/static-spa/README.md
+++ b/samples/generated/static-spa/README.md
@@ -6,7 +6,7 @@ This sample uses a [polyfill](https://github.com/okta/okta-auth-js#browser-compa
 
 ## Commands
 
-If running from the workspace directory, add the `--cwd` option: `yarn --cwd samples/static-spa start`
+If running from the workspace directory, add the `--cwd` option: `yarn --cwd samples/generated/static-spa start`
 
 | Command               | Description                    |
 | --------------------- | ------------------------------ |

--- a/samples/generated/webpack-spa/README.md
+++ b/samples/generated/webpack-spa/README.md
@@ -6,7 +6,7 @@ This sample uses a [polyfill](https://github.com/okta/okta-auth-js#browser-compa
 
 ## Commands
 
-If running from the workspace directory, add the `--cwd` option: `yarn --cwd samples/webpack-spa start`
+If running from the workspace directory, add the `--cwd` option: `yarn --cwd samples/generated/webpack-spa start`
 
 | Command               | Description                    |
 | --------------------- | ------------------------------ |

--- a/samples/templates/partials/spa/README.md
+++ b/samples/templates/partials/spa/README.md
@@ -6,7 +6,7 @@ This sample uses a [polyfill](https://github.com/okta/okta-auth-js#browser-compa
 
 ## Commands
 
-If running from the workspace directory, add the `--cwd` option: `yarn --cwd samples/{{ name }} start`
+If running from the workspace directory, add the `--cwd` option: `yarn --cwd samples/generated/{{ name }} start`
 
 | Command               | Description                    |
 | --------------------- | ------------------------------ |

--- a/samples/templates/partials/web/README.md
+++ b/samples/templates/partials/web/README.md
@@ -9,7 +9,7 @@ By default the app server runs at `http://localhost:{{ port }}`.
 
 ## Commands
 
-If running from the workspace directory, add the `--cwd` option: `yarn --cwd samples/{{ name }} start`
+If running from the workspace directory, add the `--cwd` option: `yarn --cwd samples/generated/{{ name }} start`
 
 | Command               | Description                    |
 | --------------------- | ------------------------------ |


### PR DESCRIPTION
Copy of https://github.com/okta/okta-auth-js/pull/840

Fixed some incorrect paths to samples (templates and generated) in readme