### PR TITLE
Updates e2e script to run against trex environment

### DIFF
--- a/scripts/e2e-samples.sh
+++ b/scripts/e2e-samples.sh
@@ -14,13 +14,9 @@ export DBUS_SESSION_BUS_ADDRESS=/dev/null
 # Configuration
 # Remember to set this while running tests locally 
 export ORG_OIE_ENABLED=true 
-export ISSUER=https://javascript-idx-sdk.okta.com/oauth2/default
 export USERNAME=mary@acme.com
-export CLIENT_ID=0oav2oxnlYjULp0Cy5d6
 get_secret prod/okta-sdk-vars/password PASSWORD
-get_secret prod/okta-sdk-vars/client_secret CLIENT_SECRET
 get_secret prod/okta-sdk-vars/a18n_apiKey A18N_API_KEY
-get_secret prod/okta-sdk-vars/idx_sdk_e2e_apiKey OKTA_API_KEY
 export FB_USERNAME=js_ekdtypn_user@tfbnw.net
 get_secret prod/okta-sdk-vars/fb_password FB_PASSWORD
 
@@ -28,6 +24,21 @@ get_secret prod/okta-sdk-vars/fb_password FB_PASSWORD
 aws s3 --quiet --region us-east-1 cp s3://ci-secret-stash/prod/okta-sdk-vars/testenv.yml $OKTA_HOME/$REPO/testenv.yml
 #get_secret prod/okta-sdk-vars/testenv.yml TESTENV_YML
 #echo $TESTENV_YML > $OKTA_HOME/$REPO/testenv.yml
+
+# If this script is run as a bacon task, run against trexcloud environment
+if [[ "${BACON_TASK}" == true ]]; then
+  echo "Running tests against trexcloud org"
+  export ISSUER=https://javascript-idx-sdk.trexcloud.com/oauth2/default
+  export CLIENT_ID=0oa3r1keeeFFb7VMG0g7
+  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_client_secret CLIENT_SECRET
+  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_idx_sdk_e2e_apiKey OKTA_API_KEY
+else
+  echo "Running tests against production (ok12) org"
+  export ISSUER=https://javascript-idx-sdk.okta.com/oauth2/default
+  export CLIENT_ID=0oav2oxnlYjULp0Cy5d6
+  get_secret prod/okta-sdk-vars/client_secret CLIENT_SECRET
+  get_secret prod/okta-sdk-vars/idx_sdk_e2e_apiKey OKTA_API_KEY
+fi
 
 # Run the tests
 if ! yarn test:samples; then


### PR DESCRIPTION
- Setup a bacon task to run e2e-samples tests - https://bacon-go.aue1e.saasure.net/tasks/JS_IDX_SDK_E2E_TESTS
- Based on the env var `BACON_TASK`, e2e-samples tests are either run against trex org (when `BACON_TASK` is set) or production org (when `BACON_TASK` is not set when running regular CI tests)
- This helps us get early feedback if there are any regressions due to changes in okta-core as trex is deployed 1 week ahead of production 