### PR TITLE
fix: autoRenew tokens when isAuthenticated is called

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -145,6 +145,7 @@ export function buildOptions(args: OktaAuthOptions = {}): OktaAuthOptions {
     devMode: !!args.devMode,
     storageManager: args.storageManager,
     cookies: isBrowser() ? getCookieSettings(args, isHTTPS()) : args.cookies,
+    tokenManager: args.tokenManager,
 
     // Give the developer the ability to disable token signature validation.
     ignoreSignature: !!args.ignoreSignature,


### PR DESCRIPTION
tokenManager config is not copied from OktaAuth instantiation options and not available in OktaAuth.isAuthenticated
Resolves: #924