### PR TITLE
feat: shared transaction storage

### DIFF
--- a/lib/StorageManager.ts
+++ b/lib/StorageManager.ts
@@ -16,6 +16,7 @@ import {
   PKCE_STORAGE_NAME,
   TOKEN_STORAGE_NAME,
   TRANSACTION_STORAGE_NAME,
+  SHARED_TRANSACTION_STORAGE_NAME,
   IDX_RESPONSE_STORAGE_NAME,
   CACHE_STORAGE_NAME,
   REDIRECT_OAUTH_PARAMS_NAME
@@ -94,6 +95,14 @@ export default class StorageManager {
     logServerSideMemoryStorageWarning(options);
     const storage = this.getStorage(options);
     const storageKey = options.storageKey || TRANSACTION_STORAGE_NAME;
+    return new SavedObject(storage, storageKey);
+  }
+
+  getSharedTansactionStorage(options?: StorageOptions): TransactionStorage {
+    options = this.getOptionsForSection('shared-transaction', options);
+    logServerSideMemoryStorageWarning(options);
+    const storage = this.getStorage(options);
+    const storageKey = options.storageKey || SHARED_TRANSACTION_STORAGE_NAME;
     return new SavedObject(storage, storageKey);
   }
 

--- a/lib/TransactionManager.ts
+++ b/lib/TransactionManager.ts
@@ -27,7 +27,12 @@ import {
 } from './types';
 import { RawIdxResponse, isRawIdxResponse } from './idx/types/idx-js';
 import { warn } from './util';
-
+import {
+  clearTransactionFromSharedStorage,
+  loadTransactionFromSharedStorage,
+  pruneSharedStorage,
+  saveTransactionToSharedStorage
+} from './util/sharedStorage';
 export default class TransactionManager {
   options: TransactionManagerOptions;
   storageManager: StorageManager;
@@ -35,6 +40,7 @@ export default class TransactionManager {
   saveNonceCookie: boolean;
   saveStateCookie: boolean;
   saveParamsCookie: boolean;
+  enableSharedStorage: boolean;
 
   constructor(options: TransactionManagerOptions) {
     this.storageManager = options.storageManager;
@@ -42,6 +48,7 @@ export default class TransactionManager {
     this.saveNonceCookie = options.saveNonceCookie === false ? false : true;
     this.saveStateCookie = options.saveStateCookie === false ? false : true;
     this.saveParamsCookie = options.saveParamsCookie === false ? false : true;
+    this.enableSharedStorage = options.enableSharedStorage === false ? false : true;
     this.options = options;
   }
 
@@ -52,6 +59,10 @@ export default class TransactionManager {
     const idxStateStorage: StorageProvider = this.storageManager.getIdxResponseStorage();
     idxStateStorage?.clearStorage();
 
+    if (this.enableSharedStorage && options.state) {
+      clearTransactionFromSharedStorage(this.storageManager, options.state);
+    }
+  
     if (!this.legacyWidgetSupport) {
       return;
     }
@@ -85,6 +96,7 @@ export default class TransactionManager {
       return;
     }
   
+    // Legacy cookie storage
     if (this.saveNonceCookie || this.saveStateCookie || this.saveParamsCookie) {
       const cookieStorage: CookieStorage = this.storageManager.getStorage({ storageType: 'cookie' }) as CookieStorage;
 
@@ -120,6 +132,11 @@ export default class TransactionManager {
         cookieStorage.setItem(REDIRECT_STATE_COOKIE_NAME, meta.state, null);
       }
     }
+
+    // Shared storage allows continuation of transaction in another tab
+    if (this.enableSharedStorage && meta.state) {
+      saveTransactionToSharedStorage(this.storageManager, meta.state, meta);
+    }
   }
 
   exists(options: TransactionMetaOptions = {}): boolean {
@@ -132,9 +149,22 @@ export default class TransactionManager {
   }
 
   // load transaction meta from storage
+  // eslint-disable-next-line complexity,max-statements
   load(options: TransactionMetaOptions = {}): TransactionMeta {
+
+    let meta: TransactionMeta;
+
+    // If state was passed, try loading transaction data from shared storage
+    if (this.enableSharedStorage && options.state) {
+      pruneSharedStorage(this.storageManager); // prune before load
+      meta = loadTransactionFromSharedStorage(this.storageManager, options.state);
+      if (isTransactionMeta(meta)) {
+        return meta;
+      }
+    }
+
     let storage: StorageProvider = this.storageManager.getTransactionStorage();
-    let meta = storage.getStorage();
+    meta = storage.getStorage();
     if (isTransactionMeta(meta)) {
       // if we have meta in the new location, there is no need to go further
       return meta;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -21,6 +21,7 @@ export const TOKEN_STORAGE_NAME = 'okta-token-storage';
 export const CACHE_STORAGE_NAME = 'okta-cache-storage';
 export const PKCE_STORAGE_NAME = 'okta-pkce-storage';
 export const TRANSACTION_STORAGE_NAME = 'okta-transaction-storage';
+export const SHARED_TRANSACTION_STORAGE_NAME = 'okta-shared-transaction-storage';
 export const IDX_RESPONSE_STORAGE_NAME = 'okta-idx-response-storage';
 export const ACCESS_TOKEN_STORAGE_KEY = 'accessToken';
 export const ID_TOKEN_STORAGE_KEY =  'idToken';

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -43,6 +43,11 @@ const BROWSER_STORAGE: StorageManagerOptions = {
       'localStorage',
       'cookie'
     ]
+  },
+  'shared-transaction': {
+    storageTypes: [
+      'localStorage'
+    ]
   }
 };
 

--- a/lib/types/Transaction.ts
+++ b/lib/types/Transaction.ts
@@ -15,7 +15,7 @@ import StorageManager from '../StorageManager';
 import { CustomUrls } from './OktaAuthOptions';
 
 export interface TransactionManagerOptions {
-  storageManager: StorageManager;
+  storageManager?: StorageManager;
   enableSharedStorage?: boolean; // default false
   legacyWidgetSupport?: boolean; // default true
   saveNonceCookie?: boolean; // default true

--- a/lib/types/Transaction.ts
+++ b/lib/types/Transaction.ts
@@ -16,6 +16,7 @@ import { CustomUrls } from './OktaAuthOptions';
 
 export interface TransactionManagerOptions {
   storageManager: StorageManager;
+  enableSharedStorage?: boolean; // default false
   legacyWidgetSupport?: boolean; // default true
   saveNonceCookie?: boolean; // default true
   saveStateCookie?: boolean; // default true
@@ -25,6 +26,7 @@ export interface TransactionManagerOptions {
 export interface TransactionMetaOptions {
   pkce?: boolean;
   oauth?: boolean;
+  state?: string;
 }
 
 // formerly known as "Redirect OAuth Params"

--- a/lib/util/sharedStorage.ts
+++ b/lib/util/sharedStorage.ts
@@ -1,0 +1,44 @@
+import { isTransactionMeta, TransactionMeta } from '../types';
+import StorageManager from '../StorageManager';
+
+const MAX_ENTRY_LIFETIME = 30 * 60 * 1000; // 30 minutes
+
+export function pruneSharedStorage(storageManager: StorageManager) {
+  const sharedStorage = storageManager.getSharedTansactionStorage();
+  const entries = sharedStorage.getStorage();
+  Object.keys(entries).forEach(state => {
+    const entry = entries[state];
+    if (Date.now() - entry.dateCreated > MAX_ENTRY_LIFETIME) {
+      delete entries[state];
+    }
+  });
+  sharedStorage.setStorage(entries);
+}
+
+export function saveTransactionToSharedStorage(storageManager: StorageManager, state: string, meta: TransactionMeta) {
+  const sharedStorage = storageManager.getSharedTansactionStorage();
+  const entries = sharedStorage.getStorage();
+  entries[state] = {
+    dateCreated: Date.now(),
+    transaction: meta
+  };
+  sharedStorage.setStorage(entries);
+}
+
+
+export function loadTransactionFromSharedStorage(storageManager: StorageManager, state: string) {
+  const sharedStorage = storageManager.getSharedTansactionStorage();
+  const entries = sharedStorage.getStorage();
+  const entry = entries[state];
+  if (entry.transaction && isTransactionMeta(entry.transaction)) {
+    return entry.transaction;
+  }
+  return null;
+}
+
+export function clearTransactionFromSharedStorage(storageManager: StorageManager, state: string) {
+  const sharedStorage = storageManager.getSharedTansactionStorage();
+  const entries = sharedStorage.getStorage();
+  delete entries[state];
+  sharedStorage.setStorage(entries);
+}

--- a/lib/util/sharedStorage.ts
+++ b/lib/util/sharedStorage.ts
@@ -8,7 +8,8 @@ export function pruneSharedStorage(storageManager: StorageManager) {
   const entries = sharedStorage.getStorage();
   Object.keys(entries).forEach(state => {
     const entry = entries[state];
-    if (Date.now() - entry.dateCreated > MAX_ENTRY_LIFETIME) {
+    const age = Date.now() - entry.dateCreated;
+    if (age > MAX_ENTRY_LIFETIME) {
       delete entries[state];
     }
   });
@@ -30,7 +31,7 @@ export function loadTransactionFromSharedStorage(storageManager: StorageManager,
   const sharedStorage = storageManager.getSharedTansactionStorage();
   const entries = sharedStorage.getStorage();
   const entry = entries[state];
-  if (entry.transaction && isTransactionMeta(entry.transaction)) {
+  if (entry && entry.transaction && isTransactionMeta(entry.transaction)) {
     return entry.transaction;
   }
   return null;

--- a/test/apps/app/src/config.ts
+++ b/test/apps/app/src/config.ts
@@ -27,6 +27,7 @@ export interface Config extends OktaAuthOptions {
   clientSecret: string;
   forceRedirect: boolean;
   useInteractionCodeFlow: boolean; // widget option
+  enableSharedStorage: boolean; // TransactionManager
 }
 
 export function getDefaultConfig(): Config {
@@ -51,7 +52,8 @@ export function getDefaultConfig(): Config {
     cookies: {
       secure: true
     },
-    useInteractionCodeFlow: false
+    useInteractionCodeFlow: false,
+    enableSharedStorage: false
   };
 }
 
@@ -77,12 +79,14 @@ export function getConfigFromUrl(): Config {
   const idps = url.searchParams.get('idps') || '';
   const useInteractionCodeFlow = url.searchParams.get('useInteractionCodeFlow') === 'true'; // off by default
   const forceRedirect = url.searchParams.get('forceRedirect') === 'true'; // off by default
+  const enableSharedStorage = url.searchParams.get('enableSharedStorage') === 'true'; // off by default
 
   return {
     forceRedirect,
     siwVersion,
     siwAuthClient,
     idps,
+    enableSharedStorage,
     redirectUri,
     postLogoutRedirectUri,
     issuer,
@@ -100,6 +104,9 @@ export function getConfigFromUrl(): Config {
     tokenManager: {
       storage,
       expireEarlySeconds
+    },
+    transactionManager: {
+      enableSharedStorage
     },
     useInteractionCodeFlow
   };
@@ -128,8 +135,9 @@ export function flattenConfig(config: Config): any {
   const flat: Record<string, any> = {};
   Object.assign(flat, config.tokenManager);
   Object.assign(flat, config.cookies);
+  Object.assign(flat, config.transactionManager);
   Object.keys(config).forEach(key => {
-    if (key !== 'tokenManager' && key !== 'cookies') {
+    if (key !== 'tokenManager' && key !== 'cookies' && key !== 'transactionManager') {
       (flat as any)[key] = (config as any)[key];
     }
   });

--- a/test/apps/app/src/form.ts
+++ b/test/apps/app/src/form.ts
@@ -48,6 +48,9 @@ const Form = `
     <option value="cookie">Cookie</option>
     <option value="memory">Memory</option>
   </select><br/>
+  <label for="enableSharedStorage">Enable shared transaction storage (to continue flow in another tab)</label><br/>
+  <input id="f_enableSharedStorage-on" name="enableSharedStorage" type="radio" value="true"/>YES<br/>
+  <input id="f_enableSharedStorage-off" name="enableSharedStorage" type="radio" value="false"/>NO<br/>
   <label for="expireEarlySeconds">ExpireEarlySeconds</label><input id="f_expireEarlySeconds" name="expireEarlySeconds" type="number" /><br/>
   <label for="secure">Secure Cookies</label><br/>
   <input id="f_secureCookies-on" name="secure" type="radio" value="true"/>ON<br/>
@@ -131,6 +134,12 @@ export function updateForm(origConfig: Config): void {
     (document.getElementById('f_authClient-on') as HTMLInputElement).checked = true;
   } else {
     (document.getElementById('f_authClient-off') as HTMLInputElement).checked = true;
+  }
+
+  if (config.enableSharedStorage) {
+    (document.getElementById('f_enableSharedStorage-on') as HTMLInputElement).checked = true;
+  } else {
+    (document.getElementById('f_enableSharedStorage-off') as HTMLInputElement).checked = true;
   }
 }
 


### PR DESCRIPTION
- when enabled transaction data is stored in localStorage, indexed by state
- if `transactionManager.load(` is called with a matching `state` then transaction data can be retrieved by another tab
- entries are pruned on load. (maximum age is 30 minutes)

Must be enabled via config:
```
{
  transactionManager: {
    enableSharedStorage: true
  }
}
```
Test app includes checkbox option to enable this feature.
