### PR TITLE
feat: expose introspect, interact methods on idx namespace

### DIFF
--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -96,7 +96,9 @@ import { AuthStateManager } from './AuthStateManager';
 import StorageManager from './StorageManager';
 import TransactionManager from './TransactionManager';
 import { buildOptions } from './options';
-import { 
+import {
+  interact,
+  introspect as introspectV2,
   authenticate,
   cancel,
   register,
@@ -242,6 +244,8 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
 
     // IDX
     this.idx = {
+      interact: interact.bind(null, this),
+      introspect: introspectV2.bind(null, this),
       authenticate: authenticate.bind(null, this),
       register: register.bind(null, this),
       cancel: cancel.bind(null, this),

--- a/lib/idx/index.ts
+++ b/lib/idx/index.ts
@@ -13,6 +13,8 @@
 
 export * from './authenticate';
 export * from './cancel';
+export * from './interact';
+export * from './introspect';
 export * from './register';
 export * from './recoverPassword';
 export * from './handleInteractionCodeRedirect';

--- a/lib/idx/introspect.ts
+++ b/lib/idx/introspect.ts
@@ -16,7 +16,7 @@ import { IdxResponse, RawIdxResponse } from './types/idx-js';
 import { getOAuthDomain } from '../oidc';
 import { IDX_API_VERSION } from '../constants';
 
-interface IntrospectOptions {
+export interface IntrospectOptions {
   interactionHandle: string;
   stateHandle?: string;
 }

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -28,7 +28,9 @@ import {
   IdxOptions,
   IdxTransaction,
 } from '../idx/types';
-
+import { InteractOptions, InteractResponse } from '../idx/interact';
+import { IntrospectOptions } from '../idx/introspect';
+import { IdxResponse } from '../idx/types/idx-js';
 export interface OktaAuth {
   options: OktaAuthOptions;
   getIssuerOrigin(): string;
@@ -250,6 +252,8 @@ export interface PkceAPI {
 }
 
 export interface IdxAPI {
+  interact: (options?: InteractOptions) => Promise<InteractResponse>;
+  introspect: (options?: IntrospectOptions) => Promise<IdxResponse>;
   authenticate: (options: AuthenticationOptions) => Promise<IdxTransaction>;
   register: (options: IdxRegistrationOptions) => Promise<IdxTransaction>;
   cancel: (options?: CancelOptions) => Promise<IdxTransaction>;


### PR DESCRIPTION
- the primary purpose is to help the widget with conversion away from idx-js, to use auth-js as the sole IDX client for consistency with headers and other config.
- these methods may be removed in the next major version.