### PR TITLE
Restore samples changes (Protect router methods with try/catch wrapper)

### DIFF
--- a/samples/generated/express-embedded-auth-with-sdk/web-server/middlewares/userContext.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/middlewares/userContext.js
@@ -11,9 +11,9 @@
  */
 
 
-const { getAuthClient } = require('../utils');
+const { getAuthClient, withCatch } = require('../utils');
 
-module.exports = async function userContext(req, res, next) {
+module.exports = withCatch(async function userContext(req, res, next) {
   const authClient = getAuthClient(req);
   const { idToken, accessToken, refreshToken } = authClient.tokenManager.getTokensSync();
   if (idToken && accessToken) {
@@ -27,4 +27,4 @@ module.exports = async function userContext(req, res, next) {
   }
   
   next();
-};
+});

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/routes/authenticator.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/routes/authenticator.js
@@ -11,16 +11,15 @@
  */
 
 
-const express = require('express');
-
 const { 
   getAuthClient, 
   handleTransaction,
   renderTemplate,
   renderPage,
+  routerWithCatch,
 } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 // Handle select-authenticator
 router.get('/select-authenticator', (req, res) => {

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/routes/cancel.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/routes/cancel.js
@@ -11,10 +11,9 @@
  */
 
 
-const express = require('express');
-const { getAuthClient, handleTransaction } = require('../utils');
+const { getAuthClient, handleTransaction, routerWithCatch } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 router.post('/cancel', async (req, res, next) => {
   const authClient = getAuthClient(req);

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/routes/home.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/routes/home.js
@@ -11,9 +11,9 @@
  */
 
 
-const express = require('express');
+const { routerWithCatch } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 router.get('/', (req, res) => {
   // clear any existing transaction

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/routes/login.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/routes/login.js
@@ -11,14 +11,14 @@
  */
 
 
-const express = require('express');
 const { 
   getAuthClient, 
   handleTransaction,
   renderTemplate,
+  routerWithCatch,
 } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 const getIdpSemanticClass = (type) => {
   switch (type) {

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/routes/logout.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/routes/logout.js
@@ -11,10 +11,9 @@
  */
 
 
-const express = require('express');
-const { getAuthClient } = require('../utils');
+const { getAuthClient, routerWithCatch } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 router.post('/logout', async (req, res) => {
   try {

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/routes/recover-password.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/routes/recover-password.js
@@ -11,15 +11,15 @@
  */
 
 
-const express = require('express');
 const { 
   getAuthClient,
   handleTransaction,
   renderTemplate,
   renderPage,
+  routerWithCatch,
 } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 // entry route
 router.get('/recover-password', (req, res) => {

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/routes/register.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/routes/register.js
@@ -11,14 +11,14 @@
  */
 
 
-const express = require('express');
 const { 
   getAuthClient,
   handleTransaction,
   renderTemplate,
+  routerWithCatch,
 } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 // entry route
 router.get('/register', async (req, res) => {

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/routes/terminal.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/routes/terminal.js
@@ -11,10 +11,9 @@
  */
 
 
-const express = require('express');
-const { renderTemplate } = require('../utils');
+const { renderTemplate, routerWithCatch } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 router.get('/terminal', (req, res) => {
   renderTemplate(req, res, 'terminal');

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/utils/index.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/utils/index.js
@@ -19,6 +19,7 @@ const renderTemplate = require('./renderTemplate');
 const renderPage = require('./renderPage');
 const redirect = require('./redirect');
 const getFormActionPath = require('./getFormActionPath');
+const {withCatch, routerWithCatch} = require('./withCatch');
 
 module.exports = {
   getAuthClient,
@@ -29,4 +30,6 @@ module.exports = {
   renderPage,
   redirect,
   getFormActionPath,
+  withCatch,
+  routerWithCatch,
 };

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/utils/withCatch.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/utils/withCatch.js
@@ -1,0 +1,27 @@
+const express = require('express');
+
+const withCatch = fn => {
+  return async (req, res, next) => {
+    try {
+      await fn(req, res, next);
+    } catch (err) {
+      next(err);
+    }
+  };
+};
+
+const routerWithCatch = () => {
+  const router = express.Router();
+  for (const method of ['get', 'post', 'put', 'delete']) {
+    const original = router[method];
+    router[method] = function(path, handler) {
+      original.call(this, path, withCatch(handler));
+    };
+  }
+  return router;
+};
+
+module.exports = {
+  withCatch,
+  routerWithCatch,
+};

--- a/samples/generated/express-embedded-sign-in-widget/web-server/middlewares/userContext.js
+++ b/samples/generated/express-embedded-sign-in-widget/web-server/middlewares/userContext.js
@@ -11,9 +11,9 @@
  */
 
 
-const { getAuthClient } = require('../utils');
+const { getAuthClient, withCatch } = require('../utils');
 
-module.exports = async function userContext(req, res, next) {
+module.exports = withCatch(async function userContext(req, res, next) {
   const authClient = getAuthClient(req);
   const { idToken, accessToken, refreshToken } = authClient.tokenManager.getTokensSync();
   if (idToken && accessToken) {
@@ -27,4 +27,4 @@ module.exports = async function userContext(req, res, next) {
   }
   
   next();
-};
+});

--- a/samples/generated/express-embedded-sign-in-widget/web-server/routes/login.js
+++ b/samples/generated/express-embedded-sign-in-widget/web-server/routes/login.js
@@ -11,15 +11,15 @@
  */
 
 
-const express = require('express');
 const { 
   getAuthTransaction,
   getAuthClient,
+  routerWithCatch,
 } = require('../utils');
 
 const getConfig = require('../../config');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 router.get('/login', (req, res, next) => {
   getAuthTransaction(req)

--- a/samples/generated/express-embedded-sign-in-widget/web-server/routes/logout.js
+++ b/samples/generated/express-embedded-sign-in-widget/web-server/routes/logout.js
@@ -11,10 +11,9 @@
  */
 
 
-const express = require('express');
-const { getAuthClient } = require('../utils');
+const { getAuthClient, routerWithCatch } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 router.post('/logout', async (req, res) => {
   try {

--- a/samples/generated/express-embedded-sign-in-widget/web-server/utils/index.js
+++ b/samples/generated/express-embedded-sign-in-widget/web-server/utils/index.js
@@ -13,8 +13,11 @@
 
 const getAuthClient = require('./getAuthClient');
 const getAuthTransaction = require('./getAuthTransaction');
+const {withCatch, routerWithCatch} = require('./withCatch');
 
 module.exports = {
   getAuthClient,
   getAuthTransaction,
+  withCatch,
+  routerWithCatch,
 };

--- a/samples/generated/express-embedded-sign-in-widget/web-server/utils/withCatch.js
+++ b/samples/generated/express-embedded-sign-in-widget/web-server/utils/withCatch.js
@@ -1,0 +1,27 @@
+const express = require('express');
+
+const withCatch = fn => {
+  return async (req, res, next) => {
+    try {
+      await fn(req, res, next);
+    } catch (err) {
+      next(err);
+    }
+  };
+};
+
+const routerWithCatch = () => {
+  const router = express.Router();
+  for (const method of ['get', 'post', 'put', 'delete']) {
+    const original = router[method];
+    router[method] = function(path, handler) {
+      original.call(this, path, withCatch(handler));
+    };
+  }
+  return router;
+};
+
+module.exports = {
+  withCatch,
+  routerWithCatch,
+};

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/middlewares/userContext.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/middlewares/userContext.js
@@ -11,9 +11,9 @@
  */
 
 
-const { getAuthClient } = require('../utils');
+const { getAuthClient, withCatch } = require('../utils');
 
-module.exports = async function userContext(req, res, next) {
+module.exports = withCatch(async function userContext(req, res, next) {
   const authClient = getAuthClient(req);
   const { idToken, accessToken, refreshToken } = authClient.tokenManager.getTokensSync();
   if (idToken && accessToken) {
@@ -27,4 +27,4 @@ module.exports = async function userContext(req, res, next) {
   }
   
   next();
-};
+});

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/routes/authenticator.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/routes/authenticator.js
@@ -11,16 +11,15 @@
  */
 
 
-const express = require('express');
-
 const { 
   getAuthClient, 
   handleTransaction,
   renderTemplate,
   renderPage,
+  routerWithCatch,
 } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 // Handle select-authenticator
 router.get('/select-authenticator', (req, res) => {

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/routes/cancel.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/routes/cancel.js
@@ -11,10 +11,9 @@
  */
 
 
-const express = require('express');
-const { getAuthClient, handleTransaction } = require('../utils');
+const { getAuthClient, handleTransaction, routerWithCatch } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 router.post('/cancel', async (req, res, next) => {
   const authClient = getAuthClient(req);

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/routes/home.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/routes/home.js
@@ -11,9 +11,9 @@
  */
 
 
-const express = require('express');
+const { routerWithCatch } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 router.get('/', (req, res) => {
   // clear any existing transaction

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/routes/login.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/routes/login.js
@@ -11,14 +11,14 @@
  */
 
 
-const express = require('express');
 const { 
   getAuthClient, 
   handleTransaction,
   renderTemplate,
+  routerWithCatch,
 } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 const getIdpSemanticClass = (type) => {
   switch (type) {

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/routes/logout.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/routes/logout.js
@@ -11,10 +11,9 @@
  */
 
 
-const express = require('express');
-const { getAuthClient } = require('../utils');
+const { getAuthClient, routerWithCatch } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 router.post('/logout', async (req, res) => {
   try {

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/routes/recover-password.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/routes/recover-password.js
@@ -11,15 +11,15 @@
  */
 
 
-const express = require('express');
 const { 
   getAuthClient,
   handleTransaction,
   renderTemplate,
   renderPage,
+  routerWithCatch,
 } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 // entry route
 router.get('/recover-password', (req, res) => {

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/routes/register.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/routes/register.js
@@ -11,14 +11,14 @@
  */
 
 
-const express = require('express');
 const { 
   getAuthClient,
   handleTransaction,
   renderTemplate,
+  routerWithCatch,
 } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 // entry route
 router.get('/register', async (req, res) => {

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/routes/terminal.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/routes/terminal.js
@@ -11,10 +11,9 @@
  */
 
 
-const express = require('express');
-const { renderTemplate } = require('../utils');
+const { renderTemplate, routerWithCatch } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 router.get('/terminal', (req, res) => {
   renderTemplate(req, res, 'terminal');

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/utils/index.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/utils/index.js
@@ -19,6 +19,7 @@ const renderTemplate = require('./renderTemplate');
 const renderPage = require('./renderPage');
 const redirect = require('./redirect');
 const getFormActionPath = require('./getFormActionPath');
+const {withCatch, routerWithCatch} = require('./withCatch');
 
 module.exports = {
   getAuthClient,
@@ -29,4 +30,6 @@ module.exports = {
   renderPage,
   redirect,
   getFormActionPath,
+  withCatch,
+  routerWithCatch,
 };

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/utils/withCatch.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/utils/withCatch.js
@@ -1,0 +1,27 @@
+const express = require('express');
+
+const withCatch = fn => {
+  return async (req, res, next) => {
+    try {
+      await fn(req, res, next);
+    } catch (err) {
+      next(err);
+    }
+  };
+};
+
+const routerWithCatch = () => {
+  const router = express.Router();
+  for (const method of ['get', 'post', 'put', 'delete']) {
+    const original = router[method];
+    router[method] = function(path, handler) {
+      original.call(this, path, withCatch(handler));
+    };
+  }
+  return router;
+};
+
+module.exports = {
+  withCatch,
+  routerWithCatch,
+};

--- a/samples/templates/express-embedded-sign-in-widget/web-server/middlewares/userContext.js
+++ b/samples/templates/express-embedded-sign-in-widget/web-server/middlewares/userContext.js
@@ -11,9 +11,9 @@
  */
 
 
-const { getAuthClient } = require('../utils');
+const { getAuthClient, withCatch } = require('../utils');
 
-module.exports = async function userContext(req, res, next) {
+module.exports = withCatch(async function userContext(req, res, next) {
   const authClient = getAuthClient(req);
   const { idToken, accessToken, refreshToken } = authClient.tokenManager.getTokensSync();
   if (idToken && accessToken) {
@@ -27,4 +27,4 @@ module.exports = async function userContext(req, res, next) {
   }
   
   next();
-};
+});

--- a/samples/templates/express-embedded-sign-in-widget/web-server/routes/login.js
+++ b/samples/templates/express-embedded-sign-in-widget/web-server/routes/login.js
@@ -11,15 +11,15 @@
  */
 
 
-const express = require('express');
 const { 
   getAuthTransaction,
   getAuthClient,
+  routerWithCatch,
 } = require('../utils');
 
 const getConfig = require('../../config');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 router.get('/login', (req, res, next) => {
   getAuthTransaction(req)

--- a/samples/templates/express-embedded-sign-in-widget/web-server/routes/logout.js
+++ b/samples/templates/express-embedded-sign-in-widget/web-server/routes/logout.js
@@ -11,10 +11,9 @@
  */
 
 
-const express = require('express');
-const { getAuthClient } = require('../utils');
+const { getAuthClient, routerWithCatch } = require('../utils');
 
-const router = express.Router();
+const router = routerWithCatch();
 
 router.post('/logout', async (req, res) => {
   try {

--- a/samples/templates/express-embedded-sign-in-widget/web-server/utils/index.js
+++ b/samples/templates/express-embedded-sign-in-widget/web-server/utils/index.js
@@ -13,8 +13,11 @@
 
 const getAuthClient = require('./getAuthClient');
 const getAuthTransaction = require('./getAuthTransaction');
+const {withCatch, routerWithCatch} = require('./withCatch');
 
 module.exports = {
   getAuthClient,
   getAuthTransaction,
+  withCatch,
+  routerWithCatch,
 };

--- a/samples/templates/express-embedded-sign-in-widget/web-server/utils/withCatch.js
+++ b/samples/templates/express-embedded-sign-in-widget/web-server/utils/withCatch.js
@@ -1,0 +1,27 @@
+const express = require('express');
+
+const withCatch = fn => {
+  return async (req, res, next) => {
+    try {
+      await fn(req, res, next);
+    } catch (err) {
+      next(err);
+    }
+  };
+};
+
+const routerWithCatch = () => {
+  const router = express.Router();
+  for (const method of ['get', 'post', 'put', 'delete']) {
+    const original = router[method];
+    router[method] = function(path, handler) {
+      original.call(this, path, withCatch(handler));
+    };
+  }
+  return router;
+};
+
+module.exports = {
+  withCatch,
+  routerWithCatch,
+};


### PR DESCRIPTION
Changes in [this PR](https://github.com/okta/okta-auth-js/pull/907) were made to `generated` instead of `templates`.
And were lost after [regenerating samples](https://github.com/okta/okta-auth-js/pull/949)
This PR restores changes to `templates` and `generated`