### PR TITLE
fix: Obvious Fix - Adds TokenParams back to SignInWithRedirectOptions

### DIFF
--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -204,7 +204,7 @@ export interface SigninOptions extends
     sendFingerprint?: boolean;
 }
 
-export interface SigninWithRedirectOptions extends SigninOptions {
+export interface SigninWithRedirectOptions extends SigninOptions, TokenParams {
   originalUri?: string;
 }
 


### PR DESCRIPTION
The TokenParams type was removed from SignInWithRedirectOptions in commit 4e6279a0d2e9be398fd38371049323cbfdf8e0ca. This appears to have been unintentional and has caused type issues for users.

resolves: #899