### PR TITLE
fix: autoRenew tokens when isAuthenticated is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.4.3
+
+### Bug Fixes
+
+- [#926](https://github.com/okta/okta-auth-js/pull/926) Fixes incorrect using of `tokenManager` config (options `autoRenew`, `autoRemove`) in `OktaAuth.isAuthenticated`.
+
 ## 5.4.2
 
 ### Bug Fixes

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -502,7 +502,7 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
   async isAuthenticated(): Promise<boolean> {
 
     let { accessToken, idToken } = this.tokenManager.getTokensSync();
-    const { autoRenew, autoRemove } = this.options.tokenManager || {};
+    const { autoRenew, autoRemove } = this.tokenManager.getOptions();
 
     if (accessToken && this.tokenManager.hasExpired(accessToken)) {
       accessToken = null;

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -145,7 +145,6 @@ export function buildOptions(args: OktaAuthOptions = {}): OktaAuthOptions {
     devMode: !!args.devMode,
     storageManager: args.storageManager,
     cookies: isBrowser() ? getCookieSettings(args, isHTTPS()) : args.cookies,
-    tokenManager: args.tokenManager,
 
     // Give the developer the ability to disable token signature validation.
     ignoreSignature: !!args.ignoreSignature,

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -145,6 +145,7 @@ export function buildOptions(args: OktaAuthOptions = {}): OktaAuthOptions {
     devMode: !!args.devMode,
     storageManager: args.storageManager,
     cookies: isBrowser() ? getCookieSettings(args, isHTTPS()) : args.cookies,
+    tokenManager: args.tokenManager,
 
     // Give the developer the ability to disable token signature validation.
     ignoreSignature: !!args.ignoreSignature,

--- a/test/spec/OktaAuth/api.ts
+++ b/test/spec/OktaAuth/api.ts
@@ -227,6 +227,10 @@ describe('OktaAuth (api)', function() {
         accessToken: { accessToken: true },
         idToken: { idToken: true }
       });
+      jest.spyOn(auth.tokenManager, 'getOptions').mockReturnValue({
+        autoRenew: false,
+        autoRemove: false,
+      });
       jest.spyOn(auth.tokenManager, 'hasExpired').mockImplementation(token => {
         return isAccessToken(token) ? true : false;
       });
@@ -240,6 +244,10 @@ describe('OktaAuth (api)', function() {
       jest.spyOn(auth.tokenManager, 'getTokensSync').mockReturnValue({
         accessToken: { accessToken: true },
         idToken: { idToken: true }
+      });
+      jest.spyOn(auth.tokenManager, 'getOptions').mockReturnValue({
+        autoRenew: false,
+        autoRemove: false,
       });
       jest.spyOn(auth.tokenManager, 'hasExpired').mockImplementation(token => {
         return isIDToken(token) ? true : false;

--- a/test/spec/OktaAuth/api.ts
+++ b/test/spec/OktaAuth/api.ts
@@ -298,6 +298,49 @@ describe('OktaAuth (api)', function() {
         expect(auth.tokenManager.renew).toHaveBeenCalledWith('idToken');
       });
     });
+
+    describe('if autoRemove=true', () => {
+      beforeEach(function() {
+        auth = new OktaAuth({ issuer, pkce: false, tokenManager: {
+          autoRenew: false,
+          autoRemove: true,
+        } });
+      });
+
+      it('remove expired accessToken and return false', async () => {
+        jest.spyOn(auth.tokenManager, 'getTokensSync').mockReturnValue({
+          accessToken: { accessToken: true },
+          idToken: { idToken: true }
+        });
+        jest.spyOn(auth.tokenManager, 'hasExpired').mockImplementation(token => {
+          return isAccessToken(token) ? true : false;
+        });
+        jest.spyOn(auth.tokenManager, 'remove').mockReturnValue(undefined);
+        const res = await auth.isAuthenticated();
+        expect(res).toBe(false);
+        expect(auth.tokenManager.getTokensSync).toHaveBeenCalled();
+        expect(auth.tokenManager.hasExpired).toHaveBeenCalledTimes(2);
+        expect(auth.tokenManager.remove).toHaveBeenCalledTimes(1);
+        expect(auth.tokenManager.remove).toHaveBeenCalledWith('accessToken');
+      });
+  
+      it('remove expired idToken and return false', async () => {
+        jest.spyOn(auth.tokenManager, 'getTokensSync').mockReturnValue({
+          accessToken: { accessToken: true },
+          idToken: { idToken: true }
+        });
+        jest.spyOn(auth.tokenManager, 'hasExpired').mockImplementation(token => {
+          return isIDToken(token) ? true : false;
+        });
+        jest.spyOn(auth.tokenManager, 'remove').mockReturnValue(undefined);
+        const res = await auth.isAuthenticated();
+        expect(res).toBe(false);
+        expect(auth.tokenManager.getTokensSync).toHaveBeenCalled();
+        expect(auth.tokenManager.hasExpired).toHaveBeenCalledTimes(2);
+        expect(auth.tokenManager.remove).toHaveBeenCalledTimes(1);
+        expect(auth.tokenManager.remove).toHaveBeenCalledWith('idToken');
+      });
+    });
   });
 
   describe('getUser', () => {

--- a/test/spec/OktaAuth/api.ts
+++ b/test/spec/OktaAuth/api.ts
@@ -272,7 +272,7 @@ describe('OktaAuth (api)', function() {
         jest.spyOn(auth.tokenManager, 'hasExpired').mockImplementation(token => {
           return isAccessToken(token) ? true : false;
         });
-        jest.spyOn(auth.tokenManager, 'renew').mockImplementation(_tokenType => true);
+        jest.spyOn(auth.tokenManager, 'renew').mockReturnValue(true);
         const res = await auth.isAuthenticated();
         expect(res).toBe(true);
         expect(auth.tokenManager.getTokensSync).toHaveBeenCalled();
@@ -289,7 +289,7 @@ describe('OktaAuth (api)', function() {
         jest.spyOn(auth.tokenManager, 'hasExpired').mockImplementation(token => {
           return isIDToken(token) ? true : false;
         });
-        jest.spyOn(auth.tokenManager, 'renew').mockImplementation(_tokenType => true);
+        jest.spyOn(auth.tokenManager, 'renew').mockReturnValue(true);
         const res = await auth.isAuthenticated();
         expect(res).toBe(true);
         expect(auth.tokenManager.getTokensSync).toHaveBeenCalled();

--- a/test/spec/OktaAuth/api.ts
+++ b/test/spec/OktaAuth/api.ts
@@ -185,7 +185,6 @@ describe('OktaAuth (api)', function() {
   });
 
   describe('isAuthenticated', () => {
-
     beforeEach(function() {
       auth = new OktaAuth({ issuer, pkce: false, tokenManager: {
         autoRenew: false,
@@ -257,48 +256,48 @@ describe('OktaAuth (api)', function() {
       expect(auth.tokenManager.hasExpired).toHaveBeenCalledTimes(2);
     });
 
-    it('can renew expired accessToken and return true if autoRenew=true', async () => {
-      jest.spyOn(auth.tokenManager, 'getTokensSync').mockReturnValue({
-        accessToken: { accessToken: true },
-        idToken: { idToken: true }
+    describe('if autoRenew=true', () => {
+      beforeEach(function() {
+        auth = new OktaAuth({ issuer, pkce: false, tokenManager: {
+          autoRenew: true,
+          autoRemove: false,
+        } });
       });
-      jest.spyOn(auth.tokenManager, 'getOptions').mockReturnValue({
-        autoRenew: true,
-        autoRemove: false,
-      });
-      jest.spyOn(auth.tokenManager, 'hasExpired').mockImplementation(token => {
-        return isAccessToken(token) ? true : false;
-      });
-      jest.spyOn(auth.tokenManager, 'renew').mockImplementation(_tokenType => true);
-      const res = await auth.isAuthenticated();
-      expect(res).toBe(true);
-      expect(auth.tokenManager.getTokensSync).toHaveBeenCalled();
-      expect(auth.tokenManager.hasExpired).toHaveBeenCalledTimes(2);
-      expect(auth.tokenManager.renew).toHaveBeenCalledTimes(1);
-      expect(auth.tokenManager.renew).toHaveBeenCalledWith('accessToken');
-    });
 
-    it('can renew expired idToken and return true if autoRenew=true', async () => {
-      jest.spyOn(auth.tokenManager, 'getTokensSync').mockReturnValue({
-        accessToken: { accessToken: true },
-        idToken: { idToken: true }
+      it('renew expired accessToken and return true', async () => {
+        jest.spyOn(auth.tokenManager, 'getTokensSync').mockReturnValue({
+          accessToken: { accessToken: true },
+          idToken: { idToken: true }
+        });
+        jest.spyOn(auth.tokenManager, 'hasExpired').mockImplementation(token => {
+          return isAccessToken(token) ? true : false;
+        });
+        jest.spyOn(auth.tokenManager, 'renew').mockImplementation(_tokenType => true);
+        const res = await auth.isAuthenticated();
+        expect(res).toBe(true);
+        expect(auth.tokenManager.getTokensSync).toHaveBeenCalled();
+        expect(auth.tokenManager.hasExpired).toHaveBeenCalledTimes(2);
+        expect(auth.tokenManager.renew).toHaveBeenCalledTimes(1);
+        expect(auth.tokenManager.renew).toHaveBeenCalledWith('accessToken');
       });
-      jest.spyOn(auth.tokenManager, 'getOptions').mockReturnValue({
-        autoRenew: true,
-        autoRemove: false,
+  
+      it('renew expired idToken and return true', async () => {
+        jest.spyOn(auth.tokenManager, 'getTokensSync').mockReturnValue({
+          accessToken: { accessToken: true },
+          idToken: { idToken: true }
+        });
+        jest.spyOn(auth.tokenManager, 'hasExpired').mockImplementation(token => {
+          return isIDToken(token) ? true : false;
+        });
+        jest.spyOn(auth.tokenManager, 'renew').mockImplementation(_tokenType => true);
+        const res = await auth.isAuthenticated();
+        expect(res).toBe(true);
+        expect(auth.tokenManager.getTokensSync).toHaveBeenCalled();
+        expect(auth.tokenManager.hasExpired).toHaveBeenCalledTimes(2);
+        expect(auth.tokenManager.renew).toHaveBeenCalledTimes(1);
+        expect(auth.tokenManager.renew).toHaveBeenCalledWith('idToken');
       });
-      jest.spyOn(auth.tokenManager, 'hasExpired').mockImplementation(token => {
-        return isIDToken(token) ? true : false;
-      });
-      jest.spyOn(auth.tokenManager, 'renew').mockImplementation(_tokenType => true);
-      const res = await auth.isAuthenticated();
-      expect(res).toBe(true);
-      expect(auth.tokenManager.getTokensSync).toHaveBeenCalled();
-      expect(auth.tokenManager.hasExpired).toHaveBeenCalledTimes(2);
-      expect(auth.tokenManager.renew).toHaveBeenCalledTimes(1);
-      expect(auth.tokenManager.renew).toHaveBeenCalledWith('idToken');
     });
-
   });
 
   describe('getUser', () => {

--- a/test/spec/OktaAuth/api.ts
+++ b/test/spec/OktaAuth/api.ts
@@ -258,6 +258,48 @@ describe('OktaAuth (api)', function() {
       expect(auth.tokenManager.hasExpired).toHaveBeenCalledTimes(2);
     });
 
+    it('can renew expired accessToken and return true if autoRenew=true', async () => {
+      jest.spyOn(auth.tokenManager, 'getTokensSync').mockReturnValue({
+        accessToken: { accessToken: true },
+        idToken: { idToken: true }
+      });
+      jest.spyOn(auth.tokenManager, 'getOptions').mockReturnValue({
+        autoRenew: true,
+        autoRemove: false,
+      });
+      jest.spyOn(auth.tokenManager, 'hasExpired').mockImplementation(token => {
+        return isAccessToken(token) ? true : false;
+      });
+      jest.spyOn(auth.tokenManager, 'renew').mockImplementation(_tokenType => true);
+      const res = await auth.isAuthenticated();
+      expect(res).toBe(true);
+      expect(auth.tokenManager.getTokensSync).toHaveBeenCalled();
+      expect(auth.tokenManager.hasExpired).toHaveBeenCalledTimes(2);
+      expect(auth.tokenManager.renew).toHaveBeenCalledTimes(1);
+      expect(auth.tokenManager.renew).toHaveBeenCalledWith('accessToken');
+    });
+
+    it('can renew expired idToken and return true if autoRenew=true', async () => {
+      jest.spyOn(auth.tokenManager, 'getTokensSync').mockReturnValue({
+        accessToken: { accessToken: true },
+        idToken: { idToken: true }
+      });
+      jest.spyOn(auth.tokenManager, 'getOptions').mockReturnValue({
+        autoRenew: true,
+        autoRemove: false,
+      });
+      jest.spyOn(auth.tokenManager, 'hasExpired').mockImplementation(token => {
+        return isIDToken(token) ? true : false;
+      });
+      jest.spyOn(auth.tokenManager, 'renew').mockImplementation(_tokenType => true);
+      const res = await auth.isAuthenticated();
+      expect(res).toBe(true);
+      expect(auth.tokenManager.getTokensSync).toHaveBeenCalled();
+      expect(auth.tokenManager.hasExpired).toHaveBeenCalledTimes(2);
+      expect(auth.tokenManager.renew).toHaveBeenCalledTimes(1);
+      expect(auth.tokenManager.renew).toHaveBeenCalledWith('idToken');
+    });
+
   });
 
   describe('getUser', () => {

--- a/test/spec/OktaAuth/api.ts
+++ b/test/spec/OktaAuth/api.ts
@@ -186,6 +186,13 @@ describe('OktaAuth (api)', function() {
 
   describe('isAuthenticated', () => {
 
+    beforeEach(function() {
+      auth = new OktaAuth({ issuer, pkce: false, tokenManager: {
+        autoRenew: false,
+        autoRemove: false,
+      } });
+    });
+
     it('returns true if accessToken and idToken exist and are not expired', async () => {
       jest.spyOn(auth.tokenManager, 'getTokensSync').mockReturnValue({
         accessToken: { fake: true },
@@ -227,10 +234,6 @@ describe('OktaAuth (api)', function() {
         accessToken: { accessToken: true },
         idToken: { idToken: true }
       });
-      jest.spyOn(auth.tokenManager, 'getOptions').mockReturnValue({
-        autoRenew: false,
-        autoRemove: false,
-      });
       jest.spyOn(auth.tokenManager, 'hasExpired').mockImplementation(token => {
         return isAccessToken(token) ? true : false;
       });
@@ -244,10 +247,6 @@ describe('OktaAuth (api)', function() {
       jest.spyOn(auth.tokenManager, 'getTokensSync').mockReturnValue({
         accessToken: { accessToken: true },
         idToken: { idToken: true }
-      });
-      jest.spyOn(auth.tokenManager, 'getOptions').mockReturnValue({
-        autoRenew: false,
-        autoRemove: false,
       });
       jest.spyOn(auth.tokenManager, 'hasExpired').mockImplementation(token => {
         return isIDToken(token) ? true : false;

--- a/test/support/util.js
+++ b/test/support/util.js
@@ -229,7 +229,8 @@ function setup(options) {
         headers: options.headers,
         ignoreSignature: options.bypassCrypto === true,
         tokenManager: {
-          autoRenew: false
+          autoRenew: false,
+          autoRemove: false
         }
       });
 


### PR DESCRIPTION
Copy of https://github.com/okta/okta-auth-js/pull/925 with tests and using `tokenManager.getOptions`

Fixes issue: tokenManager config is not actually used in OktaAuth.isAuthenticated
Resolves: #924

Internal ref: OKTA-425705