### PR TITLE
fix: safari & firefox block getWithPopup issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - [#983](https://github.com/okta/okta-auth-js/pull/983) Adds new method `setHeaders`
 
+### Fixes
+
+- [#988](https://github.com/okta/okta-auth-js/pull/988) Fixes Safari & Firefox browsers block `getWithPopup` issue
+
 ### Other
 
 - [#981](https://github.com/okta/okta-auth-js/pull/981) TypeScript: Allows optional paramters for IDX methods

--- a/lib/oidc/getWithPopup.ts
+++ b/lib/oidc/getWithPopup.ts
@@ -14,16 +14,22 @@ import { AuthSdkError } from '../errors';
 import { OktaAuth, TokenParams, TokenResponse } from '../types';
 import { clone } from '../util';
 import { getToken } from './getToken';
+import { loadPopup } from './util';
 
 export function getWithPopup(sdk: OktaAuth, options: TokenParams): Promise<TokenResponse> {
   if (arguments.length > 2) {
     return Promise.reject(new AuthSdkError('As of version 3.0, "getWithPopup" takes only a single set of options'));
   }
 
+  // some browsers (safari, firefox) block popup if it's initialed from an async process
+  // here we create the popup window immediately after user interaction
+  // then redirect to the /authorize endpoint when the requestUrl is available
+  const popupWindow = loadPopup('/', options);
   options = clone(options) || {};
   Object.assign(options, {
     display: 'popup',
-    responseMode: 'okta_post_message'
+    responseMode: 'okta_post_message',
+    popupWindow
   });
   return getToken(sdk, options);
 }

--- a/lib/oidc/util/browser.ts
+++ b/lib/oidc/util/browser.ts
@@ -14,7 +14,6 @@
 /* eslint-disable complexity, max-statements */
 import { AuthSdkError } from '../../errors';
 import { OktaAuth } from '../../types';
-import { isIE11OrLess } from '../../features';
 
 export function addListener(eventTarget, name, fn) {
   if (eventTarget.addEventListener) {
@@ -44,17 +43,7 @@ export function loadPopup(src, options) {
   var title = options.popupTitle || 'External Identity Provider User Authentication';
   var appearance = 'toolbar=no, scrollbars=yes, resizable=yes, ' +
     'top=100, left=500, width=600, height=600';
-
-  if (isIE11OrLess()) {
-    // IE<=11 doesn't fully support postMessage at time of writting.
-    // the following simple solution happened to solve the issue
-    // without adding another proxy layer which makes flow more complecated.
-    var winEl = window.open('/', title, appearance);
-    winEl.location.href = src;
-    return winEl;
-  } else {
-    return window.open(src, title, appearance);
-  }
+  return window.open(src, title, appearance);
 }
 
 export function addPostMessageListener(sdk: OktaAuth, timeout, state) {

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -120,7 +120,13 @@ export interface TokenParams extends CustomUrls {
   prompt?: string;
   sessionToken?: string;
   timeout?: number;
+  // TODO: remove in the next major version
   popupTitle?: string;
+}
+
+export interface PopupParams {
+  popupTitle?: string;
+  popupWindow?: Window;
 }
 
 export interface TokenResponse {

--- a/test/spec/oidc/getWithPopup.ts
+++ b/test/spec/oidc/getWithPopup.ts
@@ -66,7 +66,10 @@ describe('token.getWithPopup', function() {
     var timeoutMs = 120000;
     var mockWindow = {
       closed: false,
-      close: jest.fn()
+      close: jest.fn(),
+      location: {
+        assign: jest.fn()
+      }
     };
     jest.spyOn(window, 'open').mockImplementation(function () {
       return mockWindow as unknown as Window; // valid window is returned
@@ -273,6 +276,9 @@ describe('token.getWithPopup', function() {
         this.closed = false;
         this.close = () => {
           this.closed = true;
+        };
+        this.location = {
+          assign: jest.fn()
         };
       }
       jest.spyOn(window, 'open').mockImplementation(function() {

--- a/test/spec/oidc/util/browser.ts
+++ b/test/spec/oidc/util/browser.ts
@@ -51,27 +51,4 @@ describe('loadPopup', function() {
     );
   });
 
-  it('popups window with full src url directly when IE mode', function () {
-    var mockElem = {
-      location: {
-
-      }
-    } as unknown as Window;
-    jest.spyOn(libFeatures, 'isIE11OrLess').mockReturnValue(true);
-    jest.spyOn(window, 'open').mockReturnValue(mockElem);
-
-    var winEl = loadPopup('/path/to/foo', {
-      popupTitle: 'Hello Okta'
-    });
-
-    expect(winEl).toBe(mockElem);
-    expect((window.open as jest.Mock).mock.calls.length).toBe(1);
-    expect(window.open).toHaveBeenCalledWith(
-      '/',
-      'Hello Okta',
-      'toolbar=no, scrollbars=yes, resizable=yes, top=100, left=500, width=600, height=600'
-    );
-    expect(winEl.location.href).toBe('/path/to/foo');
-  });
-
 });

--- a/test/support/oauthUtil.js
+++ b/test/support/oauthUtil.js
@@ -368,7 +368,10 @@ oauthUtil.setupPopup = function(opts) {
   var src;
   var fakeWindow = {
     location: {
-      hash: ''
+      hash: '',
+      assign: function(url) {
+        src = url;
+      }
     },
     closed: false,
     close: function() {
@@ -377,8 +380,7 @@ oauthUtil.setupPopup = function(opts) {
   };
   jest.spyOn(fakeWindow, 'close');
 
-  jest.spyOn(window, 'open').mockImplementation(function(s) {
-    src = s;
+  jest.spyOn(window, 'open').mockImplementation(function() {
     setTimeout(function() {
       if (opts.closePopup) {
         fakeWindow.close();


### PR DESCRIPTION
Safari and Firefox block popup when they think the popup is not triggered by user interaction (when `window.open` is called asynchronous). This PR initials the popup window right after the user interaction, then update the redirect url when information is ready.

Tests: 
* Manually tested
* Updated unit test
* E2E - Saucelab tests should be re-enabled on bacon (OKTA-440989)