### PR TITLE
Adds feature to store a device_secret in TokenStore

### DIFF
--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -192,7 +192,7 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
       this.options.maxClockSkew = args.maxClockSkew;
     }
 
-    // As some end user's devices can have their date 
+    // As some end user's devices can have their date
     // and time incorrectly set, allow for the disabling
     // of the jwt liftetime validation
     this.options.ignoreLifetime = !!args.ignoreLifetime;
@@ -548,6 +548,13 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
   getRefreshToken(): string | undefined {
     const { refreshToken } = this.tokenManager.getTokensSync();
     return refreshToken ? refreshToken.refreshToken : undefined;
+  }
+
+  getDeviceSecret(): object | undefined {
+    const { deviceSecret, idToken } = this.tokenManager.getTokensSync();
+    return (deviceSecret && idToken) ? 
+      { deviceSecret: deviceSecret.deviceSecret, subject: idToken.idToken } : 
+      undefined;
   }
 
   /**

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -25,6 +25,7 @@ import {
   isIDToken, 
   isAccessToken,
   isRefreshToken,
+  isDeviceSecret,
   StorageOptions,
   StorageType,
   OktaAuth,
@@ -260,6 +261,8 @@ export class TokenManager implements TokenManagerInterface {
         tokens.idToken = token;
       } else if (isRefreshToken(token)) { 
         tokens.refreshToken = token;
+      } else if (isDeviceSecret(token)) { 
+        tokens.deviceSecret = token;
       }
     });
     return tokens;
@@ -271,11 +274,13 @@ export class TokenManager implements TokenManagerInterface {
 
   getStorageKeyByType(type: TokenType): string {
     const tokenStorage = this.storage.getStorage();
+    // eslint-disable-next-line complexity
     const key = Object.keys(tokenStorage).filter(key => {
       const token = tokenStorage[key];
       return (isAccessToken(token) && type === 'accessToken') 
         || (isIDToken(token) && type === 'idToken')
-        || (isRefreshToken(token) && type === 'refreshToken');
+        || (isRefreshToken(token) && type === 'refreshToken')
+        || (isDeviceSecret(token) && type === 'deviceSecret');
     })[0];
     return key;
   }
@@ -290,6 +295,9 @@ export class TokenManager implements TokenManagerInterface {
     if(isRefreshToken(token)) {
       return 'refreshToken';
     }
+    if(isDeviceSecret(token)) {
+      return 'deviceSecret';
+    }
     throw new AuthSdkError('Unknown token type');
   }
 
@@ -298,8 +306,10 @@ export class TokenManager implements TokenManagerInterface {
     // TODO: callbacks can be removed in the next major version OKTA-407224
     accessTokenCb?: Function, 
     idTokenCb?: Function,
-    refreshTokenCb?: Function
+    refreshTokenCb?: Function,
+    deviceSecretCb?: Function
   ): void {
+    // eslint-disable-next-line complexity
     const handleTokenCallback = (key, token) => {
       const type = this.getTokenType(token);
       if (type === 'accessToken') {
@@ -308,6 +318,8 @@ export class TokenManager implements TokenManagerInterface {
         idTokenCb && idTokenCb(key, token);
       } else if (type === 'refreshToken') {
         refreshTokenCb && refreshTokenCb(key, token);
+      } else if (type === 'deviceSecret') {
+        deviceSecretCb && deviceSecretCb(key, token);
       }
     };
     const handleAdded = (key, token) => {
@@ -327,7 +339,7 @@ export class TokenManager implements TokenManagerInterface {
       handleTokenCallback(key, token);
     };
     
-    const types: TokenType[] = ['idToken', 'accessToken', 'refreshToken'];
+    const types: TokenType[] = ['idToken', 'accessToken', 'refreshToken', 'deviceSecret'];
     const existingTokens = this.getTokensSync();
 
     // valid tokens

--- a/lib/oidc/handleOAuthResponse.ts
+++ b/lib/oidc/handleOAuthResponse.ts
@@ -81,6 +81,7 @@ export function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res
       var accessToken = res.access_token;
       var idToken = res.id_token;
       var refreshToken = res.refresh_token;
+      var deviceSecret = res.device_secret;
       var now = Math.floor(Date.now()/1000);
 
       if (accessToken) {
@@ -106,6 +107,18 @@ export function handleOAuthResponse(sdk: OktaAuth, tokenParams: TokenParams, res
           tokenUrl: urls.tokenUrl,
           authorizeUrl: urls.authorizeUrl,
           issuer: urls.issuer,
+        };
+      }
+
+      if (deviceSecret) {
+        tokenDict.deviceSecret = {
+          deviceSecret: deviceSecret,
+          // should not be used, this is the accessToken expire time
+          // TODO: remove "expiresAt" in the next major version OKTA-407224
+          expiresAt: Number(expiresIn) + now, 
+          scopes: scopes,
+          authorizeUrl: urls.authorizeUrl,
+          subjectToken: idToken
         };
       }
 

--- a/lib/oidc/util/validateToken.ts
+++ b/lib/oidc/util/validateToken.ts
@@ -1,10 +1,10 @@
 /* eslint-disable complexity */
 
 import { AuthSdkError } from '../../errors';
-import { isAccessToken, isIDToken, isRefreshToken, Token, TokenType } from '../../types';
+import { isAccessToken, isIDToken, isRefreshToken, isDeviceSecret, Token, TokenType } from '../../types';
 
 export function validateToken(token: Token, type?: TokenType) {
-  if (!isIDToken(token) && !isAccessToken(token) && !isRefreshToken(token)) {
+  if (!isIDToken(token) && !isAccessToken(token) && !isRefreshToken(token) && !isDeviceSecret(token)) {
     throw new AuthSdkError(
       'Token must be an Object with scopes, expiresAt, and one of: an idToken, accessToken, or refreshToken property'
     );
@@ -19,5 +19,9 @@ export function validateToken(token: Token, type?: TokenType) {
 
   if (type === 'refreshToken' && !isRefreshToken(token)) {
     throw new AuthSdkError('invalid refreshToken');
+  }
+
+  if (type === 'deviceSecret' && !isDeviceSecret(token)) {
+    throw new AuthSdkError('invalid deviceSecret');
   }
 }

--- a/lib/types/OAuth.ts
+++ b/lib/types/OAuth.ts
@@ -42,6 +42,7 @@ export interface OAuthResponse {
   access_token?: string;
   id_token?: string;
   refresh_token?: string;
+  device_secret?: string;
   scope?: string;
   error?: string;
   error_description?: string;

--- a/lib/types/Token.ts
+++ b/lib/types/Token.ts
@@ -31,6 +31,11 @@ export interface RefreshToken extends AbstractToken {
   issuer: string;
 }
 
+export interface DeviceSecret extends AbstractToken {
+  deviceSecret: string;
+  subjectToken: string;
+}
+
 // eslint-disable-next-line @typescript-eslint/interface-name-prefix
 export interface IDToken extends AbstractToken {
   idToken: string;
@@ -39,14 +44,14 @@ export interface IDToken extends AbstractToken {
   clientId: string;
 }
 
-export type Token = AccessToken | IDToken | RefreshToken;
-export type RevocableToken = AccessToken | RefreshToken;
+export type Token = AccessToken | IDToken | RefreshToken | DeviceSecret;
+export type RevocableToken = AccessToken | RefreshToken | DeviceSecret;
 
-export type TokenType = 'accessToken' | 'idToken' | 'refreshToken';
+export type TokenType = 'accessToken' | 'idToken' | 'refreshToken' | 'deviceSecret';
 
 export function isToken(obj: any): obj is Token {
   if (obj &&
-      (obj.accessToken || obj.idToken || obj.refreshToken) &&
+      (obj.accessToken || obj.idToken || obj.refreshToken || obj.deviceSecret) &&
       Array.isArray(obj.scopes)) {
     return true;
   }
@@ -65,8 +70,13 @@ export function isRefreshToken(obj: any): obj is RefreshToken {
   return obj && obj.refreshToken;
 }
 
+export function isDeviceSecret(obj: any): obj is DeviceSecret {
+  return obj && obj.deviceSecret;
+}
+
 export interface Tokens {
   accessToken?: AccessToken;
   idToken?: IDToken;
   refreshToken?: RefreshToken;
+  deviceSecret?: DeviceSecret;
 }

--- a/lib/types/TokenManager.ts
+++ b/lib/types/TokenManager.ts
@@ -17,7 +17,7 @@ export interface TokenManagerInterface {
   on: (event: string, handler: TokenManagerErrorEventHandler | TokenManagerEventHandler, context?: object) => void;
   off: (event: string, handler?: TokenManagerErrorEventHandler | TokenManagerEventHandler) => void;
   getTokensSync(): Tokens;
-  setTokens({ accessToken, idToken, refreshToken }: Tokens, accessTokenCb?: Function, idTokenCb?: Function, refreshTokenCb?: Function): void;
+  setTokens({ accessToken, idToken, refreshToken, deviceSecret }: Tokens, accessTokenCb?: Function, idTokenCb?: Function, refreshTokenCb?: Function, deviceSecretCb?: Function): void;
   getStorageKeyByType(type: TokenType): string;
   add(key: any, token: Token): void;
   updateRefreshToken(token: RefreshToken);


### PR DESCRIPTION
feat: Updates Adds feature to store a device_secret in TokenStore

Allows the TokenStore to store a device_secret in the TokenStore if the device_secret scope is requested. 
Allows the device_secret and associated id_token to be retrieved from the TokenStore.
This is to support [https://developer.okta.com/docs/guides/configure-native-sso/main/](https://developer.okta.com/docs/guides/configure-native-sso/main/) if a SPA/Web app is run on a mobile device without persistent cookies set, a native app on the device can be opened and SSO into using the device_secret.