### PR TITLE
Fix TS issues with transformAuthState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Other
 
 - [#947](https://github.com/okta/okta-auth-js/pull/947) TypeScript: Allow custom keys in `AuthState` interface
-- [#947](https://github.com/okta/okta-auth-js/pull/947) TypeScript: Use `OktaAuth` class instead of interface for `transformAuthState`, `restoreOriginalUri`
 
 ## 5.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 5.6.0
+
+### Other
+
+- [#947](https://github.com/okta/okta-auth-js/pull/947) TypeScript: Allow custom keys in `AuthState` interface
+- [#947](https://github.com/okta/okta-auth-js/pull/947) TypeScript: Use `OktaAuth` class instead of interface for `transformAuthState`, `restoreOriginalUri`
+
 ## 5.5.0
 
 ### Features

--- a/lib/types/AuthState.ts
+++ b/lib/types/AuthState.ts
@@ -19,6 +19,8 @@ export interface AuthState {
   refreshToken?: RefreshToken;
   isAuthenticated?: boolean;
   error?: Error;
+  // Custom keys are allowed via transformAuthState()
+  [otherOption: string]: unknown;
 }
 
 export interface AuthStateLogOptions {

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -13,10 +13,10 @@
 import { StorageManagerOptions, StorageUtil } from './Storage';
 import { CookieOptions } from './Cookies';
 import { HttpRequestClient } from './http';
-import { OktaAuth } from './';
 import { AuthState } from './AuthState';
 import { TransactionManagerOptions } from './Transaction';
 import { SimpleStorage } from './Storage';
+import OktaAuth from '../OktaAuth';
 
 export interface TokenManagerOptions {
   autoRenew?: boolean;

--- a/test/types/config.test-d.ts
+++ b/test/types/config.test-d.ts
@@ -89,6 +89,7 @@ const config: OktaAuthOptions = {
     }
     const user = await oktaAuth.token.getUserInfo();
     authState.isAuthenticated = !!user;
+    authState.user = user;
     return authState;
   },
   restoreOriginalUri: async (oktaAuth, originalUri) => {


### PR DESCRIPTION
- Allow custom keys in `AuthState` interface
- Use `OktaAuth` class instead of interface for `transformAuthState`, `restoreOriginalUri`

Internal ref: [OKTA-379786](https://oktainc.atlassian.net/browse/OKTA-379786)
Resolves https://github.com/okta/okta-auth-js/issues/667
