### PR TITLE
fix: OIE user not assigned error in res - OKTA-420953

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#926](https://github.com/okta/okta-auth-js/pull/926) Fixes incorrect using of `tokenManager` config (options `autoRenew`, `autoRemove`) in `OktaAuth.isAuthenticated`.
 - [#931](https://github.com/okta/okta-auth-js/pull/931) Fixes types compatibility issue with old typescript versions (< 3.8)
+- [#930](https://github.com/okta/okta-auth-js/pull/930) Fixes incorrect error message in idx `AuthTransaction` when user is not assigned.
 
 ## 5.4.2
 
@@ -15,7 +16,7 @@
 
 ## 5.4.1
 
--[#916](https://github.com/okta/okta-auth-js/pull/916) Removes misleading warning message for TokenManager methods
+- [#916](https://github.com/okta/okta-auth-js/pull/916) Removes misleading warning message for TokenManager methods
 
 ## 5.4.0
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "5.4.2",
+  "version": "5.4.3",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/test/apps/react-oie/src/App.js
+++ b/test/apps/react-oie/src/App.js
@@ -47,19 +47,34 @@ function App() {
     setTransaction(newTransaction);
   };
 
+  const handleLogoutOut = async () => {
+    await oktaAuth.signOut();
+  };
+
   if (!transaction) {
     return <div>loading...</div>;
   }
 
-  const { status, tokens, nextStep } = transaction;
+  const { status, tokens, nextStep, error, messages } = transaction;
   
   if (status === IdxStatus.SUCCESS) {
     return (
       <>
-        <h3>ID Token</h3>
-        <pre>{JSON.stringify(tokens.idToken, undefined, 2)}</pre>
+        <button onClick={handleLogoutOut}>Logout</button>
+        <div>
+          <h3>ID Token</h3>
+          <pre>{JSON.stringify(tokens.idToken, undefined, 2)}</pre>
+        </div>
       </>
     );
+  }
+
+  if (status === IdxStatus.FAILURE) {
+    return (<div>{error.errorSummary}</div>);
+  }
+
+  if (status === IdxStatus.TERMINAL) {
+    return (<div>{JSON.stringify(messages, null, 4)}</div>);
   }
 
   const { name, inputs, select } = formMetaMapper(nextStep);
@@ -67,12 +82,10 @@ function App() {
     <form onSubmit={handleSubmit}>
       <h3>{name}</h3>
       {inputs && inputs.map(({ label, name, type, required }) => (
-        <>
-          <label>{label}&nbsp;
-            <input name={name} type={type} required={required} onChange={handleChange} />
-          </label>
+        <label key={name}>{label}&nbsp;
+          <input name={name} type={type} required={required} onChange={handleChange} />
           <br/>
-        </>
+        </label>
       ))}
       {select && (
         <select name={select.name} onChange={handleChange}>

--- a/test/spec/idx/authenticate.ts
+++ b/test/spec/idx/authenticate.ts
@@ -254,6 +254,31 @@ describe('idx/authenticate', () => {
       }]);
     });
 
+    it('returns terminal error when user account is not assigned to the application and okta session exists', async () => {
+      const { authClient } = testContext;
+      const errorResponse = RawIdxResponseFactory.build({
+        messages: IdxMessagesFactory.build({
+          value: [
+            IdxErrorUserNotAssignedFactory.build()
+          ]
+        })
+      });
+      const idxResponse = IdxResponseFactory.build({
+        rawIdxState: errorResponse
+      });
+      jest.spyOn(mocked.introspect, 'introspect').mockResolvedValue(idxResponse);
+
+      const res = await authenticate(authClient, {});
+      expect(res.status).toBe(IdxStatus.TERMINAL);
+      expect(res.messages).toEqual([{
+        class: 'ERROR',
+        i18n: {
+          key: undefined // this error does not have an i18n key
+        },
+        message: 'User is not assigned to this application'
+      }]);
+    });
+
     it('returns terminal error when user account is locked or suspeneded', async () => {
       const { authClient } = testContext;
       const errorResponse = RawIdxResponseFactory.build({


### PR DESCRIPTION
introspect call only returns `messages` field when session has already been created and user is not assigned to the app.

This fix handles the above scenario by returning `terminal` state with messages in authTransaction.