### PR TITLE
Disable lifetime check (copy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.5.0
+
+### Features
+
+- [#933](https://github.com/okta/okta-auth-js/pull/933) Adds `ignoreLifetime` option to disable token lifetime validation
+
 ## 5.4.3
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -462,6 +462,11 @@ ID token signatures are validated by default when `token.getWithoutPrompt`, `tok
 
 Defaults to 300 (five minutes). This is the maximum difference allowed between a client's clock and Okta's, in seconds, when validating tokens. Setting this to 0 is not recommended, because it increases the likelihood that valid tokens will fail validation.
 
+#### `ignoreLifetime`
+
+Token lifetimes are validated using the `maxClockSkew`.
+To override this and disable token lifetime validation, set this value to `true`. 
+
 #### `transformAuthState`
 
 Callback function. When [updateAuthState](#authstatemanagerupdateauthstate) is called a new authState object is produced. Providing a `transformAuthState` function allows you to modify or replace this object before it is stored and emitted. A common use case is to change the meaning of [isAuthenticated](#authstatemanager). By default, `updateAuthState` will set `authState.isAuthenticated` to true if unexpired tokens are available from [tokenManager](#tokenmanager). This logic could be customized to also require a valid Okta SSO session:

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -192,6 +192,11 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
       this.options.maxClockSkew = args.maxClockSkew;
     }
 
+    // As some end user's devices can have their date 
+    // and time incorrectly set, allow for the disabling
+    // of the jwt liftetime validation
+    this.options.ignoreLifetime = !!args.ignoreLifetime;
+
     this.session = {
       close: closeSession.bind(null, this),
       exists: sessionExists.bind(null, this),

--- a/lib/oidc/util/validateClaims.ts
+++ b/lib/oidc/util/validateClaims.ts
@@ -44,11 +44,13 @@ export function validateClaims(sdk: OktaAuth, claims: UserClaims, validationPara
     throw new AuthSdkError('The JWT expired before it was issued');
   }
 
-  if ((now - sdk.options.maxClockSkew) > claims.exp) {
-    throw new AuthSdkError('The JWT expired and is no longer valid');
-  }
+  if (!sdk.options.ignoreLifetime) {
+    if ((now - sdk.options.maxClockSkew) > claims.exp) {
+      throw new AuthSdkError('The JWT expired and is no longer valid');
+    }
 
-  if (claims.iat > (now + sdk.options.maxClockSkew)) {
-    throw new AuthSdkError('The JWT was issued in the future');
+    if (claims.iat > (now + sdk.options.maxClockSkew)) {
+      throw new AuthSdkError('The JWT was issued in the future');
+    }
   }
 }

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -53,6 +53,7 @@ export interface OktaAuthOptions extends CustomUrls {
   scopes?: string[];
   state?: string;
   ignoreSignature?: boolean;
+  ignoreLifetime?: boolean;
   tokenManager?: TokenManagerOptions;
   postLogoutRedirectUri?: string;
   storageUtil?: StorageUtil;

--- a/test/spec/OktaAuth/constructor.ts
+++ b/test/spec/OktaAuth/constructor.ts
@@ -66,6 +66,7 @@ describe('OktaAuth (constructor)', () => {
     'headers',
     'devMode',
     'ignoreSignature',
+    'ignoreLifetime',
     'storageUtil',
   ]);
 
@@ -103,6 +104,7 @@ describe('OktaAuth (constructor)', () => {
           };
           break;
         case 'ignoreSignature':
+        case 'ignoreLifetime':
         case 'devMode':
           val = true;
           break;

--- a/test/spec/oidc/util/validateClaims.ts
+++ b/test/spec/oidc/util/validateClaims.ts
@@ -138,6 +138,23 @@ describe('validateClaims', function () {
     expect(fn).toThrowError('The JWT expired and is no longer valid'); 
   });
 
+  it('will skip jwt expired check if `ignoreLifetime` is true', function() {
+    var now = 10;
+    util.warpToUnixTime(now);
+    var claims = {
+      iss: validationOptions.issuer,
+      aud: validationOptions.clientId,
+      exp: now - 1,
+      iat: now - 2
+    } as unknown as UserClaims;
+    sdk.options.maxClockSkew = 0;
+    sdk.options.ignoreLifetime = true;
+    var fn = function () {
+      validateClaims(sdk, claims, validationOptions);
+    };
+    expect(fn).not.toThrowError();
+  });
+
   it('throws if issued in the future', function() {
     var now = 10;
     util.warpToUnixTime(now);
@@ -171,6 +188,23 @@ describe('validateClaims', function () {
     expect(fn).not.toThrowError();
     util.warpToUnixTime(now - skew);
     expect(fn).toThrowError('The JWT was issued in the future'); 
+  });
+
+  it('will skip jwt future issue check if `ignoreLifetime` is true', function() {
+    var now = 10;
+    util.warpToUnixTime(now);
+    var claims = {
+      iss: validationOptions.issuer,
+      aud: validationOptions.clientId,
+      exp: now + 2,
+      iat: now + 1
+    } as unknown as UserClaims;
+    sdk.options.maxClockSkew = 0;
+    sdk.options.ignoreLifetime = true;
+    var fn = function () {
+      validateClaims(sdk, claims, validationOptions);
+    };
+    expect(fn).not.toThrowError();
   });
 
   it('can validate all claims without error', function() {

--- a/test/types/config.test-d.ts
+++ b/test/types/config.test-d.ts
@@ -48,6 +48,7 @@ const config: OktaAuthOptions = {
   userinfoUrl: 'https://{yourOktaDomain}/oauth2/v1/userinfo',
   tokenUrl: 'https://{yourOktaDomain}/oauth2/v1/userinfo',
   ignoreSignature: true,
+  ignoreLifetime: true,
   maxClockSkew: 10,
 
   storageManager: {


### PR DESCRIPTION
Copy of https://github.com/okta/okta-auth-js/pull/885

Adds `ignoreLifetime` option to disable token lifetime validation

Resolves https://github.com/okta/okta-auth-js/issues/879

Internal ref: [OKTA-417253](https://oktainc.atlassian.net/browse/OKTA-417253)
