### PR TITLE
feat: provide method to set request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 5.3.0
 
+
+### Features
+
+- [#891](https://github.com/okta/okta-auth-js/pull/891) Adds new method `http.setRequestHeader`
+
 ### Bug Fixes
 
 - [#852](https://github.com/okta/okta-auth-js/pull/852) Skips non-successful requests cacheing

--- a/README.md
+++ b/README.md
@@ -866,6 +866,8 @@ Defaults to `none` if the `secure` option is `true`, or `lax` if the `secure` op
   * [authStateManager.updateAuthState](#authstatemanagerupdateauthstate)
   * [authStateManager.subscribe](#authstatemanagersubscribehandler)
   * [authStateManager.unsubscribe](#authstatemanagerunsubscribehandler)
+* [http](#http)
+  * [http.setRequestHeader](#httpsetrequestheader)
 
 ------
 
@@ -2644,6 +2646,14 @@ var config = {
 
 var authClient = new OktaAuth(config);
 ```
+
+### `http`
+
+The `http` API allows customization of network requests made by internal HTTP agents.
+
+#### `http.setRequestHeader`
+
+Sets the value for a request header after [configuration options](#configuration-options) have already been processed. Headers can also be customized by setting a `headers` object in the [configuration](#configuration-options) object.
 
 ### Supported APIs
 

--- a/lib/OktaUserAgent.ts
+++ b/lib/OktaUserAgent.ts
@@ -1,3 +1,16 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
 /* global SDK_VERSION */
 import { isBrowser } from './features';
 

--- a/lib/http/headers.ts
+++ b/lib/http/headers.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+import { OktaAuth } from '../types';
+
+export function setRequestHeader(authClient: OktaAuth, headerName, headerValue) {
+  authClient.options.headers = authClient.options.headers || {};
+  authClient.options.headers[headerName] = headerValue;
+}

--- a/lib/http/index.ts
+++ b/lib/http/index.ts
@@ -1,0 +1,2 @@
+export * from './headers';
+export * from './request';

--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -12,12 +12,12 @@
  */
 
 /* eslint-disable complexity */
-import { isString, clone, isAbsoluteUrl, removeNils } from './util';
-import AuthApiError from './errors/AuthApiError';
-import { STATE_TOKEN_KEY_NAME, DEFAULT_CACHE_DURATION } from './constants';
-import { OktaAuth, RequestOptions, FetchOptions, RequestData } from './types';
+import { isString, clone, isAbsoluteUrl, removeNils } from '../util';
+import AuthApiError from '../errors/AuthApiError';
+import { STATE_TOKEN_KEY_NAME, DEFAULT_CACHE_DURATION } from '../constants';
+import { OktaAuth, RequestOptions, FetchOptions, RequestData } from '../types';
 
-function httpRequest(sdk: OktaAuth, options: RequestOptions): Promise<any> {
+export function httpRequest(sdk: OktaAuth, options: RequestOptions): Promise<any> {
   options = options || {};
   var url = options.url,
       method = options.method,
@@ -113,7 +113,7 @@ function httpRequest(sdk: OktaAuth, options: RequestOptions): Promise<any> {
     });
 }
 
-function get(sdk: OktaAuth, url: string, options?: RequestOptions) {
+export function get(sdk: OktaAuth, url: string, options?: RequestOptions) {
   url = isAbsoluteUrl(url) ? url : sdk.getIssuerOrigin() + url;
   var getOptions = {
     url: url,
@@ -123,7 +123,7 @@ function get(sdk: OktaAuth, url: string, options?: RequestOptions) {
   return httpRequest(sdk, getOptions);
 }
 
-function post(sdk: OktaAuth, url: string, args?: RequestData, options?: RequestOptions) {
+export function post(sdk: OktaAuth, url: string, args?: RequestData, options?: RequestOptions) {
   url = isAbsoluteUrl(url) ? url : sdk.getIssuerOrigin() + url;
   var postOptions = {
     url: url,
@@ -134,9 +134,3 @@ function post(sdk: OktaAuth, url: string, args?: RequestData, options?: RequestO
   Object.assign(postOptions, options);
   return httpRequest(sdk, postOptions);
 }
-
-export default {
-  get: get,
-  post: post,
-  httpRequest: httpRequest
-};

--- a/lib/idx/headers.ts
+++ b/lib/idx/headers.ts
@@ -1,0 +1,36 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+// BETA - SUBJECT TO CHANGE
+// Currently we must modify request headers using the single instance of `idx.client.interceptors` exported from IDX-JS
+// This means that multiple instances of OktaAuth will see the same header modifications
+// TODO: use AuthJS http agent for IDX API requests. OKTA-417473
+import { OktaAuth } from '../types';
+import idx from '@okta/okta-idx-js';
+export function setGlobalRequestInterceptor(fn) {
+  idx.client.interceptors.request.use(fn);
+}
+
+// A factory which returns a function that can be passed to `setGlobalRequestInterceptor`
+export function createGlobalRequestInterceptor(sdk: OktaAuth) {
+  return function (requestConfig) {
+    // Set user-agent and any other custom headers set in the options
+    var oktaUserAgentHeader = sdk._oktaUserAgent.getHttpHeader();
+    const headers = Object.assign({
+      ...oktaUserAgentHeader
+    }, sdk.options.headers);
+    Object.keys(headers).forEach(name => {
+      requestConfig.headers[name] = headers[name];
+    });
+  };
+}

--- a/lib/oidc/endpoints/token.ts
+++ b/lib/oidc/endpoints/token.ts
@@ -14,7 +14,7 @@
 import { AuthSdkError } from '../../errors';
 import { CustomUrls, OAuthParams, OAuthResponse, RefreshToken, TokenParams } from '../../types';
 import { removeNils, toQueryString } from '../../util';
-import http from '../../http';
+import { httpRequest } from '../../http';
 
 function validateOptions(options: TokenParams) {
   // Quick validation
@@ -68,7 +68,7 @@ export function postToTokenEndpoint(sdk, options: TokenParams, urls: CustomUrls)
     'Content-Type': 'application/x-www-form-urlencoded'
   };
 
-  return http.httpRequest(sdk, {
+  return httpRequest(sdk, {
     url: urls.tokenUrl,
     method: 'POST',
     args: data,
@@ -77,7 +77,7 @@ export function postToTokenEndpoint(sdk, options: TokenParams, urls: CustomUrls)
 }
 
 export function postRefreshToken(sdk, options: TokenParams, refreshToken: RefreshToken): Promise<OAuthResponse> {
-  return http.httpRequest(sdk, {
+  return httpRequest(sdk, {
     url: refreshToken.tokenUrl,
     method: 'POST',
     headers: {

--- a/lib/oidc/endpoints/well-known.ts
+++ b/lib/oidc/endpoints/well-known.ts
@@ -10,14 +10,14 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-import http from '../../http';
+import { get } from '../../http';
 import { find } from '../../util';
 import { OktaAuth, WellKnownResponse } from '../../types';
 import AuthSdkError from '../../errors/AuthSdkError';
 
 export function getWellKnown(sdk: OktaAuth, issuer?: string): Promise<WellKnownResponse> {
   var authServerUri = (issuer || sdk.options.issuer);
-  return http.get(sdk, authServerUri + '/.well-known/openid-configuration', {
+  return get(sdk, authServerUri + '/.well-known/openid-configuration', {
     cacheResponse: true
   });
 }
@@ -46,7 +46,7 @@ export function getKey(sdk: OktaAuth, issuer: string, kid: string): Promise<stri
     httpCache.clearStorage(jwksUri);
 
     // Pull the latest keys if the key wasn't in the cache
-    return http.get(sdk, jwksUri, {
+    return get(sdk, jwksUri, {
       cacheResponse: true
     })
     .then(function(res) {

--- a/lib/oidc/getUserInfo.ts
+++ b/lib/oidc/getUserInfo.ts
@@ -13,7 +13,7 @@
  */
 import { isFunction } from '../util';
 import { AuthSdkError, OAuthError } from '../errors';
-import http from '../http';
+import { httpRequest } from '../http';
 import { AccessToken, IDToken, UserClaims, isAccessToken, isIDToken } from '../types';
 
 export async function getUserInfo(sdk, accessTokenObject: AccessToken, idTokenObject: IDToken): Promise<UserClaims> {
@@ -33,7 +33,7 @@ export async function getUserInfo(sdk, accessTokenObject: AccessToken, idTokenOb
     return Promise.reject(new AuthSdkError('getUserInfo requires an ID token object'));
   }
 
-  return http.httpRequest(sdk, {
+  return httpRequest(sdk, {
     url: accessTokenObject.userinfoUrl,
     method: 'GET',
     accessToken: accessTokenObject.accessToken

--- a/lib/oidc/revokeToken.ts
+++ b/lib/oidc/revokeToken.ts
@@ -12,7 +12,7 @@
  */
 
 /* eslint complexity:[0,8] */
-import http from '../http';
+import { post } from '../http';
 import { toQueryString } from '../util';
 import {
   getOAuthUrls,
@@ -52,7 +52,7 @@ export function revokeToken(sdk: OktaAuth, token: RevocableToken): Promise<any> 
         token: refreshToken || accessToken,
       }).slice(1);
       var creds = clientSecret ? btoa(`${clientId}:${clientSecret}`) : btoa(clientId);
-      return http.post(sdk, revokeUrl, args, {
+      return post(sdk, revokeUrl, args, {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
           'Authorization': 'Basic ' + creds

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -12,7 +12,7 @@
  */
 /* global window */
 import { omit, getLink, toQueryString } from './util';
-import http from './http';
+import { get, post, httpRequest } from './http';
 
 function sessionExists(sdk) {
   return sdk.session.get()
@@ -28,16 +28,16 @@ function sessionExists(sdk) {
 }
 
 function getSession(sdk) { 
-  return http.get(sdk, '/api/v1/sessions/me', { withCredentials: true })
+  return get(sdk, '/api/v1/sessions/me', { withCredentials: true })
   .then(function(session) {
     var res = omit(session, '_links');
 
     res.refresh = function() {
-      return http.post(sdk, getLink(session, 'refresh').href, {}, { withCredentials: true });
+      return post(sdk, getLink(session, 'refresh').href, {}, { withCredentials: true });
     };
 
     res.user = function() {
-      return http.get(sdk, getLink(session, 'user').href, { withCredentials: true });
+      return get(sdk, getLink(session, 'user').href, { withCredentials: true });
     };
 
     return res;
@@ -49,7 +49,7 @@ function getSession(sdk) {
 }
 
 function closeSession(sdk) {
-  return http.httpRequest(sdk, {
+  return httpRequest(sdk, {
     url: sdk.getIssuerOrigin() + '/api/v1/sessions/me',
     method: 'DELETE',
     withCredentials: true
@@ -57,7 +57,7 @@ function closeSession(sdk) {
 }
 
 function refreshSession(sdk) {
-  return http.post(sdk, '/api/v1/sessions/me/lifecycle/refresh', {}, { withCredentials: true });
+  return post(sdk, '/api/v1/sessions/me/lifecycle/refresh', {}, { withCredentials: true });
 }
 
 function setCookieAndRedirect(sdk, sessionToken, redirectUrl) {

--- a/lib/tx/AuthTransaction.ts
+++ b/lib/tx/AuthTransaction.ts
@@ -11,7 +11,7 @@
  *
  */
 
-import http from '../http';
+import { get } from '../http';
 import { find, omit, toQueryString, clone, isObject } from '../util';
 import AuthSdkError from '../errors/AuthSdkError';
 import { TransactionState } from './TransactionState';
@@ -125,7 +125,7 @@ function link2fn(sdk, res, obj, link, ref) {
 
       case 'GET':
         return function() {
-          return http.get(sdk, link.href, { withCredentials: true });
+          return get(sdk, link.href, { withCredentials: true });
         };
 
       case 'POST':

--- a/lib/tx/api.ts
+++ b/lib/tx/api.ts
@@ -12,7 +12,7 @@
  */
 
 /* eslint-disable complexity, max-statements */
-import http from '../http';
+import { post } from '../http';
 import AuthSdkError from '../errors/AuthSdkError';
 import { STATE_TOKEN_KEY_NAME } from '../constants';
 import { addStateToken } from './util';
@@ -20,7 +20,7 @@ import { AuthTransaction } from './AuthTransaction';
 
 function transactionStatus(sdk, args) {
   args = addStateToken(sdk, args);
-  return http.post(sdk, sdk.getIssuerOrigin() + '/api/v1/authn', args, { withCredentials: true });
+  return post(sdk, sdk.getIssuerOrigin() + '/api/v1/authn', args, { withCredentials: true });
 }
 
 function resumeTransaction(sdk, args) {
@@ -60,7 +60,7 @@ function introspect (sdk, args) {
 function transactionStep(sdk, args) {
   args = addStateToken(sdk, args);
   // v1 pipeline introspect API
-  return http.post(sdk, sdk.getIssuerOrigin() + '/api/v1/authn/introspect', args, { withCredentials: true });
+  return post(sdk, sdk.getIssuerOrigin() + '/api/v1/authn/introspect', args, { withCredentials: true });
 }
 
 function transactionExists(sdk) {
@@ -69,7 +69,7 @@ function transactionExists(sdk) {
 }
 
 function postToTransaction(sdk, url, args, options?) {
-  return http.post(sdk, url, args, options)
+  return post(sdk, url, args, options)
     .then(function(res) {
       return new AuthTransaction(sdk, res);
     });

--- a/lib/tx/poll.ts
+++ b/lib/tx/poll.ts
@@ -11,7 +11,7 @@
  *
  */
 
-import http from '../http';
+import { post } from '../http';
 import { isNumber, isObject, getLink, toQueryString, delay as delayFn } from '../util';
 import { DEFAULT_POLLING_DELAY } from '../constants';
 import AuthSdkError from '../errors/AuthSdkError';
@@ -77,7 +77,7 @@ export function getPollFn(sdk, res: TransactionState, ref) {
       }
 
       var href = pollLink.href + toQueryString(opts);
-      return http.post(sdk, href, getStateToken(res), {
+      return post(sdk, href, getStateToken(res), {
         saveAuthnState: false,
         withCredentials: true
       });

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -51,6 +51,11 @@ export interface APIError {
   errorCauses?: string[];
 }
 
+// HTTP API
+export interface HttpAPI {
+  setRequestHeader(name: string, value: string): void;
+}
+
 // Transaction API
 
 export type TransactionExistsFunction = () => boolean;

--- a/test/spec/http/headers.ts
+++ b/test/spec/http/headers.ts
@@ -1,0 +1,98 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+import { httpRequest, setRequestHeader } from '../../../lib/http';
+
+describe('HTTP headers', () => {
+  let testContext;
+  beforeEach(() => {
+    testContext = {
+      url: 'fake-url',
+      sdk: {
+        options: {
+          httpRequestClient: () => Promise.resolve({
+            responseText: null
+          }),
+          storageUtil: {}
+        },
+        storageManager: {
+          getHttpCache: () => {}
+        },
+        _oktaUserAgent: {
+          getHttpHeader: () => {}
+        }
+      }
+    };
+  });
+
+  it('uses header values set in SDK options', async () => {
+    const { sdk, url } = testContext;
+    sdk.options.headers = {
+      'my-header': 'my-value',
+      'other-header': 'other-value'
+    };
+    jest.spyOn(sdk.options, 'httpRequestClient');
+    await httpRequest(sdk, { url, method: 'get' });
+    expect(sdk.options.httpRequestClient).toHaveBeenCalledWith('get', 'fake-url', {
+      data: undefined,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'my-header': 'my-value',
+        'other-header': 'other-value'
+      },
+      withCredentials: false
+    });
+  });
+
+  it('uses header values set using setRequestHeader', async () => {
+    const { sdk, url } = testContext;
+    jest.spyOn(sdk.options, 'httpRequestClient');
+    setRequestHeader(sdk, 'my-header', 'my-value');
+    setRequestHeader(sdk, 'other-header', 'other-value');
+    await httpRequest(sdk, { url, method: 'get' });
+    expect(sdk.options.httpRequestClient).toHaveBeenCalledWith('get', 'fake-url', {
+      data: undefined,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'my-header': 'my-value',
+        'other-header': 'other-value'
+      },
+      withCredentials: false
+    });
+  });
+
+  it('can override header values set in options using setRequestHeader', async () => {
+    const { sdk, url } = testContext;
+    jest.spyOn(sdk.options, 'httpRequestClient');
+    sdk.options.headers = {
+      'my-header': 'my-value',
+      'other-header': 'other-value'
+    };
+    setRequestHeader(sdk, 'my-header', 'my-value2');
+    setRequestHeader(sdk, 'other-header', 'other-value2');
+    await httpRequest(sdk, { url, method: 'get' });
+    expect(sdk.options.httpRequestClient).toHaveBeenCalledWith('get', 'fake-url', {
+      data: undefined,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'my-header': 'my-value2',
+        'other-header': 'other-value2'
+      },
+      withCredentials: false
+    });
+  });
+
+});

--- a/test/spec/http/request.ts
+++ b/test/spec/http/request.ts
@@ -11,15 +11,15 @@
  */
 
 
-/* global USER_AGENT */
+declare var USER_AGENT: string; // set in jest config
 
-import http from '../../lib/http';
+import { httpRequest } from '../../../lib/http';
 import { 
   OktaAuth, 
   DEFAULT_CACHE_DURATION, 
   AuthApiError, 
   STATE_TOKEN_KEY_NAME 
-} from '../../lib';
+} from '../../../lib';
 
 describe('HTTP Requestor', () => {
   let sdk;
@@ -37,7 +37,7 @@ describe('HTTP Requestor', () => {
     sdk = null;
     httpRequestClient = null;
   });
-  function createAuthClient(options) {
+  function createAuthClient(options?) {
     httpRequestClient = httpRequestClient || jest.fn().mockReturnValue(Promise.resolve({
       responseText: JSON.stringify(response1)
     }));
@@ -54,7 +54,7 @@ describe('HTTP Requestor', () => {
   describe('withCredentials', () => {
     it('can be enabled', () => {
       createAuthClient();
-      return http.httpRequest(sdk, { url, withCredentials: true })
+      return httpRequest(sdk, { url, withCredentials: true })
       .then(res => {
         expect(res).toBe(response1);
         expect(httpRequestClient).toHaveBeenCalledWith(undefined, url, {
@@ -72,7 +72,7 @@ describe('HTTP Requestor', () => {
   describe('headers', () => {
     it('sets defaults', () => {
       createAuthClient();
-      return http.httpRequest(sdk, { url })
+      return httpRequest(sdk, { url })
       .then(res => {
         expect(res).toBe(response1);
         expect(httpRequestClient).toHaveBeenCalledWith(undefined, url, {
@@ -92,7 +92,7 @@ describe('HTTP Requestor', () => {
           'fake': 'value'
         }
       });
-      return http.httpRequest(sdk, { url })
+      return httpRequest(sdk, { url })
       .then(res => {
         expect(res).toBe(response1);
         expect(httpRequestClient).toHaveBeenCalledWith(undefined, url, {
@@ -109,7 +109,7 @@ describe('HTTP Requestor', () => {
     });
     it('accepts headers on httpRequest', () => {
       createAuthClient();
-      return http.httpRequest(sdk, {
+      return httpRequest(sdk, {
         url, 
         headers: {
           'fake': 'value'
@@ -131,7 +131,7 @@ describe('HTTP Requestor', () => {
     });
     it('removes headers with undefined value', () => {
       createAuthClient();
-      return http.httpRequest(sdk, {
+      return httpRequest(sdk, {
         url, 
         headers: {
           'fake': undefined
@@ -152,7 +152,7 @@ describe('HTTP Requestor', () => {
     });
     it('can set an Authorization header using accessToken', () => {
       createAuthClient();
-      return http.httpRequest(sdk, {
+      return httpRequest(sdk, {
         url, 
         accessToken: 'fake'
       })
@@ -175,7 +175,7 @@ describe('HTTP Requestor', () => {
       jest.spyOn(sdk._oktaUserAgent, 'getHttpHeader').mockImplementation(() => ({
         'X-Okta-User-Agent-Extended': 'okta-auth-js/a.b fake/x.y'
       }));
-      return http.httpRequest(sdk, { url })
+      return httpRequest(sdk, { url })
         .then(res => {
           expect(res).toBe(response1);
           expect(sdk._oktaUserAgent.getHttpHeader).toHaveBeenCalledTimes(1);
@@ -206,7 +206,7 @@ describe('HTTP Requestor', () => {
         expiresAt: Math.floor(Date.now()/1000) + DEFAULT_CACHE_DURATION,
         response: response2
       });
-      return http.httpRequest(sdk, { url, cacheResponse: true })
+      return httpRequest(sdk, { url, cacheResponse: true })
         .then(res => {
           expect(res).toBe(response2);
           expect(httpRequestClient).not.toHaveBeenCalled();
@@ -215,7 +215,7 @@ describe('HTTP Requestor', () => {
     it('will update cache', () => {
       jest.spyOn(httpCache, 'updateStorage');
       jest.spyOn(Date, 'now').mockReturnValue(1000);
-      return http.httpRequest(sdk, { url, cacheResponse: true, method: 'GET' })
+      return httpRequest(sdk, { url, cacheResponse: true, method: 'GET' })
         .then(res => {
           expect(res).toBe(response1);
           expect(httpRequestClient).toHaveBeenCalledWith('GET', url, expect.any(Object));
@@ -232,7 +232,7 @@ describe('HTTP Requestor', () => {
         response: response2
       });
       httpCache.updateStorage.mockClear();
-      return http.httpRequest(sdk, { url, cacheResponse: false, method: 'GET' })
+      return httpRequest(sdk, { url, cacheResponse: false, method: 'GET' })
         .then(res => {
           expect(res).toBe(response1);
           expect(httpRequestClient).toHaveBeenCalledWith('GET', url, expect.any(Object));
@@ -248,7 +248,7 @@ describe('HTTP Requestor', () => {
       const response = { responseText: 'fake error', status: 404 };
       initWithErrorResponse(response);
       createAuthClient();
-      return http.httpRequest(sdk, { url })
+      return httpRequest(sdk, { url })
         .catch(err => {
           expect(err).toBeInstanceOf(AuthApiError);
           expect(err.errorSummary).toBe('Unknown error');
@@ -260,7 +260,7 @@ describe('HTTP Requestor', () => {
       const response = { responseText: JSON.stringify(json), status: 404 };
       initWithErrorResponse(response);
       createAuthClient();
-      return http.httpRequest(sdk, { url })
+      return httpRequest(sdk, { url })
         .catch(err => {
           expect(err).toBeInstanceOf(AuthApiError);
           expect(err.xhr).toEqual(response);
@@ -272,7 +272,7 @@ describe('HTTP Requestor', () => {
       const response = { responseText: JSON.stringify(json), status: 501 };
       initWithErrorResponse(response);
       createAuthClient();
-      return http.httpRequest(sdk, { url })
+      return httpRequest(sdk, { url })
         .catch(err => {
           expect(err).toBeInstanceOf(AuthApiError);
           expect(err.xhr).toEqual(response);
@@ -290,7 +290,7 @@ describe('HTTP Requestor', () => {
       createAuthClient({
         transformErrorXHR
       });
-      return http.httpRequest(sdk, { url })
+      return httpRequest(sdk, { url })
         .catch(err => {
           expect(err).toBeInstanceOf(AuthApiError);
           expect(err.xhr).toEqual({
@@ -307,7 +307,7 @@ describe('HTTP Requestor', () => {
       createAuthClient();
       const storage = sdk.options.storageUtil.storage;
       jest.spyOn(storage, 'delete');
-      return http.httpRequest(sdk, { url })
+      return httpRequest(sdk, { url })
         .catch(err => {
           expect(err).toBeInstanceOf(AuthApiError);
           expect(err.xhr).toEqual(response);

--- a/test/spec/idx/headers.ts
+++ b/test/spec/idx/headers.ts
@@ -1,0 +1,191 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+const mocked = {
+
+  crossFetch: {
+    __esModule: true, // fool babel require interop
+    default: () => Promise.resolve({
+      ok: true,
+      json: () => {}
+    })
+  }
+};
+
+jest.mock('cross-fetch', () => {
+  return mocked.crossFetch;
+});
+
+import idx from '@okta/okta-idx-js';
+import { setRequestHeader } from '../../../lib/http';
+import { createGlobalRequestInterceptor, setGlobalRequestInterceptor } from '../../../lib/idx/headers';
+
+describe('idx headers', () => {
+
+  let testContext;
+  beforeEach(() => {
+    testContext = {
+      url: 'fake-url',
+      domain: 'fake-domain',
+      interactionHandle: null,
+      stateHandle: 'fake-stateHandle',
+      version: 'fake-version',
+      sdk: {
+        options: {
+          httpRequestClient: () => Promise.resolve({
+            responseText: null
+          }),
+          storageUtil: {}
+        },
+        storageManager: {
+          getHttpCache: () => {}
+        },
+        _oktaUserAgent: {
+          getHttpHeader: () => {
+            return {
+              'X-Okta-User-Agent-Extended': 'fake-sdk-user-agent'
+            };
+          }
+        }
+      }
+    };
+  });
+
+  async function callIntrospect() {
+    const { domain, interactionHandle, stateHandle, version } = testContext;
+    await idx.introspect({ domain, interactionHandle, stateHandle, version });
+  }
+
+  describe('without interceptor', () => {
+    it('idx does not use header values set in SDK options or SDK user agent', async () => {
+      const { sdk } = testContext;
+      sdk.options.headers = {
+        'my-header': 'my-value',
+        'other-header': 'other-value'
+      };
+      jest.spyOn(mocked.crossFetch, 'default');
+      await callIntrospect();
+      expect(mocked.crossFetch.default).toHaveBeenCalledWith('fake-domain/idp/idx/introspect', {
+        body: JSON.stringify({
+          stateToken: 'fake-stateHandle'
+        }),
+        credentials: 'include',
+        headers: {
+          'X-Okta-User-Agent-Extended': 'okta-idx-js/0.19.0',
+          'accept': 'application/ion+json; okta-version=fake-version',
+          'content-type': 'application/ion+json; okta-version=fake-version',
+        },
+        method: 'POST'
+      });
+    });
+  
+    it('idx does not use header values set using setRequestHeader or SDK user agent', async () => {
+      const { sdk } = testContext;
+      setRequestHeader(sdk, 'my-header', 'my-value');
+      setRequestHeader(sdk, 'other-header', 'other-value');
+      jest.spyOn(mocked.crossFetch, 'default');
+      await callIntrospect();
+      expect(mocked.crossFetch.default).toHaveBeenCalledWith('fake-domain/idp/idx/introspect', {
+        body: JSON.stringify({
+          stateToken: 'fake-stateHandle'
+        }),
+        credentials: 'include',
+        headers: {
+          'X-Okta-User-Agent-Extended': 'okta-idx-js/0.19.0',
+          'accept': 'application/ion+json; okta-version=fake-version',
+          'content-type': 'application/ion+json; okta-version=fake-version',
+        },
+        method: 'POST'
+      });
+    });
+  });
+
+  describe('with interceptor', () => {
+    beforeEach(() => {
+      const { sdk } = testContext;
+      setGlobalRequestInterceptor(createGlobalRequestInterceptor(sdk));
+    });
+
+    it('idx uses header values set in SDK options and SDK user agent', async () => {
+      const { sdk } = testContext;
+      sdk.options.headers = {
+        'my-header': 'my-value',
+        'other-header': 'other-value'
+      };
+      jest.spyOn(mocked.crossFetch, 'default');
+      await callIntrospect();
+      expect(mocked.crossFetch.default).toHaveBeenCalledWith('fake-domain/idp/idx/introspect', {
+        body: JSON.stringify({
+          stateToken: 'fake-stateHandle'
+        }),
+        credentials: 'include',
+        headers: {
+          'X-Okta-User-Agent-Extended': 'fake-sdk-user-agent',
+          'accept': 'application/ion+json; okta-version=fake-version',
+          'content-type': 'application/ion+json; okta-version=fake-version',
+          'my-header': 'my-value',
+          'other-header': 'other-value'
+        },
+        method: 'POST'
+      });
+    });
+  
+    it('idx uses header values set using setRequestHeader and SDK user agent', async () => {
+      const { sdk } = testContext;
+      setRequestHeader(sdk, 'my-header', 'my-value');
+      setRequestHeader(sdk, 'other-header', 'other-value');
+      jest.spyOn(mocked.crossFetch, 'default');
+      await callIntrospect();
+      expect(mocked.crossFetch.default).toHaveBeenCalledWith('fake-domain/idp/idx/introspect', {
+        body: JSON.stringify({
+          stateToken: 'fake-stateHandle'
+        }),
+        credentials: 'include',
+        headers: {
+          'X-Okta-User-Agent-Extended': 'fake-sdk-user-agent',
+          'accept': 'application/ion+json; okta-version=fake-version',
+          'content-type': 'application/ion+json; okta-version=fake-version',
+          'my-header': 'my-value',
+          'other-header': 'other-value'
+        },
+        method: 'POST'
+      });
+    });
+
+    it('idx uses header values overridden using setRequestHeader and SDK user agent', async () => {
+      const { sdk } = testContext;
+      sdk.options.headers = {
+        'my-header': 'my-value',
+        'other-header': 'other-value'
+      };
+      setRequestHeader(sdk, 'my-header', 'my-value2');
+      setRequestHeader(sdk, 'other-header', 'other-value2');
+      jest.spyOn(mocked.crossFetch, 'default');
+      await callIntrospect();
+      expect(mocked.crossFetch.default).toHaveBeenCalledWith('fake-domain/idp/idx/introspect', {
+        body: JSON.stringify({
+          stateToken: 'fake-stateHandle'
+        }),
+        credentials: 'include',
+        headers: {
+          'X-Okta-User-Agent-Extended': 'fake-sdk-user-agent',
+          'accept': 'application/ion+json; okta-version=fake-version',
+          'content-type': 'application/ion+json; okta-version=fake-version',
+          'my-header': 'my-value2',
+          'other-header': 'other-value2'
+        },
+        method: 'POST'
+      });
+    });
+  });
+});

--- a/test/spec/idx/interact.ts
+++ b/test/spec/idx/interact.ts
@@ -14,7 +14,9 @@
 import { interact } from '../../../lib/idx/interact';
 
 jest.mock('@okta/okta-idx-js', () => {
+  const actual = jest.requireActual('@okta/okta-idx-js').default;
   return {
+    client: actual.client,
     interact: () => {}
   };
 });

--- a/test/spec/oidc/endpoints/token.ts
+++ b/test/spec/oidc/endpoints/token.ts
@@ -10,11 +10,21 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+jest.mock('../../../../lib/http', () => {
+  const actual = jest.requireActual('../../../../lib/http');
+  return {
+    httpRequest: actual.httpRequest,
+    post: actual.post,
+    setRequestHeader: actual.setRequestHeader
+  };
+});
+
+const mocked = {
+  http: require('../../../../lib/http')
+};
 
 import { OktaAuth, AuthSdkError } from '@okta/okta-auth-js';
 import util from '@okta/test.support/util';
-import http from '../../../../lib/http';
-
 import { postToTokenEndpoint } from '../../../../lib/oidc/endpoints/token';
 import factory from '@okta/test.support/factory';
 
@@ -91,7 +101,7 @@ describe('token endpoint', function() {
     });
 
     it('Does not throw if options are valid', function() {
-      var httpRequst = jest.spyOn(http, 'httpRequest').mockImplementation();
+      var httpRequst = jest.spyOn(mocked.http, 'httpRequest').mockImplementation();
       var urls = {
         tokenUrl: 'http://superfake'
       };

--- a/test/spec/oidc/parseFromUrl.ts
+++ b/test/spec/oidc/parseFromUrl.ts
@@ -10,13 +10,24 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+jest.mock('../../../lib/http', () => {
+  const actual = jest.requireActual('../../../lib/http');
+  return {
+    httpRequest: actual.httpRequest,
+    get: actual.get,
+    setRequestHeader: actual.setRequestHeader
+  };
+});
+
+const mocked = {
+  http: require('../../../lib/http')
+};
 
 import { OktaAuth } from '@okta/okta-auth-js';
 import TransactionManager from '../../../lib/TransactionManager';
 import tokens from '@okta/test.support/tokens';
 import util from '@okta/test.support/util';
 import oauthUtil from '@okta/test.support/oauthUtil';
-import http from '../../../lib/http';
 import { isInteractionRequiredError } from '../../../lib/oidc';
 
 describe('token.parseFromUrl', function() {
@@ -30,7 +41,7 @@ describe('token.parseFromUrl', function() {
       redirectUri
     });
     spyOn(TransactionManager.prototype, 'clear').and.callThrough();
-    spyOn(http, 'httpRequest').and.returnValue(Promise.resolve(response));
+    spyOn(mocked.http, 'httpRequest').and.returnValue(Promise.resolve(response));
   }
 
   it('authorization_code: Will return code', function() {

--- a/test/spec/oidc/revokeToken.ts
+++ b/test/spec/oidc/revokeToken.ts
@@ -12,9 +12,21 @@
 
 
 /* global btoa */
+jest.mock('../../../lib/http', () => {
+  const actual = jest.requireActual('../../../lib/http');
+  return {
+    httpRequest: actual.httpRequest,
+    post: actual.post,
+    setRequestHeader: actual.setRequestHeader
+  };
+});
+
+const mocked = {
+  http: require('../../../lib/http')
+};
+
 import { OktaAuth, AccessToken } from '@okta/okta-auth-js';
 import util from '@okta/test.support/util';
-import http from '../../../lib/http';
 
 function setupSync(options?) {
   options = Object.assign({ issuer: 'http://example.okta.com', pkce: false }, options);
@@ -60,13 +72,13 @@ describe('token.revoke', function() {
       });
   });
   it('makes a POST to /v1/revoke', function() {
-    spyOn(http, 'post').and.returnValue(Promise.resolve());
+    spyOn(mocked.http, 'post').and.returnValue(Promise.resolve());
     var clientId = 'fake-client-id';
     var oa = setupSync({ clientId: clientId });
     var accessToken = createAccessToken('fake/ &token');
     return oa.token.revoke(accessToken)
       .then(function() {
-        expect(http.post).toHaveBeenCalledWith(oa, 
+        expect(mocked.http.post).toHaveBeenCalledWith(oa, 
           'http://example.okta.com/oauth2/v1/revoke', 
           'token_type_hint=access_token&token=fake%2F%20%26token', {
             headers: {
@@ -78,7 +90,7 @@ describe('token.revoke', function() {
   });
   it('will throw if http.post rejects', function() {
     var testError = new Error('test error');
-    spyOn(http, 'post').and.callFake(function() {
+    spyOn(mocked.http, 'post').and.callFake(function() {
       return Promise.reject(testError);
     });
     var clientId = 'fake-client-id';


### PR DESCRIPTION
Adds a new sub-api, "http" with one method (so far), `setRequestHeader`. This allows setting the "headers" option after the AuthJS has already been constructed.  Options set here will effect both IDX and non-IDX requests.

The primary purpose of this commit is to set custom request headers on IDX requests, specifically for device fingerprinting. This is needed to unblock removing idx-js dependency from the widget.

One (nice) side-effect of this commit is that the full "sdk" user-agent will now be sent on IDX API requests.