### PR TITLE
Add response headers to all responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - [#933](https://github.com/okta/okta-auth-js/pull/933) Adds `ignoreLifetime` option to disable token lifetime validation
+- [#932](https://github.com/okta/okta-auth-js/pull/932) Adds `headers` with response headers to all responses
 
 ## 5.4.3
 

--- a/lib/fetch/fetchRequest.ts
+++ b/lib/fetch/fetchRequest.ts
@@ -29,11 +29,12 @@ function readData(response: FetchResponse): Promise<object | string> {
   }
 }
 
-function formatResult(status: number, data: object | string) {
+function formatResult(status: number, data: object | string, response: Response) {
   const isObject = typeof data === 'object';
   const result: HttpResponse = {
     responseText: isObject ? JSON.stringify(data) : data as string,
-    status: status
+    status: status,
+    rawResponse: response
   };
   if (isObject) {
     result.responseType = 'json';
@@ -69,7 +70,7 @@ function fetchRequest(method: string, url: string, args: FetchOptions) {
     var status = response.status;
     return readData(response)
       .then(data => {
-        return formatResult(status, data);
+        return formatResult(status, data, response);
       })
       .then(result => {
         if (error || result.responseJSON?.error) {

--- a/lib/fetch/fetchRequest.ts
+++ b/lib/fetch/fetchRequest.ts
@@ -31,14 +31,14 @@ function readData(response: FetchResponse): Promise<object | string> {
 
 function formatResult(status: number, data: object | string, response: Response) {
   const isObject = typeof data === 'object';
-  const responseHeaders = {};
+  const headers = {};
   for (const pair of response.headers.entries()) {
-    responseHeaders[pair[0]] = pair[1];
+    headers[pair[0]] = pair[1];
   }
   const result: HttpResponse = {
     responseText: isObject ? JSON.stringify(data) : data as string,
     status: status,
-    responseHeaders
+    headers
   };
   if (isObject) {
     result.responseType = 'json';

--- a/lib/fetch/fetchRequest.ts
+++ b/lib/fetch/fetchRequest.ts
@@ -31,10 +31,14 @@ function readData(response: FetchResponse): Promise<object | string> {
 
 function formatResult(status: number, data: object | string, response: Response) {
   const isObject = typeof data === 'object';
+  const responseHeaders = {};
+  for (const pair of response.headers.entries()) {
+    responseHeaders[pair[0]] = pair[1];
+  }
   const result: HttpResponse = {
     responseText: isObject ? JSON.stringify(data) : data as string,
     status: status,
-    rawResponse: response
+    responseHeaders
   };
   if (isObject) {
     result.responseType = 'json';

--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -63,7 +63,7 @@ export function httpRequest(sdk: OktaAuth, options: RequestOptions): Promise<any
       if (res && isString(res)) {
         res = JSON.parse(res);
         if (res && typeof res === 'object') {
-          res.rawResponse = resp.rawResponse;
+          res.responseHeaders = resp.responseHeaders;
         }
       }
 
@@ -78,14 +78,9 @@ export function httpRequest(sdk: OktaAuth, options: RequestOptions): Promise<any
       }
 
       if (res && options.cacheResponse) {
-        let cachedRes = res;
-        if (typeof res === 'object') {
-          cachedRes = {...res};
-          delete cachedRes.rawResponse;
-        }
         httpCache.updateStorage(url, {
           expiresAt: Math.floor(Date.now()/1000) + DEFAULT_CACHE_DURATION,
-          response: cachedRes
+          response: res
         });
       }
 

--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -62,6 +62,9 @@ export function httpRequest(sdk: OktaAuth, options: RequestOptions): Promise<any
       res = resp.responseText;
       if (res && isString(res)) {
         res = JSON.parse(res);
+        if (res && typeof res === 'object') {
+          res.rawResponse = resp.rawResponse;
+        }
       }
 
       if (saveAuthnState) {
@@ -75,9 +78,14 @@ export function httpRequest(sdk: OktaAuth, options: RequestOptions): Promise<any
       }
 
       if (res && options.cacheResponse) {
+        let cachedRes = res;
+        if (typeof res === 'object') {
+          cachedRes = {...res};
+          delete cachedRes.rawResponse;
+        }
         httpCache.updateStorage(url, {
           expiresAt: Math.floor(Date.now()/1000) + DEFAULT_CACHE_DURATION,
-          response: res
+          response: cachedRes
         });
       }
 

--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -62,8 +62,8 @@ export function httpRequest(sdk: OktaAuth, options: RequestOptions): Promise<any
       res = resp.responseText;
       if (res && isString(res)) {
         res = JSON.parse(res);
-        if (res && typeof res === 'object') {
-          res.responseHeaders = resp.responseHeaders;
+        if (res && typeof res === 'object' && !res.headers) {
+          res.headers = resp.headers;
         }
       }
 

--- a/lib/types/http.ts
+++ b/lib/types/http.ts
@@ -53,5 +53,5 @@ export interface HttpResponse {
   responseJSON?: {
     [propName: string]: any;
   };
-  rawResponse: Response;
+  responseHeaders: HeadersInit;
 }

--- a/lib/types/http.ts
+++ b/lib/types/http.ts
@@ -53,4 +53,5 @@ export interface HttpResponse {
   responseJSON?: {
     [propName: string]: any;
   };
+  rawResponse: Response;
 }

--- a/lib/types/http.ts
+++ b/lib/types/http.ts
@@ -53,5 +53,5 @@ export interface HttpResponse {
   responseJSON?: {
     [propName: string]: any;
   };
-  responseHeaders: HeadersInit;
+  headers: HeadersInit;
 }

--- a/test/spec/TokenManager/renew.ts
+++ b/test/spec/TokenManager/renew.ts
@@ -178,7 +178,7 @@ describe('TokenManager renew', () => {
         responseJSON: {
           error: 'invalid_grant'
         },
-        responseHeaders: {}
+        headers: {}
       });
       try {
         await testContext.instance.renew('idToken');

--- a/test/spec/TokenManager/renew.ts
+++ b/test/spec/TokenManager/renew.ts
@@ -178,7 +178,7 @@ describe('TokenManager renew', () => {
         responseJSON: {
           error: 'invalid_grant'
         },
-        rawResponse: null
+        responseHeaders: {}
       });
       try {
         await testContext.instance.renew('idToken');

--- a/test/spec/TokenManager/renew.ts
+++ b/test/spec/TokenManager/renew.ts
@@ -177,7 +177,8 @@ describe('TokenManager renew', () => {
         responseText: 'does not matter',
         responseJSON: {
           error: 'invalid_grant'
-        }
+        },
+        rawResponse: null
       });
       try {
         await testContext.instance.renew('idToken');

--- a/test/spec/authn/__snapshots__/mfa-challenge.js.snap
+++ b/test/spec/authn/__snapshots__/mfa-challenge.js.snap
@@ -76,7 +76,7 @@ Object {
   },
   "expiresAt": "2015-06-10T22:42:40.224Z",
   "factorResult": "WAITING",
-  "responseHeaders": Object {
+  "headers": Object {
     "Content-Type": "application/json",
     "X-Rate-Limit-Limit": 1000,
   },

--- a/test/spec/authn/__snapshots__/mfa-challenge.js.snap
+++ b/test/spec/authn/__snapshots__/mfa-challenge.js.snap
@@ -76,6 +76,10 @@ Object {
   },
   "expiresAt": "2015-06-10T22:42:40.224Z",
   "factorResult": "WAITING",
+  "responseHeaders": Object {
+    "Content-Type": "application/json",
+    "X-Rate-Limit-Limit": 1000,
+  },
   "stateToken": "00T4jcVNRzJy5dkWJ4P7c9051dY3FUYY9O2zvbU_vI",
   "status": "MFA_CHALLENGE",
 }

--- a/test/spec/authn/factor-enroll.js
+++ b/test/spec/authn/factor-enroll.js
@@ -33,9 +33,9 @@ describe('FACTOR_ENROLL', function () {
           });
           return factor.questions();
         },
-        expectations: function (test, res) {
+        expectations: function (test, res, resp) {
           expect(test.resReply.status).toEqual(200);
-          expect(test.responseBody).toEqual(res);
+          expect(resp).toEqual(res);
         }
       });
     });

--- a/test/spec/authn/mfa-challenge.js
+++ b/test/spec/authn/mfa-challenge.js
@@ -1350,7 +1350,7 @@ describe('MFA_CHALLENGE', function () {
       expectations: function (test) {
         expect(test.transactionCallbackFn.calls.count()).toBe(2);
         const res = test.transactionCallbackFn.calls.argsFor(0)[0];
-        delete res.rawResponse;
+        delete res.responseHeaders; //todo
         expect(res).toMatchSnapshot();
       },
     });

--- a/test/spec/authn/mfa-challenge.js
+++ b/test/spec/authn/mfa-challenge.js
@@ -1349,7 +1349,9 @@ describe('MFA_CHALLENGE', function () {
       },
       expectations: function (test) {
         expect(test.transactionCallbackFn.calls.count()).toBe(2);
-        expect(test.transactionCallbackFn.calls.argsFor(0)[0]).toMatchSnapshot();
+        const res = test.transactionCallbackFn.calls.argsFor(0)[0];
+        delete res.rawResponse;
+        expect(res).toMatchSnapshot();
       },
     });
 

--- a/test/spec/authn/mfa-challenge.js
+++ b/test/spec/authn/mfa-challenge.js
@@ -1350,7 +1350,6 @@ describe('MFA_CHALLENGE', function () {
       expectations: function (test) {
         expect(test.transactionCallbackFn.calls.count()).toBe(2);
         const res = test.transactionCallbackFn.calls.argsFor(0)[0];
-        delete res.responseHeaders; //todo
         expect(res).toMatchSnapshot();
       },
     });

--- a/test/spec/authn/mfa-challenge.js
+++ b/test/spec/authn/mfa-challenge.js
@@ -1349,8 +1349,7 @@ describe('MFA_CHALLENGE', function () {
       },
       expectations: function (test) {
         expect(test.transactionCallbackFn.calls.count()).toBe(2);
-        const res = test.transactionCallbackFn.calls.argsFor(0)[0];
-        expect(res).toMatchSnapshot();
+        expect(test.transactionCallbackFn.calls.argsFor(0)[0]).toMatchSnapshot();
       },
     });
 

--- a/test/spec/authn/mfa-enroll-activate.js
+++ b/test/spec/authn/mfa-enroll-activate.js
@@ -377,8 +377,8 @@ describe('MFA_ENROLL_ACTIVATE', function () {
             return trans.activate();
           });
       },
-      expectations: function (test) {
-        expect(test.trans.data).toEqual(test.responseBody);
+      expectations: function (test, _res, resp) {
+        expect(test.trans.data).toEqual(resp);
       }
     });
   });

--- a/test/spec/authn/mfa-enroll.js
+++ b/test/spec/authn/mfa-enroll.js
@@ -33,9 +33,9 @@ describe('MFA_ENROLL', function () {
           });
           return factor.questions();
         },
-        expectations: function (test, res) {
+        expectations: function (test, res, resp) {
           expect(test.resReply.status).toEqual(200);
-          expect(test.responseBody).toEqual(res);
+          expect(resp).toEqual(res);
         }
       });
     });

--- a/test/spec/fetchRequest.js
+++ b/test/spec/fetchRequest.js
@@ -33,6 +33,14 @@ describe('fetchRequest', function () {
 
   const fetchRequest = require('../../lib/fetch/fetchRequest').default;
 
+  const getResponseHeadersObject = function() {
+    const responseHeadersObject = {};
+    for (const pair of responseHeaders.entries()) {
+      responseHeadersObject[pair[0]] = pair[1];
+    }
+    return responseHeadersObject;
+  };
+
   beforeEach(function() {
     mocked.crossFetch.mockReset();
     mocked.crossFetch.mockImplementation(() => {
@@ -191,7 +199,7 @@ describe('fetchRequest', function () {
           responseJSON,
           responseText,
           responseType: 'json',
-          rawResponse: response
+          responseHeaders: getResponseHeadersObject()
         });
       });
     });
@@ -203,17 +211,18 @@ describe('fetchRequest', function () {
         expect(res).toEqual({
           status: response.status,
           responseText,
-          rawResponse: response
+          responseHeaders: getResponseHeadersObject()
         });
       });
     });
 
-    it('Contains rawResponse that can be used to get response headers', function() {
+    it('Contains responseHeaders', function() {
       responseHeaders.set('X-Rate-Limit-Limit', '500');
       return fetchRequest(requestMethod, requestUrl, {})
       .then(res => {
-        expect(res.rawResponse).toBeDefined();
-        expect(res.rawResponse.headers.get('X-Rate-Limit-Limit')).toEqual('500');
+        expect(res.responseHeaders).toBeDefined();
+        expect(typeof res.responseHeaders).toEqual('object');
+        expect(res.responseHeaders['X-Rate-Limit-Limit']).toEqual('500');
       });
     });
 
@@ -227,7 +236,7 @@ describe('fetchRequest', function () {
           responseText,
           responseType: 'json',
           responseJSON,
-          rawResponse: response
+          responseHeaders: getResponseHeadersObject()
         });
       });
     });
@@ -241,7 +250,7 @@ describe('fetchRequest', function () {
         expect(err).toEqual({
           status: response.status,
           responseText,
-          rawResponse: response
+          responseHeaders: getResponseHeadersObject()
         });
       });
     });
@@ -267,7 +276,7 @@ describe('fetchRequest', function () {
           responseText: JSON.stringify(errorJSON),
           responseJSON: errorJSON,
           responseType: 'json',
-          rawResponse: response
+          responseHeaders: getResponseHeadersObject()
         });
       });
     });
@@ -292,7 +301,7 @@ describe('fetchRequest', function () {
           responseText: JSON.stringify(errorJSON),
           responseJSON: errorJSON,
           responseType: 'json',
-          rawResponse: response
+          responseHeaders: getResponseHeadersObject()
         });
       });
     });

--- a/test/spec/fetchRequest.js
+++ b/test/spec/fetchRequest.js
@@ -208,7 +208,7 @@ describe('fetchRequest', function () {
       });
     });
 
-    it('Contains raw response that can be used to get response headers', function() {
+    it('Contains rawResponse that can be used to get response headers', function() {
       responseHeaders.set('X-Rate-Limit-Limit', '500');
       return fetchRequest(requestMethod, requestUrl, {})
       .then(res => {

--- a/test/spec/fetchRequest.js
+++ b/test/spec/fetchRequest.js
@@ -190,7 +190,8 @@ describe('fetchRequest', function () {
           status: response.status,
           responseJSON,
           responseText,
-          responseType: 'json'
+          responseType: 'json',
+          rawResponse: response
         });
       });
     });
@@ -201,7 +202,8 @@ describe('fetchRequest', function () {
       .then(res => {
         expect(res).toEqual({
           status: response.status,
-          responseText
+          responseText,
+          rawResponse: response
         });
       });
     });
@@ -215,7 +217,8 @@ describe('fetchRequest', function () {
           status: response.status,
           responseText,
           responseType: 'json',
-          responseJSON
+          responseJSON,
+          rawResponse: response
         });
       });
     });
@@ -228,7 +231,8 @@ describe('fetchRequest', function () {
       .catch(err => {
         expect(err).toEqual({
           status: response.status,
-          responseText
+          responseText,
+          rawResponse: response
         });
       });
     });
@@ -253,7 +257,8 @@ describe('fetchRequest', function () {
           status: response.status,
           responseText: JSON.stringify(errorJSON),
           responseJSON: errorJSON,
-          responseType: 'json'
+          responseType: 'json',
+          rawResponse: response
         });
       });
     });
@@ -277,7 +282,8 @@ describe('fetchRequest', function () {
           status: response.status,
           responseText: JSON.stringify(errorJSON),
           responseJSON: errorJSON,
-          responseType: 'json'
+          responseType: 'json',
+          rawResponse: response
         });
       });
     });

--- a/test/spec/fetchRequest.js
+++ b/test/spec/fetchRequest.js
@@ -199,7 +199,7 @@ describe('fetchRequest', function () {
           responseJSON,
           responseText,
           responseType: 'json',
-          responseHeaders: getResponseHeadersObject()
+          headers: getResponseHeadersObject()
         });
       });
     });
@@ -211,18 +211,18 @@ describe('fetchRequest', function () {
         expect(res).toEqual({
           status: response.status,
           responseText,
-          responseHeaders: getResponseHeadersObject()
+          headers: getResponseHeadersObject()
         });
       });
     });
 
-    it('Contains responseHeaders', function() {
+    it('Contains response headers', function() {
       responseHeaders.set('X-Rate-Limit-Limit', '500');
       return fetchRequest(requestMethod, requestUrl, {})
       .then(res => {
-        expect(res.responseHeaders).toBeDefined();
-        expect(typeof res.responseHeaders).toEqual('object');
-        expect(res.responseHeaders['X-Rate-Limit-Limit']).toEqual('500');
+        expect(res.headers).toBeDefined();
+        expect(typeof res.headers).toEqual('object');
+        expect(res.headers['X-Rate-Limit-Limit']).toEqual('500');
       });
     });
 
@@ -236,7 +236,7 @@ describe('fetchRequest', function () {
           responseText,
           responseType: 'json',
           responseJSON,
-          responseHeaders: getResponseHeadersObject()
+          headers: getResponseHeadersObject()
         });
       });
     });
@@ -250,7 +250,7 @@ describe('fetchRequest', function () {
         expect(err).toEqual({
           status: response.status,
           responseText,
-          responseHeaders: getResponseHeadersObject()
+          headers: getResponseHeadersObject()
         });
       });
     });
@@ -276,7 +276,7 @@ describe('fetchRequest', function () {
           responseText: JSON.stringify(errorJSON),
           responseJSON: errorJSON,
           responseType: 'json',
-          responseHeaders: getResponseHeadersObject()
+          headers: getResponseHeadersObject()
         });
       });
     });
@@ -301,7 +301,7 @@ describe('fetchRequest', function () {
           responseText: JSON.stringify(errorJSON),
           responseJSON: errorJSON,
           responseType: 'json',
-          responseHeaders: getResponseHeadersObject()
+          headers: getResponseHeadersObject()
         });
       });
     });

--- a/test/spec/fetchRequest.js
+++ b/test/spec/fetchRequest.js
@@ -208,6 +208,15 @@ describe('fetchRequest', function () {
       });
     });
 
+    it('Contains raw response that can be used to get response headers', function() {
+      responseHeaders.set('X-Rate-Limit-Limit', '500');
+      return fetchRequest(requestMethod, requestUrl, {})
+      .then(res => {
+        expect(res.rawResponse).toBeDefined();
+        expect(res.rawResponse.headers.get('X-Rate-Limit-Limit')).toEqual('500');
+      });
+    });
+
     it('Throws the response if response.ok is false (JSON)', () => {
       response.status = 401;
       response.ok = false;

--- a/test/spec/oidc/endpoints/well-known.ts
+++ b/test/spec/oidc/endpoints/well-known.ts
@@ -31,6 +31,18 @@ import wellKnown from '@okta/test.support/xhr/well-known';
 import keys from '@okta/test.support/xhr/keys';
 import tokens from '@okta/test.support/tokens';
 
+const responseHeaders = {
+  'Content-Type': 'application/json'
+};
+const wellKnownResponse = {
+  ...wellKnown.response,
+  responseHeaders
+};
+const keysResponse = {
+  ...keys.response,
+  responseHeaders
+};
+
 // Expected cookie settings. Cache will use the same settings on HTTP and HTTPS
 var cookieSettings = {
   secure: false,
@@ -61,9 +73,9 @@ describe('getWellKnown', function() {
     execute: function(test) {
       return getWellKnown(test.oa);
     },
-    expectations: function (test, res) {
+    expectations: function (test, res, resp) {
       expect(test.resReply.status).toEqual(200);
-      expect(test.responseBody).toEqual(res);
+      expect(resp).toEqual(res);
     }
   });
   util.itMakesCorrectRequestResponse({
@@ -84,9 +96,9 @@ describe('getWellKnown', function() {
     execute: function(test) {
       return getWellKnown(test.oa);
     },
-    expectations: function (test, res) {
+    expectations: function (test, res, resp) {
       expect(test.resReply.status).toEqual(200);
-      expect(test.responseBody).toEqual(res);
+      expect(resp).toEqual(res);
     }
   });
   util.itMakesCorrectRequestResponse({
@@ -107,9 +119,9 @@ describe('getWellKnown', function() {
     execute: function(test) {
       return getWellKnown(test.oa);
     },
-    expectations: function (test, res) {
+    expectations: function (test, res, resp) {
       expect(test.resReply.status).toEqual(200);
-      expect(test.responseBody).toEqual(res);
+      expect(resp).toEqual(res);
     }
   });
   util.itMakesCorrectRequestResponse({
@@ -129,9 +141,9 @@ describe('getWellKnown', function() {
     execute: function(test) {
       return getWellKnown(test.oa, 'https://auth-js-test.okta.com/oauth2/custom2');
     },
-    expectations: function (test, res) {
+    expectations: function (test, res, resp) {
       expect(test.resReply.status).toEqual(200);
-      expect(test.responseBody).toEqual(res);
+      expect(resp).toEqual(res);
     }
   });
   util.itMakesCorrectRequestResponse({
@@ -160,7 +172,7 @@ describe('getWellKnown', function() {
       expect(cache).toEqual({
         'https://auth-js-test.okta.com/.well-known/openid-configuration': {
           expiresAt: 1449786329,
-          response: wellKnown.response
+          response: wellKnownResponse
         }
       });
     }
@@ -175,7 +187,7 @@ describe('getWellKnown', function() {
       storage.setStorage({
         'https://auth-js-test.okta.com/.well-known/openid-configuration': {
           expiresAt: 1449786329,
-          response: wellKnown.response
+          response: wellKnownResponse
         }
       });
       return getWellKnown(test.oa);
@@ -185,7 +197,7 @@ describe('getWellKnown', function() {
       expect(cache).toEqual({
         'https://auth-js-test.okta.com/.well-known/openid-configuration': {
           expiresAt: 1449786329,
-          response: wellKnown.response
+          response: wellKnownResponse
         }
       });
     }
@@ -209,7 +221,7 @@ describe('getWellKnown', function() {
       storage.setStorage({
         'https://auth-js-test.okta.com/.well-known/openid-configuration': {
           expiresAt: 1449786329,
-          response: wellKnown.response
+          response: wellKnownResponse
         }
       });
       return getWellKnown(test.oa);
@@ -219,7 +231,7 @@ describe('getWellKnown', function() {
       expect(cache).toEqual({
         'https://auth-js-test.okta.com/.well-known/openid-configuration': {
           expiresAt: 1450086400,
-          response: wellKnown.response
+          response: wellKnownResponse
         }
       });
     }
@@ -256,7 +268,7 @@ describe('getWellKnown', function() {
         expect(cache).toEqual(JSON.stringify({
           'https://auth-js-test.okta.com/.well-known/openid-configuration': {
             expiresAt: 1449786329,
-            response: wellKnown.response
+            response: wellKnownResponse
           }
         }));
       }
@@ -289,7 +301,7 @@ describe('getWellKnown', function() {
           JSON.stringify({
             'https://auth-js-test.okta.com/.well-known/openid-configuration': {
               expiresAt: 1449786329,
-              response: wellKnown.response
+              response: wellKnownResponse
             }
           }),
           '2200-01-01T00:00:00.000Z',
@@ -326,7 +338,7 @@ describe('getWellKnown', function() {
           JSON.stringify({
             'https://auth-js-test.okta.com/.well-known/openid-configuration': {
               expiresAt: 1449786329,
-              response: wellKnown.response
+              response: wellKnownResponse
             }
           }),
           '2200-01-01T00:00:00.000Z',
@@ -371,7 +383,7 @@ describe('getKey', function() {
       storage.setStorage({
         'https://auth-js-test.okta.com/.well-known/openid-configuration': {
           expiresAt: 1449786329,
-          response: wellKnown.response
+          response: wellKnownResponse
         }
       });
       return getKey(test.oa, null, 'U5R8cHbGw445Qbq8zVO1PcCpXL8yG6IcovVa3laCoxM');
@@ -382,11 +394,11 @@ describe('getKey', function() {
       expect(cache).toEqual({
         'https://auth-js-test.okta.com/.well-known/openid-configuration': {
           expiresAt: 1449786329,
-          response: wellKnown.response
+          response: wellKnownResponse
         },
         'https://auth-js-test.okta.com/oauth2/v1/keys': {
           expiresAt: 1449786329,
-          response: keys.response
+          response: keysResponse
         }
       });
     }
@@ -412,7 +424,7 @@ describe('getKey', function() {
       storage.setStorage({
         'https://auth-js-test.okta.com/.well-known/openid-configuration': {
           expiresAt: 1449786329,
-          response: wellKnown.response
+          response: wellKnownResponse
         },
         'https://auth-js-test.okta.com/oauth2/v1/keys': {
           expiresAt: 1449786329,
@@ -424,7 +436,8 @@ describe('getKey', function() {
               e: 'AQAB',
               use: 'sig',
               kid: 'modifiedKeyId'
-            }]
+            }],
+            'responseHeaders': responseHeaders
           }
         }
       });
@@ -437,11 +450,11 @@ describe('getKey', function() {
       expect(cache).toEqual({
         'https://auth-js-test.okta.com/.well-known/openid-configuration': {
           expiresAt: 1449786329,
-          response: wellKnown.response
+          response: wellKnownResponse
         },
         'https://auth-js-test.okta.com/oauth2/v1/keys': {
           expiresAt: 1449786329,
-          response: keys.response
+          response: keysResponse
         }
       });
     }
@@ -467,11 +480,11 @@ describe('getKey', function() {
       storage.setStorage({
         'https://auth-js-test.okta.com/.well-known/openid-configuration': {
           expiresAt: 1449786329,
-          response: wellKnown.response
+          response: wellKnownResponse
         },
         'https://auth-js-test.okta.com/oauth2/v1/keys': {
           expiresAt: 1449786329,
-          response: keys.response
+          response: keysResponse
         }
       });
 
@@ -483,11 +496,11 @@ describe('getKey', function() {
       expect(cache).toEqual({
         'https://auth-js-test.okta.com/.well-known/openid-configuration': {
           expiresAt: 1449786329,
-          response: wellKnown.response
+          response: wellKnownResponse
         },
         'https://auth-js-test.okta.com/oauth2/v1/keys': {
           expiresAt: 1449786329,
-          response: keys.response
+          response: keysResponse
         }
       });
     }

--- a/test/spec/oidc/endpoints/well-known.ts
+++ b/test/spec/oidc/endpoints/well-known.ts
@@ -31,16 +31,16 @@ import wellKnown from '@okta/test.support/xhr/well-known';
 import keys from '@okta/test.support/xhr/keys';
 import tokens from '@okta/test.support/tokens';
 
-const responseHeaders = {
+const headers = {
   'Content-Type': 'application/json'
 };
 const wellKnownResponse = {
   ...wellKnown.response,
-  responseHeaders
+  headers
 };
 const keysResponse = {
   ...keys.response,
-  responseHeaders
+  headers
 };
 
 // Expected cookie settings. Cache will use the same settings on HTTP and HTTPS
@@ -437,7 +437,7 @@ describe('getKey', function() {
               use: 'sig',
               kid: 'modifiedKeyId'
             }],
-            'responseHeaders': responseHeaders
+            'headers': headers
           }
         }
       });

--- a/test/spec/oidc/getUserInfo.ts
+++ b/test/spec/oidc/getUserInfo.ts
@@ -27,6 +27,9 @@ describe('token.getUserInfo', function() {
   beforeEach(() => {
     responseXHR = _.cloneDeep(require('@okta/test.support/xhr/userinfo'));
     responseXHR.response.sub = tokens.standardIdTokenParsed.claims.sub;
+    responseXHR.response.responseHeaders = {
+      'Content-Type': 'application/json'
+    };
   });
 
   util.itMakesCorrectRequestResponse({

--- a/test/spec/oidc/getUserInfo.ts
+++ b/test/spec/oidc/getUserInfo.ts
@@ -27,7 +27,7 @@ describe('token.getUserInfo', function() {
   beforeEach(() => {
     responseXHR = _.cloneDeep(require('@okta/test.support/xhr/userinfo'));
     responseXHR.response.sub = tokens.standardIdTokenParsed.claims.sub;
-    responseXHR.response.responseHeaders = {
+    responseXHR.response.headers = {
       'Content-Type': 'application/json'
     };
   });

--- a/test/spec/oidc/util/refreshToken.ts
+++ b/test/spec/oidc/util/refreshToken.ts
@@ -12,7 +12,7 @@ describe('refreshToken', () => {
         responseJSON: {
           error: 'invalid_grant'
         },
-        responseHeaders: {}
+        headers: {}
       };
       const error = new AuthApiError({
         errorSummary: 'does not matter'
@@ -29,7 +29,7 @@ describe('refreshToken', () => {
       responseJSON: {
         error: 'something else'
       },
-      responseHeaders: {}
+      headers: {}
     };
     const error = new AuthApiError({
       errorSummary: 'does not matter'

--- a/test/spec/oidc/util/refreshToken.ts
+++ b/test/spec/oidc/util/refreshToken.ts
@@ -12,7 +12,7 @@ describe('refreshToken', () => {
         responseJSON: {
           error: 'invalid_grant'
         },
-        rawResponse: null
+        responseHeaders: {}
       };
       const error = new AuthApiError({
         errorSummary: 'does not matter'
@@ -29,7 +29,7 @@ describe('refreshToken', () => {
       responseJSON: {
         error: 'something else'
       },
-      rawResponse: null
+      responseHeaders: {}
     };
     const error = new AuthApiError({
       errorSummary: 'does not matter'

--- a/test/spec/oidc/util/refreshToken.ts
+++ b/test/spec/oidc/util/refreshToken.ts
@@ -11,7 +11,8 @@ describe('refreshToken', () => {
         responseText: 'does not matter',
         responseJSON: {
           error: 'invalid_grant'
-        }
+        },
+        rawResponse: null
       };
       const error = new AuthApiError({
         errorSummary: 'does not matter'
@@ -27,7 +28,8 @@ describe('refreshToken', () => {
       responseText: 'does not matter',
       responseJSON: {
         error: 'something else'
-      }
+      },
+      rawResponse: null
     };
     const error = new AuthApiError({
       errorSummary: 'does not matter'

--- a/test/support/util.js
+++ b/test/support/util.js
@@ -72,6 +72,7 @@ function generateXHRPair(request, response, uri, responseVars) {
 
     // Import the desired xhr
     var responseXHR = typeof response === 'object' ? response : require('./xhr/' + response);
+    responseXHR = {...responseXHR};
 
     // Change the request uri to include the domain
     if (request) {
@@ -90,14 +91,8 @@ function generateXHRPair(request, response, uri, responseVars) {
     }
 
     // Fill responseHeaders
-    var responseHeaders = {};
-    //todo: wht can be map?
-    if (responseXHR.headers && responseXHR.headers.constructor.name === 'Object') {
-      // Copy from desired xhr if present
-      responseHeaders = responseXHR.headers;
-    }
+    var responseHeaders = responseXHR.headers || {};
     if (!responseHeaders['Content-Type']) {
-      // Set default Content-Type
       responseHeaders['Content-Type'] = 'application/json';
     }
     responseXHR.responseHeaders = responseHeaders;
@@ -158,7 +153,6 @@ function mockAjax(pairs) {
       xhr.json = function() {
         return Promise.resolve(xhr.response);
       };
-      //todo
       xhr.text = function() {
         return Promise.resolve(xhr.responseText);
       };

--- a/test/support/util.js
+++ b/test/support/util.js
@@ -90,12 +90,12 @@ function generateXHRPair(request, response, uri, responseVars) {
       responseXHR.responseText = JSON.stringify(responseXHR.response);
     }
 
-    // Fill responseHeaders
-    var responseHeaders = responseXHR.headers || {};
-    if (!responseHeaders['Content-Type']) {
-      responseHeaders['Content-Type'] = 'application/json';
+    // Fill headers
+    var headers = responseXHR.headers || {};
+    if (!headers['Content-Type']) {
+      headers['Content-Type'] = 'application/json';
     }
-    responseXHR.responseHeaders = responseHeaders;
+    responseXHR.headers = headers;
 
     resolve({
       request: request,
@@ -148,7 +148,7 @@ function mockAjax(pairs) {
     return new Promise(function(resolve, reject) {
       var xhr = pair.response;
       
-      xhr.headers = new Map(Object.entries(xhr.responseHeaders));
+      xhr.headers = new Map(Object.entries(xhr.headers));
       xhr.ok = xhr.status >= 200 && xhr.status < 300;
       xhr.json = function() {
         return Promise.resolve(xhr.response);
@@ -273,7 +273,7 @@ function setup(options) {
       if (resReply) {
         ret.resReply = resReply;
         ret.responseBody = resReply.response;
-        ret.responseHeaders = resReply.responseHeaders;
+        ret.headers = resReply.headers;
       }
 
       return ret;
@@ -292,7 +292,7 @@ util.itMakesCorrectRequestResponse = function (options) {
           test.trans = res;
           resp = test.responseBody;
           if (resp && typeof resp === 'object') {
-            resp = {...resp, responseHeaders: test.responseHeaders};
+            resp = {...resp, headers: test.headers};
           }
         }
         if (options.expectations) {

--- a/test/support/util.js
+++ b/test/support/util.js
@@ -271,6 +271,13 @@ function setup(options) {
     });
 }
 
+function cleanRes(res) {
+  delete res.rawResponse;
+  if (res.data) {
+    delete res.data.rawResponse;
+  }
+}
+
 util.itMakesCorrectRequestResponse = function (options) {
   var fn = options.only ? it.only : it,
       title = options.title || 'makes correct request and returns response';
@@ -278,6 +285,7 @@ util.itMakesCorrectRequestResponse = function (options) {
     return setup(options.setup).then(function (test) {
       return options.execute(test)
       .then(function (res) {
+        cleanRes(res);
         if (res.data) {
           test.trans = res;
         }
@@ -298,6 +306,7 @@ util.itErrorsCorrectly = function (options) {
     return setup(options.setup).then(function (test) {
       return options.execute(test)
       .catch(function (err) {
+        cleanRes(err);
         if (options.expectations) {
           options.expectations(test, err);
           test.ajaxMock.done();

--- a/test/support/xhr/mfa-challenge-push.js
+++ b/test/support/xhr/mfa-challenge-push.js
@@ -87,5 +87,8 @@ module.exports = {
         }
       }]
     }
+  },
+  "headers": {
+    "X-Rate-Limit-Limit": 1000
   }
 };


### PR DESCRIPTION
Expose request headers in new `responseHeaders` property.  Value is object filled with response headers key-value pairs.
This can be useful to get [X-Rate-Limit-*](https://developer.okta.com/docs/reference/rl-best-practices/) headers as requested in https://github.com/okta/okta-auth-js/issues/230

Another solution could be exposing the whole [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) object instead (eg. in property `rawResponse`, then headers could be accessed with [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) API). 
But that approach leads to problems with unit testing and caching responses (complications with serialization and mocking `Fetch API` objects).

Internal ref: [OKTA-412511](https://oktainc.atlassian.net/browse/OKTA-412511)
Resolves https://github.com/okta/okta-auth-js/issues/230

**Important**
[Most headers are not accessible](https://github.com/okta/okta-auth-js/issues/230#issuecomment-524804720) in browsers [due to CORS](https://fetch.spec.whatwg.org/#concept-filtered-response-cors). (In Node environment it works fine)
`Access-Control-Expose-Headers` should be set from server-side to allow web clients to use `X-Rate-Limit-*` etc. headers 