### PR TITLE
Support email verify callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - [#983](https://github.com/okta/okta-auth-js/pull/983) Adds new method `setHeaders`
+- [#990](https://github.com/okta/okta-auth-js/pull/990) Supports email verify callback
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.8.0
+
+### Features
+
+- [#990](https://github.com/okta/okta-auth-js/pull/990) Supports email verify callback
+
 ## 5.7.0
 
 ### Features
@@ -11,6 +17,7 @@
 
 - [#988](https://github.com/okta/okta-auth-js/pull/988) Fixes Safari & Firefox browsers block `getWithPopup` issue
 - [#995](https://github.com/okta/okta-auth-js/pull/995) Sends cookie for `authn` related requests
+- [#985](https://github.com/okta/okta-auth-js/pull/985) Fixes issue with renewTokens that would drop scopes passed to `getToken`
 
 ### Other
 

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -140,12 +140,11 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
   _oktaUserAgent: OktaUserAgent;
   _pending: { handleLogin: boolean };
   constructor(args: OktaAuthOptions) {
-    this.options = buildOptions(args);
-    const { storageManager, cookies, storageUtil } = this.options;
-    this.storageManager = new StorageManager(storageManager, cookies, storageUtil);
+    const options = this.options = buildOptions(args);
+    this.storageManager = new StorageManager(options.storageManager, options.cookies, options.storageUtil);
     this.transactionManager = new TransactionManager(Object.assign({
-      storageManager: this.storageManager
-    }, args.transactionManager));
+      storageManager: this.storageManager,
+    }, options.transactionManager));
     this._oktaUserAgent = new OktaUserAgent();
   
     this.tx = {
@@ -153,7 +152,7 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
       resume: resumeTransaction.bind(null, this),
       exists: Object.assign(transactionExists.bind(null, this), {
         _get: (name) => {
-          const storage = storageUtil.storage;
+          const storage = options.storageUtil.storage;
           return storage.get(name);
         }
       }),

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -87,7 +87,10 @@ import browserStorage from './browser/browserStorage';
 import { 
   toQueryString, 
   toAbsoluteUrl,
-  clone
+  clone,
+  isEmailVerifyCallback,
+  EmailVerifyCallbackResponse,
+  parseEmailVerifyCallback
 } from './util';
 import { getUserAgent } from './builderUtil';
 import { TokenManager } from './TokenManager';
@@ -312,6 +315,15 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
 
   isInteractionRequiredError(error: Error): boolean {
     return isInteractionRequiredError(error);
+  }
+
+  // Utility methods for email verify callback
+  isEmailVerifyCallback(urlPath: string): boolean {
+    return isEmailVerifyCallback(urlPath);
+  }
+
+  parseEmailVerifyCallback(urlPath: string): EmailVerifyCallbackResponse {
+    return parseEmailVerifyCallback(urlPath);
   }
 
   async signIn(opts: SigninOptions): Promise<AuthTransaction> {

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -44,7 +44,6 @@ import {
   IdxAPI,
   SignoutRedirectUrlOptions,
   HttpAPI,
-  TransactionMeta,
 } from './types';
 import {
   transactionStatus,

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -587,18 +587,19 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
   }
 
   getOriginalUri(state?: string): string {
-    // Try to load from session storage
-    const storage = browserStorage.getSessionStorage();
-    let originalUri = storage ? storage.getItem(REFERRER_PATH_STORAGE_KEY) : undefined;
-
-    // If not found in sessionStorage, check shared storage (if state is available)
+    // Prefer shared storage (if state is available)
     state = state || this.options.state;
-    if (!originalUri && state) {
+    if (state) {
       const sharedStorage = this.storageManager.getOriginalUriStorage();
-      originalUri = sharedStorage.getItem(state);
+      const originalUri = sharedStorage.getItem(state);
+      if (originalUri) {
+        return originalUri;
+      }
     }
 
-    return originalUri;
+    // Try to load from session storage
+    const storage = browserStorage.getSessionStorage();
+    return storage ? storage.getItem(REFERRER_PATH_STORAGE_KEY) : undefined;
   }
 
   removeOriginalUri(state?: string): void {

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -307,8 +307,8 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
   // CommonJS module users (CDN) need all exports on this object
 
   // Utility methods for interaction code flow
-  isInteractionRequired(): boolean {
-    return isInteractionRequired(this);
+  isInteractionRequired(hashOrSearch?: string): boolean {
+    return isInteractionRequired(this, hashOrSearch);
   }
 
   isInteractionRequiredError(error: Error): boolean {

--- a/lib/StorageManager.ts
+++ b/lib/StorageManager.ts
@@ -17,6 +17,7 @@ import {
   TOKEN_STORAGE_NAME,
   TRANSACTION_STORAGE_NAME,
   SHARED_TRANSACTION_STORAGE_NAME,
+  ORIGINAL_URI_STORAGE_NAME,
   IDX_RESPONSE_STORAGE_NAME,
   CACHE_STORAGE_NAME,
   REDIRECT_OAUTH_PARAMS_NAME
@@ -103,6 +104,14 @@ export default class StorageManager {
     logServerSideMemoryStorageWarning(options);
     const storage = this.getStorage(options);
     const storageKey = options.storageKey || SHARED_TRANSACTION_STORAGE_NAME;
+    return new SavedObject(storage, storageKey);
+  }
+
+  getOriginalUriStorage(options?: StorageOptions): TransactionStorage {
+    options = this.getOptionsForSection('original-uri', options);
+    logServerSideMemoryStorageWarning(options);
+    const storage = this.getStorage(options);
+    const storageKey = options.storageKey || ORIGINAL_URI_STORAGE_NAME;
     return new SavedObject(storage, storageKey);
   }
 

--- a/lib/TransactionManager.ts
+++ b/lib/TransactionManager.ts
@@ -54,13 +54,16 @@ export default class TransactionManager {
 
   clear(options: TransactionMetaOptions = {}) {
     const transactionStorage: StorageProvider = this.storageManager.getTransactionStorage();
+    const meta = transactionStorage.getStorage();
     transactionStorage.clearStorage();
 
     const idxStateStorage: StorageProvider = this.storageManager.getIdxResponseStorage();
     idxStateStorage?.clearStorage();
 
-    if (this.enableSharedStorage && options.state) {
-      clearTransactionFromSharedStorage(this.storageManager, options.state);
+    // Automatically clear shared storage if a matching state is found. options.state can be set to false to disable
+    const state = (typeof options.state === 'undefined') ? meta.state : options.state;
+    if (this.enableSharedStorage && state) {
+      clearTransactionFromSharedStorage(this.storageManager, state);
     }
   
     if (!this.legacyWidgetSupport) {

--- a/lib/TransactionManager.ts
+++ b/lib/TransactionManager.ts
@@ -95,6 +95,11 @@ export default class TransactionManager {
 
     storage.setStorage(meta);
 
+    // Shared storage allows continuation of transaction in another tab
+    if (this.enableSharedStorage && meta.state) {
+      saveTransactionToSharedStorage(this.storageManager, meta.state, meta);
+    }
+
     if (!options.oauth) {
       return;
     }
@@ -134,11 +139,6 @@ export default class TransactionManager {
         // Set state cookie for servers to validate state
         cookieStorage.setItem(REDIRECT_STATE_COOKIE_NAME, meta.state, null);
       }
-    }
-
-    // Shared storage allows continuation of transaction in another tab
-    if (this.enableSharedStorage && meta.state) {
-      saveTransactionToSharedStorage(this.storageManager, meta.state, meta);
     }
   }
 

--- a/lib/TransactionManager.ts
+++ b/lib/TransactionManager.ts
@@ -61,7 +61,7 @@ export default class TransactionManager {
     idxStateStorage?.clearStorage();
 
     // Automatically clear shared storage if a matching state is found. options.state can be set to false to disable
-    const state = (typeof options.state === 'undefined') ? meta.state : options.state;
+    const state = (typeof options.state === 'undefined') ? meta?.state : options.state;
     if (this.enableSharedStorage && state) {
       clearTransactionFromSharedStorage(this.storageManager, state);
     }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -22,6 +22,7 @@ export const CACHE_STORAGE_NAME = 'okta-cache-storage';
 export const PKCE_STORAGE_NAME = 'okta-pkce-storage';
 export const TRANSACTION_STORAGE_NAME = 'okta-transaction-storage';
 export const SHARED_TRANSACTION_STORAGE_NAME = 'okta-shared-transaction-storage';
+export const ORIGINAL_URI_STORAGE_NAME = 'okta-original-uri-storage';
 export const IDX_RESPONSE_STORAGE_NAME = 'okta-idx-response-storage';
 export const ACCESS_TOKEN_STORAGE_KEY = 'accessToken';
 export const ID_TOKEN_STORAGE_KEY =  'idToken';

--- a/lib/idx/interact.ts
+++ b/lib/idx/interact.ts
@@ -36,7 +36,8 @@ function getResponse(meta: IdxTransactionMeta): InteractResponse {
 
 // Begin or resume a transaction. Returns an interaction handle
 export async function interact (authClient: OktaAuth, options: InteractOptions = {}): Promise<InteractResponse> {
-  const meta = await getTransactionMeta(authClient);
+  let state = options.state || authClient.options.state;
+  const meta = await getTransactionMeta(authClient, { state });
 
   // Saved transaction, return meta
   if (meta.interactionHandle) {
@@ -50,7 +51,7 @@ export async function interact (authClient: OktaAuth, options: InteractOptions =
   const { clientId, redirectUri } = authClient.options;
 
   // These properties can be set in options, but also have a default value in global configuration.
-  const state = options.state || authClient.options.state || meta.state;
+  state = state || meta.state;
   const scopes = options.scopes || authClient.options.scopes || meta.scopes;
 
   const baseUrl = getOAuthBaseUrl(authClient);

--- a/lib/idx/introspect.ts
+++ b/lib/idx/introspect.ts
@@ -23,10 +23,13 @@ export interface IntrospectOptions {
 }
 
 export async function introspect (authClient: OktaAuth, options: IntrospectOptions): Promise<IdxResponse> {
+  const useLastResponse = !options.stateTokenExternalId; // email verify callback: must make a new response
   let rawIdxResponse: RawIdxResponse;
   
-  // try load from storage first
-  rawIdxResponse = authClient.transactionManager.loadIdxResponse();
+  if (useLastResponse) {
+    // try load from storage first
+    rawIdxResponse = authClient.transactionManager.loadIdxResponse();
+  }
   
   // call idx.introspect if no existing idx response available in storage
   if (!rawIdxResponse) {

--- a/lib/idx/introspect.ts
+++ b/lib/idx/introspect.ts
@@ -19,6 +19,7 @@ import { IDX_API_VERSION } from '../constants';
 export interface IntrospectOptions {
   interactionHandle: string;
   stateHandle?: string;
+  stateTokenExternalId?: string;
 }
 
 export async function introspect (authClient: OktaAuth, options: IntrospectOptions): Promise<IdxResponse> {

--- a/lib/idx/introspect.ts
+++ b/lib/idx/introspect.ts
@@ -12,7 +12,7 @@
 
 import idx from '@okta/okta-idx-js';
 import { OktaAuth } from '../types';
-import { IdxResponse, RawIdxResponse } from './types/idx-js';
+import { IdxResponse, isRawIdxResponse, RawIdxResponse } from './types/idx-js';
 import { getOAuthDomain } from '../oidc';
 import { IDX_API_VERSION } from '../constants';
 
@@ -35,7 +35,15 @@ export async function introspect (authClient: OktaAuth, options: IntrospectOptio
   if (!rawIdxResponse) {
     const version = IDX_API_VERSION;
     const domain = getOAuthDomain(authClient);
-    rawIdxResponse = await idx.introspect({ domain, version, ...options });
+    try {
+      rawIdxResponse = await idx.introspect({ domain, version, ...options });
+    } catch (err) {
+      if (isRawIdxResponse(err)) {
+        rawIdxResponse = err;
+      } else {
+        throw err;
+      }
+    }
   }
 
   return idx.makeIdxState(rawIdxResponse);

--- a/lib/idx/introspect.ts
+++ b/lib/idx/introspect.ts
@@ -17,7 +17,7 @@ import { getOAuthDomain } from '../oidc';
 import { IDX_API_VERSION } from '../constants';
 
 export interface IntrospectOptions {
-  interactionHandle: string;
+  interactionHandle?: string;
   stateHandle?: string;
   stateTokenExternalId?: string;
 }

--- a/lib/idx/remediate.ts
+++ b/lib/idx/remediate.ts
@@ -12,14 +12,12 @@
 
 
 /* eslint-disable max-statements, max-depth, complexity */
-import idx from '@okta/okta-idx-js';
 import { AuthSdkError } from '../errors';
 import { Remediator, RemediationValues } from './remediators';
 import { RunOptions, RemediationFlow } from './run';
 import { NextStep, IdxMessage } from './types';
 import { 
-  IdxResponse, 
-  isRawIdxResponse, 
+  IdxResponse,  
   IdxRemediation,
   isIdxResponse, 
 } from './types/idx-js';

--- a/lib/idx/run.ts
+++ b/lib/idx/run.ts
@@ -89,13 +89,14 @@ export async function run(
   let availableSteps;
   let status = IdxStatus.PENDING;
   let shouldClearTransaction = false;
+  let idxResponse;
 
   try {
     // Start/resume the flow
     const { interactionHandle, meta: metaFromResp } = await interact(authClient, options); 
 
     // Introspect to get idx response
-    const idxResponse = await introspect(authClient, { interactionHandle });
+    idxResponse = await introspect(authClient, { interactionHandle });
 
     if (!options.flow && !options.actions) {
       // handle start transaction
@@ -171,6 +172,7 @@ export async function run(
   }
   
   return {
+    _idxResponse: idxResponse, 
     status,
     ...(meta && { meta }),
     ...(enabledFeatures && { enabledFeatures }),

--- a/lib/idx/run.ts
+++ b/lib/idx/run.ts
@@ -33,6 +33,7 @@ export interface RunOptions {
   flow?: RemediationFlow;
   actions?: string[];
   flowMonitor?: FlowMonitor;
+  stateTokenExternalId?: string;
 }
 
 function getEnabledFeatures(idxResponse: IdxResponse): IdxFeature[] {
@@ -96,7 +97,8 @@ export async function run(
     const { interactionHandle, meta: metaFromResp } = await interact(authClient, options); 
 
     // Introspect to get idx response
-    idxResponse = await introspect(authClient, { interactionHandle });
+    const { stateTokenExternalId } = options;
+    idxResponse = await introspect(authClient, { interactionHandle, stateTokenExternalId });
 
     if (!options.flow && !options.actions) {
       // handle start transaction

--- a/lib/idx/transactionMeta.ts
+++ b/lib/idx/transactionMeta.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { OktaAuth, IdxTransactionMeta } from '../types';
+import { OktaAuth, IdxTransactionMeta, TransactionMetaOptions } from '../types';
 import { warn } from '../util';
 import { getOAuthUrls } from '../oidc';
 
@@ -19,9 +19,9 @@ export async function createTransactionMeta(authClient: OktaAuth) {
   return authClient.token.prepareTokenParams();
 }
 
-export function transactionMetaExist(authClient: OktaAuth): boolean {
-  if (authClient.transactionManager.exists()) {
-    const existing = authClient.transactionManager.load() as IdxTransactionMeta;
+export function transactionMetaExist(authClient: OktaAuth, options?: TransactionMetaOptions): boolean {
+  if (authClient.transactionManager.exists(options)) {
+    const existing = authClient.transactionManager.load(options) as IdxTransactionMeta;
     if (isTransactionMetaValid(authClient, existing) && existing.interactionHandle) {
       return true;
     }
@@ -29,10 +29,13 @@ export function transactionMetaExist(authClient: OktaAuth): boolean {
   return false;
 }
 
-export async function getTransactionMeta(authClient: OktaAuth): Promise<IdxTransactionMeta> {
+export async function getTransactionMeta(
+  authClient: OktaAuth,
+  options?: TransactionMetaOptions
+): Promise<IdxTransactionMeta> {
   // Load existing transaction meta from storage
-  if (authClient.transactionManager.exists()) {
-    const existing = authClient.transactionManager.load();
+  if (authClient.transactionManager.exists(options)) {
+    const existing = authClient.transactionManager.load(options);
     if (isTransactionMetaValid(authClient, existing)) {
       return existing as IdxTransactionMeta;
     }

--- a/lib/idx/transactionMeta.ts
+++ b/lib/idx/transactionMeta.ts
@@ -29,15 +29,24 @@ export function transactionMetaExist(authClient: OktaAuth, options?: Transaction
   return false;
 }
 
+// Returns the saved transaction meta, if it exists and is valid, or undefined
+export function getSavedTransactionMeta(authClient: OktaAuth, options?: TransactionMetaOptions): IdxTransactionMeta {
+  const state = options?.state || authClient.options.state;
+  const existing = authClient.transactionManager.load({ state }) as IdxTransactionMeta;
+  if (existing && isTransactionMetaValid(authClient, existing)) {
+    return existing;
+  }
+}
+
 export async function getTransactionMeta(
   authClient: OktaAuth,
   options?: TransactionMetaOptions
 ): Promise<IdxTransactionMeta> {
   // Load existing transaction meta from storage
   if (authClient.transactionManager.exists(options)) {
-    const existing = authClient.transactionManager.load(options);
-    if (isTransactionMetaValid(authClient, existing)) {
-      return existing as IdxTransactionMeta;
+    const validExistingMeta = getSavedTransactionMeta(authClient, options);
+    if (validExistingMeta) {
+      return validExistingMeta;
     }
     // existing meta is not valid for this configuration
     // this is common when changing configuration in local development environment

--- a/lib/idx/types/idx-js.ts
+++ b/lib/idx/types/idx-js.ts
@@ -119,3 +119,7 @@ export interface IdxResponse {
     interactionHandle?: string;
   };
 }
+
+export function isIdxResponse(obj: any): obj is IdxResponse {
+  return obj && isRawIdxResponse(obj.rawIdxState);
+}

--- a/lib/idx/types/index.ts
+++ b/lib/idx/types/index.ts
@@ -14,7 +14,7 @@
 import { InteractOptions } from '../interact';
 import { APIError, Tokens } from '../../types';
 import { IdxTransactionMeta } from '../../types/Transaction';
-import { IdxAuthenticator, IdxMessage, IdxOption } from './idx-js';
+import { IdxAuthenticator, IdxMessage, IdxOption, IdxResponse } from './idx-js';
 
 export { IdxMessage } from './idx-js';
 export { AuthenticationOptions } from '../authenticate';
@@ -70,6 +70,7 @@ export interface IdxTransaction {
   meta?: IdxTransactionMeta;
   enabledFeatures?: IdxFeature[];
   availableSteps?: NextStep[];
+  _idxResponse?: IdxResponse; // Temporary for widget conversion. Will not be supported long-term. OKTA-418165
 }
 
 export type IdxOptions = InteractOptions;

--- a/lib/oidc/getWithRedirect.ts
+++ b/lib/oidc/getWithRedirect.ts
@@ -43,10 +43,6 @@ export function getWithRedirect(sdk: OktaAuth, options: TokenParams): Promise<vo
         codeChallengeMethod,
       } = tokenParams;
 
-      // Also store the originalUri (if any) in the transaction meta.
-      // This is needed to support continue flow in another tab.
-      const originalUri = sdk.getOriginalUri();
-
       const oauthMeta: TransactionMeta = {
         issuer,
         responseType,
@@ -59,8 +55,7 @@ export function getWithRedirect(sdk: OktaAuth, options: TokenParams): Promise<vo
         redirectUri,
         codeVerifier,
         codeChallenge,
-        codeChallengeMethod,
-        originalUri,
+        codeChallengeMethod
       };
 
       sdk.transactionManager.save(oauthMeta, { oauth: true });

--- a/lib/oidc/util/loginRedirect.ts
+++ b/lib/oidc/util/loginRedirect.ts
@@ -78,12 +78,14 @@ export function isLoginRedirect (sdk: OktaAuth) {
  * Check if error=interaction_required has been passed back in the url, which happens in
  * the social auth IDP redirect flow.
  */
-export function isInteractionRequired (sdk: OktaAuth) {
+export function isInteractionRequired (sdk: OktaAuth, hashOrSearch?: string) {
+  if (!hashOrSearch) { // web only
     // First check, is this a redirect URI?
     if (!isLoginRedirect(sdk)){
       return false;
     }
   
-  var hashOrSearch = getHashOrSearch(sdk.options);
+    hashOrSearch = getHashOrSearch(sdk.options);
+  }
   return /(error=interaction_required)/i.test(hashOrSearch);
 }

--- a/lib/oidc/util/urlParams.ts
+++ b/lib/oidc/util/urlParams.ts
@@ -16,7 +16,7 @@ export function urlParamsToObject(hashOrSearch: string) {
   // Predefine regexs for parsing hash
   var plus2space = /\+/g;
   var paramSplit = /([^&=]+)=?([^&]*)/g;
-  var fragment = hashOrSearch;
+  var fragment = hashOrSearch || '';
 
   // Some hash based routers will automatically add a / character after the hash
   if (fragment.charAt(0) === '#' && fragment.charAt(1) === '/') {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -110,7 +110,7 @@ function getCookieSettings(args: OktaAuthOptions = {}, isHTTPS: boolean) {
 export function getDefaultOptions(): OktaAuthOptions {
   const storageUtil = isBrowser() ? browserStorage : serverStorage;
   const storageManager = isBrowser() ? BROWSER_STORAGE : SERVER_STORAGE;
-  const enableSharedStorage = isBrowser() ? true : false; // localStorage for multi-tab flows (web only)
+  const enableSharedStorage = isBrowser() ? true : false; // localStorage for multi-tab flows (browser only)
   return {
     devMode: false,
     httpRequestClient: fetchRequest,

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -48,6 +48,11 @@ const BROWSER_STORAGE: StorageManagerOptions = {
     storageTypes: [
       'localStorage'
     ]
+  },
+  'original-uri': {
+    storageTypes: [
+      'localStorage'
+    ]
   }
 };
 

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -110,17 +110,22 @@ function getCookieSettings(args: OktaAuthOptions = {}, isHTTPS: boolean) {
 export function getDefaultOptions(): OktaAuthOptions {
   const storageUtil = isBrowser() ? browserStorage : serverStorage;
   const storageManager = isBrowser() ? BROWSER_STORAGE : SERVER_STORAGE;
+  const enableSharedStorage = isBrowser() ? true : false; // localStorage for multi-tab flows (web only)
   return {
     devMode: false,
     httpRequestClient: fetchRequest,
     storageUtil,
-    storageManager
+    storageManager,
+    transactionManager: {
+      enableSharedStorage
+    }
   };
 }
 
 function mergeOptions(options, args): OktaAuthOptions {
   return Object.assign({}, options, removeNils(args), {
-    storageManager: Object.assign({}, options.storageManager, args.storageManager)
+    storageManager: Object.assign({}, options.storageManager, args.storageManager),
+    transactionManager: Object.assign({}, options.transactionManager, args.transactionManager),
   });
 }
 
@@ -154,6 +159,7 @@ export function buildOptions(args: OktaAuthOptions = {}): OktaAuthOptions {
     headers: args.headers,
     devMode: !!args.devMode,
     storageManager: args.storageManager,
+    transactionManager: args.transactionManager,
     cookies: isBrowser() ? getCookieSettings(args, isHTTPS()) : args.cookies,
 
     // Give the developer the ability to disable token signature validation.

--- a/lib/server/serverStorage.ts
+++ b/lib/server/serverStorage.ts
@@ -14,7 +14,9 @@
 import { SimpleStorage, StorageType, StorageUtil, Cookies } from '../types';
 import { AuthSdkError } from '../errors';
 const NodeCache = require('node-cache'); // commonJS module cannot be imported without esModuleInterop
-const sharedStorage = new NodeCache(); // this is a SHARED memory storage to support a stateless http server
+
+// this is a SHARED memory storage to support a stateless http server
+const sharedStorage = typeof NodeCache === 'function' ? new NodeCache() : null;
 
 class ServerCookies implements Cookies {
   nodeCache: any; // NodeCache

--- a/lib/util/emailVerify.ts
+++ b/lib/util/emailVerify.ts
@@ -11,7 +11,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-/* global window */
 import { urlParamsToObject  } from '../oidc/util/urlParams';
 
 export interface EmailVerifyCallbackResponse {
@@ -20,12 +19,11 @@ export interface EmailVerifyCallbackResponse {
 }
 
 // Check if state && stateTokenExternalId have been passed back in the url
-export function isEmailVerifyCallback (urlPath?: string): boolean {
-  urlPath = urlPath || window.location.search;
+export function isEmailVerifyCallback (urlPath: string): boolean {
   return /(stateTokenExternalId=)/i.test(urlPath) && /(state=)/i.test(urlPath);
 }
 
-export function parseEmailVerifyCallback(urlPath?: string): EmailVerifyCallbackResponse {
-  urlPath = urlPath || window.location.search;
+// Parse state and stateTokenExternalId from a urlPath (should be either a search or fragment from the URL)
+export function parseEmailVerifyCallback(urlPath: string): EmailVerifyCallbackResponse {
   return urlParamsToObject(urlPath) as EmailVerifyCallbackResponse;
 }

--- a/lib/util/emailVerify.ts
+++ b/lib/util/emailVerify.ts
@@ -1,0 +1,31 @@
+
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/* global window */
+import { urlParamsToObject  } from '../oidc/util/urlParams';
+
+export interface EmailVerifyCallbackResponse {
+  state: string;
+  stateTokenExternalId: string;
+}
+
+// Check if state && stateTokenExternalId have been passed back in the url
+export function isEmailVerifyCallback (urlPath?: string): boolean {
+  urlPath = urlPath || window.location.search;
+  return /(stateTokenExternalId=)/i.test(urlPath) && /(state=)/i.test(urlPath);
+}
+
+export function parseEmailVerifyCallback(urlPath?: string): EmailVerifyCallbackResponse {
+  urlPath = urlPath || window.location.search;
+  return urlParamsToObject(urlPath) as EmailVerifyCallbackResponse;
+}

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -12,6 +12,7 @@
 
 
 export * from './console';
+export * from './emailVerify';
 export * from './misc';
 export * from './object';
 export * from './types';

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "test:samples": "yarn workspace @okta/test.e2e.samples start",
     "test:integration": "jest --config ./jest.integration.js",
     "build": "node scripts/build.js",
-    "build:cdn": "cross-env NODE_ENV=production webpack --config webpack.cdn.config.js -p",
-    "build:web": "cross-env NODE_ENV=production webpack --config webpack.config.js --output-library-target=umd -p",
+    "build:cdn": "cross-env NODE_ENV=production webpack --config webpack.cdn.config.js",
+    "build:web": "cross-env NODE_ENV=production webpack --config webpack.config.js",
     "build:cjs": "cross-env babel lib -d build/cjs --config-file ./babel.cjs.js --extensions \".ts\",\".js\" --source-maps",
     "build:esm": "cross-env babel lib -d build/esm --config-file ./babel.esm.js --extensions \".ts\",\".js\" --source-maps",
-    "build:polyfill": "cross-env NODE_ENV=production webpack --config webpack.polyfill.config.js --output-library-target=umd -p",
+    "build:polyfill": "cross-env NODE_ENV=production webpack --config webpack.polyfill.config.js",
     "generate:samples": "yarn workspace @okta/samples build && yarn install --ignore-scripts",
     "dev:samples": "yarn workspace @okta/samples dev",
     "prepare": "yarn build",
@@ -121,7 +121,8 @@
     "ts-loader": "^8.0.1",
     "tsd": "^0.17.0",
     "typescript": "^4.2.3",
-    "webpack": "^4.43.0"
+    "webpack": "^5.60.0",
+    "webpack-cli": "^4.9.1"
   },
   "jest-junit": {
     "outputDirectory": "./build2/reports/unit/",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@okta/okta-idx-js": "0.19.0",
+    "@okta/okta-idx-js": "0.21.0",
     "@peculiar/webcrypto": "1.1.6",
     "Base64": "1.1.0",
     "atob": "^2.1.2",
@@ -118,7 +118,7 @@
     "lodash": "4.17.20",
     "shelljs": "0.8.4",
     "ts-jest": "^26.4.3",
-    "ts-loader": "^8.0.1",
+    "ts-loader": "^9.2.6",
     "tsd": "^0.17.0",
     "typescript": "^4.2.3",
     "webpack": "^5.60.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@okta/okta-idx-js": "0.21.0",
+    "@okta/okta-idx-js": "0.22.0",
     "@peculiar/webcrypto": "1.1.6",
     "Base64": "1.1.0",
     "atob": "^2.1.2",

--- a/samples/config.js
+++ b/samples/config.js
@@ -24,7 +24,8 @@ const spaDefaults = Object.assign({
   signinForm: true,
   mfa: true,
   authn: true,
-  signinWidget: true
+  signinWidget: true,
+  emailVerify: false // set to true once tested/ready for public release
 }, defaults);
 
 const webDefaults = Object.assign({

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/routes/login.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/routes/login.js
@@ -12,6 +12,7 @@
 
 
 const express = require('express');
+const URL = require('url').URL;
 const { 
   getAuthClient, 
   handleTransaction,
@@ -70,15 +71,23 @@ router.post('/login', async (req, res, next) => {
 });
 
 router.get('/login/callback', async (req, res, next) => {
-  const url = req.protocol + '://' + req.get('host') + req.originalUrl;
+  const { protocol, originalUrl } = req;
+  const parsedUrl = new URL(protocol + '://' + req.get('host') + originalUrl);
+  const { href, search } = parsedUrl;
   const authClient = getAuthClient(req);
+
   try {
-    // Exchange code for tokens
-    await authClient.idx.handleInteractionCodeRedirect(url);
-    // Redirect back to home page
-    res.redirect('/');
-  } catch (err) {
-    if (authClient.isInteractionRequiredError(err) === true) {
+    if (authClient.isEmailVerifyCallback(search)) {
+      const { state, stateTokenExternalId } = authClient.parseEmailVerifyCallback(search);
+      const transaction = await authClient.idx.authenticate({ 
+        state,
+        stateTokenExternalId
+      });
+      handleTransaction({ req, res, next, authClient, transaction });
+      return;
+    }
+
+    if (authClient.isInteractionRequired(search)) {
       const error = new Error(
         'Multifactor Authentication and Social Identity Providers is not currently supported, Authentication failed.'
       );
@@ -86,6 +95,11 @@ router.get('/login/callback', async (req, res, next) => {
       return;
     }
 
+    // Exchange code for tokens
+    await authClient.idx.handleInteractionCodeRedirect(href);
+    // Redirect back to home page
+    res.redirect('/');
+  } catch (err) {
     next(err);
   }
 });

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/routes/login.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/routes/login.js
@@ -78,10 +78,10 @@ router.get('/login/callback', async (req, res, next) => {
 
   try {
     if (authClient.isEmailVerifyCallback(search)) {
-      const { state, stateTokenExternald } = authClient.parseEmailVerifyCallback(search);
+      const { state, stateTokenExternalId } = authClient.parseEmailVerifyCallback(search);
       const transaction = await authClient.idx.authenticate({ 
         state,
-        stateTokenExternald
+        stateTokenExternalId
       });
       handleTransaction({ req, res, next, authClient, transaction });
       return;

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/routes/register.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/routes/register.js
@@ -21,16 +21,21 @@ const {
 const router = express.Router();
 
 // entry route
-router.get('/register', async (req, res) => {
+router.get('/register', async (req, res, next) => {
   req.setFlowStates({
     entry: '/register',
     idxMethod: 'register'
   });
   const authClient = getAuthClient(req);
+  const trans = await authClient.idx.register();
+  if (trans.error) {
+    next(trans.error);
+    return;
+  }
+
   const {
     nextStep: { inputs }
-  } = await authClient.idx.register();
-
+  } = trans;
   renderTemplate(req, res, 'enroll-profile', {
     action: '/register',
     inputs

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/server.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/server.js
@@ -84,6 +84,10 @@ app.use(function(err, req, res, next) {
     errors = [err.error_description];
   } else if (err && err.errorSummary) {
     errors = [err.errorSummary];
+  } else if (err && err.xhr) { // AuthJS
+    errors = [JSON.stringify(err.xhr.responseJSON)];
+  } else if (err && err.messages && err.messages.value) { // IDX
+    errors = err.messages.value.map(val => val.message);
   } else {
     errors = ['Internal Error!'];
   }

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/server.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/server.js
@@ -72,8 +72,6 @@ app.use(require('./routes'));
 
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars, complexity
 app.use(function(err, req, res, next) {
-  console.error(err.stack);
-
   let errors;
   if (Array.isArray(err.errorCauses) && err.errorCauses.length) {
     // handle error from SDK

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/server.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/server.js
@@ -87,6 +87,10 @@ app.use(function(err, req, res, next) {
     errors = [err.error_description];
   } else if (err && err.errorSummary) {
     errors = [err.errorSummary];
+  } else if (err && err.xhr) {
+    errors = [err.xhr.responseJSON];
+  } else if (err && err.messages && err.messages.value) {
+    errors = err.messages.value.map(value => value.message);
   } else {
     errors = ['Internal Error!'];
   }

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/server.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/server.js
@@ -72,6 +72,9 @@ app.use(require('./routes'));
 
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars, complexity
 app.use(function(err, req, res, next) {
+  if (err && err.stack) {
+    console.error(err.stack);
+  }
   let errors;
   if (Array.isArray(err.errorCauses) && err.errorCauses.length) {
     // handle error from SDK
@@ -84,10 +87,6 @@ app.use(function(err, req, res, next) {
     errors = [err.error_description];
   } else if (err && err.errorSummary) {
     errors = [err.errorSummary];
-  } else if (err && err.xhr) { // AuthJS
-    errors = [JSON.stringify(err.xhr.responseJSON)];
-  } else if (err && err.messages && err.messages.value) { // IDX
-    errors = err.messages.value.map(val => val.message);
   } else {
     errors = ['Internal Error!'];
   }

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/utils/getAuthClient.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/utils/getAuthClient.js
@@ -19,11 +19,13 @@ module.exports = function getAuthClient(req, options = {}) {
   const { oidc } = getConfig().webServer;
   const storageProvider = {
     getItem: function(key) {
-      let val;
-      try {
-        val = JSON.parse(req.session[key]);
-      } catch (err) {
-        val = null;
+      let val = req.session[key] || null;
+      if (val) {
+        try {
+          val = JSON.parse(req.session[key]);
+        } catch (err) {
+          val = null;
+        }
       }
       return val;
     },

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/views/authenticator.mustache
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/views/authenticator.mustache
@@ -44,7 +44,7 @@
                 Enter Code
               </div>
               {{#input}}
-                <input id="authenticator-code-input" type="{{type}}" name="{{name}}" required />
+                <input id="authenticator-code-input" type="{{type}}" name="{{name}}" autoComplete="off" required />
               {{/input}}
             </div>
           </div>

--- a/samples/generated/express-embedded-sign-in-widget/package.json
+++ b/samples/generated/express-embedded-sign-in-widget/package.json
@@ -18,7 +18,7 @@
     "js-yaml": "^4.1.0",
     "dotenv": "^10.0.0",
     "@okta/okta-auth-js": "*",
-    "@okta/okta-signin-widget": "^5.12.1"
+    "@okta/okta-signin-widget": "^5.13.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.7",

--- a/samples/generated/express-embedded-sign-in-widget/web-server/routes/login.js
+++ b/samples/generated/express-embedded-sign-in-widget/web-server/routes/login.js
@@ -54,7 +54,7 @@ router.get('/login', (req, res, next) => {
         codeChallengeMethod,
       };
       res.render('login', {
-        siwVersion: '5.12.1',
+        siwVersion: '5.13.0',
         widgetConfig: JSON.stringify(widgetConfig),
       });
     })

--- a/samples/generated/static-spa/public/app.js
+++ b/samples/generated/static-spa/public/app.js
@@ -420,6 +420,7 @@ function handleLoginRedirect() {
     return Promise.resolve();
   }
   
+
   // If the URL contains a code, `parseFromUrl` will grab it and exchange the code for tokens
   return authClient.token.parseFromUrl().then(function (res) {
     endAuthFlow(res.tokens); // save tokens
@@ -545,9 +546,9 @@ function redirectToLogin(additionalParams) {
   }, additionalParams));
 }
 window._loginRedirect = bindClick(redirectToLogin);
-function showSigninWidget() {
-  // Create an instance of the signin widget
-  var signIn = new OktaSignIn({
+function showSigninWidget(options) {
+  // Create widget options
+  options = Object.assign({
     baseUrl: config.issuer.split('/oauth2')[0],
     clientId: config.clientId,
     redirectUri: config.redirectUri,
@@ -562,7 +563,10 @@ function showSigninWidget() {
       }
       return { type, id };
     }).filter(idpToken => idpToken)
-  });
+  }, options);
+
+  // Create an instance of the signin widget
+  var signIn = new OktaSignIn(options);
 
   signIn.showSignIn({
     el: '#signin-widget',
@@ -579,7 +583,7 @@ function showSigninWidget() {
 
   document.getElementById('flow-widget').style.display = 'block'; // show login UI
 }
-function resumeTransaction() {
+function resumeTransaction(options) {
   if (!config.useInteractionCodeFlow) {
     // Authn
     if (authClient.tx.exists()) {
@@ -594,18 +598,18 @@ function resumeTransaction() {
     // TODO: we may be in either authenticate or recoverPassword flow
     // ExpressJS sample uses "idxMethod" in persistent storage to workaround not knowing which flow we are on
     // Here we assume we are resuming an authenticate flow, but this could be wrong.
-    return authClient.idx.authenticate()
+    return authClient.idx.authenticate(options)
       .then(handleTransaction)
       .catch(showError);
   }
 }
 
-function showSigninForm() {
+function showSigninForm(options) {
   hideRecoveryChallenge();
   hideNewPasswordForm();
 
   // Is there an existing transaction we can resume?
-  if (resumeTransaction()) {
+  if (resumeTransaction(options)) {
     return;
   }
 

--- a/samples/generated/static-spa/public/index.html
+++ b/samples/generated/static-spa/public/index.html
@@ -8,8 +8,8 @@
     <script src="/okta-auth-js.min.js" type="text/javascript"></script>
 
     <!-- okta-signin-widget assets are avilable on CDN -->
-    <script src="https://global.oktacdn.com/okta-signin-widget/5.12.1/js/okta-sign-in.min.js" type="text/javascript"></script>
-    <link href="https://global.oktacdn.com/okta-signin-widget/5.12.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+    <script src="https://global.oktacdn.com/okta-signin-widget/5.13.0/js/okta-sign-in.min.js" type="text/javascript"></script>
+    <link href="https://global.oktacdn.com/okta-signin-widget/5.13.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 
     <!-- app styles -->
     <link rel="stylesheet" href="https://unpkg.com/purecss@2.0.6/build/pure-min.css" integrity="sha384-Uu6IeWbM+gzNVXJcM9XV3SohHtmWE+3VGi496jvgX1jyvDTXfdK+rfZc8C1Aehk5" crossorigin="anonymous">

--- a/samples/generated/webpack-spa/package.json
+++ b/samples/generated/webpack-spa/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@okta/okta-auth-js": "*",
-    "@okta/okta-signin-widget": "^5.12.1"
+    "@okta/okta-signin-widget": "^5.13.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",

--- a/samples/generated/webpack-spa/src/index.js
+++ b/samples/generated/webpack-spa/src/index.js
@@ -419,6 +419,7 @@ function handleLoginRedirect() {
     return Promise.resolve();
   }
   
+
   // If the URL contains a code, `parseFromUrl` will grab it and exchange the code for tokens
   return authClient.token.parseFromUrl().then(function (res) {
     endAuthFlow(res.tokens); // save tokens
@@ -544,9 +545,9 @@ function redirectToLogin(additionalParams) {
   }, additionalParams));
 }
 window._loginRedirect = bindClick(redirectToLogin);
-function showSigninWidget() {
-  // Create an instance of the signin widget
-  var signIn = new OktaSignIn({
+function showSigninWidget(options) {
+  // Create widget options
+  options = Object.assign({
     baseUrl: config.issuer.split('/oauth2')[0],
     clientId: config.clientId,
     redirectUri: config.redirectUri,
@@ -561,7 +562,10 @@ function showSigninWidget() {
       }
       return { type, id };
     }).filter(idpToken => idpToken)
-  });
+  }, options);
+
+  // Create an instance of the signin widget
+  var signIn = new OktaSignIn(options);
 
   signIn.showSignIn({
     el: '#signin-widget',
@@ -578,7 +582,7 @@ function showSigninWidget() {
 
   document.getElementById('flow-widget').style.display = 'block'; // show login UI
 }
-function resumeTransaction() {
+function resumeTransaction(options) {
   if (!config.useInteractionCodeFlow) {
     // Authn
     if (authClient.tx.exists()) {
@@ -593,18 +597,18 @@ function resumeTransaction() {
     // TODO: we may be in either authenticate or recoverPassword flow
     // ExpressJS sample uses "idxMethod" in persistent storage to workaround not knowing which flow we are on
     // Here we assume we are resuming an authenticate flow, but this could be wrong.
-    return authClient.idx.authenticate()
+    return authClient.idx.authenticate(options)
       .then(handleTransaction)
       .catch(showError);
   }
 }
 
-function showSigninForm() {
+function showSigninForm(options) {
   hideRecoveryChallenge();
   hideNewPasswordForm();
 
   // Is there an existing transaction we can resume?
-  if (resumeTransaction()) {
+  if (resumeTransaction(options)) {
     return;
   }
 

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/routes/login.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/routes/login.js
@@ -78,10 +78,10 @@ router.get('/login/callback', async (req, res, next) => {
 
   try {
     if (authClient.isEmailVerifyCallback(search)) {
-      const { state, stateTokenExternald } = authClient.parseEmailVerifyCallback(search);
+      const { state, stateTokenExternalId } = authClient.parseEmailVerifyCallback(search);
       const transaction = await authClient.idx.authenticate({ 
         state,
-        stateTokenExternald
+        stateTokenExternalId
       });
       handleTransaction({ req, res, next, authClient, transaction });
       return;

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/routes/register.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/routes/register.js
@@ -21,16 +21,21 @@ const {
 const router = express.Router();
 
 // entry route
-router.get('/register', async (req, res) => {
+router.get('/register', async (req, res, next) => {
   req.setFlowStates({
     entry: '/register',
     idxMethod: 'register'
   });
   const authClient = getAuthClient(req);
+  const trans = await authClient.idx.register();
+  if (trans.error) {
+    next(trans.error);
+    return;
+  }
+
   const {
     nextStep: { inputs }
-  } = await authClient.idx.register();
-
+  } = trans;
   renderTemplate(req, res, 'enroll-profile', {
     action: '/register',
     inputs

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/server.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/server.js
@@ -72,8 +72,6 @@ app.use(require('./routes'));
 
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars, complexity
 app.use(function(err, req, res, next) {
-  console.error(err.stack);
-
   let errors;
   if (Array.isArray(err.errorCauses) && err.errorCauses.length) {
     // handle error from SDK

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/server.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/server.js
@@ -87,6 +87,10 @@ app.use(function(err, req, res, next) {
     errors = [err.error_description];
   } else if (err && err.errorSummary) {
     errors = [err.errorSummary];
+  } else if (err && err.xhr) {
+    errors = [err.xhr.responseJSON];
+  } else if (err && err.messages && err.messages.value) {
+    errors = err.messages.value.map(value => value.message);
   } else {
     errors = ['Internal Error!'];
   }

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/server.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/server.js
@@ -72,6 +72,9 @@ app.use(require('./routes'));
 
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars, complexity
 app.use(function(err, req, res, next) {
+  if (err && err.stack) {
+    console.error(err.stack);
+  }
   let errors;
   if (Array.isArray(err.errorCauses) && err.errorCauses.length) {
     // handle error from SDK

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/utils/getAuthClient.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/utils/getAuthClient.js
@@ -19,11 +19,13 @@ module.exports = function getAuthClient(req, options = {}) {
   const { oidc } = getConfig().webServer;
   const storageProvider = {
     getItem: function(key) {
-      let val;
-      try {
-        val = JSON.parse(req.session[key]);
-      } catch (err) {
-        val = null;
+      let val = req.session[key] || null;
+      if (val) {
+        try {
+          val = JSON.parse(req.session[key]);
+        } catch (err) {
+          val = null;
+        }
       }
       return val;
     },

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/views/authenticator.mustache
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/views/authenticator.mustache
@@ -44,7 +44,7 @@
                 Enter Code
               </div>
               {{#input}}
-                <input id="authenticator-code-input" type="{{type}}" name="{{name}}" required />
+                <input id="authenticator-code-input" type="{{type}}" name="{{name}}" autoComplete="off" required />
               {{/input}}
             </div>
           </div>

--- a/samples/templates/partials/spa/app.js
+++ b/samples/templates/partials/spa/app.js
@@ -202,6 +202,28 @@ function handleLoginRedirect() {
     return Promise.resolve();
   }
   
+  {{#if emailVerify}}
+  if (authClient.isEmailVerifyCallback(window.location.search)) {
+    return authClient.parseEmailVerifyCallback(window.location.search).then(function(res) {
+      switch (config.flow) {
+        {{#if signinWidget}}
+        case 'widget':
+          showSigninWidget();
+          break;
+        {{/if}}
+        {{#if signinForm}}
+        case 'form':
+          showSigninForm();
+          break;
+        {{/if}}
+        default:
+          throw new Error(`Email verify callback can not be used with flow: ${config.flow}`);
+          break;
+      }
+    });
+  }
+  {{/if}}
+
   // If the URL contains a code, `parseFromUrl` will grab it and exchange the code for tokens
   return authClient.token.parseFromUrl().then(function (res) {
     endAuthFlow(res.tokens); // save tokens

--- a/samples/templates/partials/spa/flow/direct/basic.js
+++ b/samples/templates/partials/spa/flow/direct/basic.js
@@ -1,4 +1,4 @@
-function resumeTransaction() {
+function resumeTransaction(options) {
   {{#if authn}}
   if (!config.useInteractionCodeFlow) {
     // Authn
@@ -15,18 +15,18 @@ function resumeTransaction() {
     // TODO: we may be in either authenticate or recoverPassword flow
     // ExpressJS sample uses "idxMethod" in persistent storage to workaround not knowing which flow we are on
     // Here we assume we are resuming an authenticate flow, but this could be wrong.
-    return authClient.idx.authenticate()
+    return authClient.idx.authenticate(options)
       .then(handleTransaction)
       .catch(showError);
   }
 }
 
-function showSigninForm() {
+function showSigninForm(options) {
   hideRecoveryChallenge();
   hideNewPasswordForm();
 
   // Is there an existing transaction we can resume?
-  if (resumeTransaction()) {
+  if (resumeTransaction(options)) {
     return;
   }
 

--- a/samples/templates/partials/spa/flow/widget.js
+++ b/samples/templates/partials/spa/flow/widget.js
@@ -1,6 +1,6 @@
-function showSigninWidget() {
-  // Create an instance of the signin widget
-  var signIn = new OktaSignIn({
+function showSigninWidget(options) {
+  // Create widget options
+  options = Object.assign({
     baseUrl: config.issuer.split('/oauth2')[0],
     clientId: config.clientId,
     redirectUri: config.redirectUri,
@@ -15,7 +15,10 @@ function showSigninWidget() {
       }
       return { type, id };
     }).filter(idpToken => idpToken)
-  });
+  }, options);
+
+  // Create an instance of the signin widget
+  var signIn = new OktaSignIn(options);
 
   signIn.showSignIn({
     el: '#signin-widget',

--- a/test/apps/app/public/index.html
+++ b/test/apps/app/public/index.html
@@ -1,13 +1,26 @@
+<!DOCTYPE html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://unpkg.com/purecss@2.0.6/build/pure-min.css" integrity="sha384-Uu6IeWbM+gzNVXJcM9XV3SohHtmWE+3VGi496jvgX1jyvDTXfdK+rfZc8C1Aehk5" crossorigin="anonymous">
     <link rel="stylesheet" href="/oidc-app.css"/>
   </head>
   <body class="oidc-app landing">
-    <div class="box nav">
-      <a class="config-link" href="#" onclick="showConfigForm(event)">⚙️</a>
-      <div class="link selected">Webpack SPA App</div>
-      <a href="/server" onclick="navigateToApp('/server', event)">Server-side Web App</a>
-      <a href="/static" onclick="navigateToApp('/static', event)">Static SPA App</a>
+    <div id="header">
+      <div class="pure-menu pure-menu-horizontal">
+        <a class="pure-menu-heading pure-menu-link config-link" href="#config" onclick="showConfigForm(event)">⚙️</a>
+        <ul class="pure-menu-list">
+          <li class="pure-menu-item pure-menu-selected">
+            <div class="pure-menu-link">Webpack SPA App</div>
+          </li>
+          <li class="pure-menu-item">
+            <a class="pure-menu-link" href="/server" onclick="navigateToApp('/server', event)">Server-side Web App</a>
+          </li>
+          <li class="pure-menu-item">
+            <a class="pure-menu-link" href="/static" onclick="navigateToApp('/static', event)">Static SPA App</a>
+          </li>
+        </ul>
+      </div>
     </div>
     <div id="root">
     </div>

--- a/test/apps/app/public/oidc-app.css
+++ b/test/apps/app/public/oidc-app.css
@@ -2,18 +2,6 @@
   box-sizing: border-box;
 }
 
-body {
-  line-height: 30px;
-}
-
-.actions {
-  line-height: 30px;
-}
-.actions a {
-  margin-top: 10px;
-  margin-bottom: 10px;
-  margin-right: 5px;
-}
 #layout {
   position: relative;
   z-index: 1;
@@ -22,6 +10,11 @@ body {
 #tokens-dump, #config-dump {
   line-height: 24px;
 }
+
+#form-content {
+  flex-grow: 1
+}
+
 #modal {
   display: none;
   position: fixed;
@@ -55,12 +48,16 @@ body {
 .box {
   border: 1px solid darkgray;
   padding: 10px;
-  max-width: 700px;
   overflow-wrap: break-word;
 }
 
+.actions {
+  max-width: 500px;
+}
+
 input[type=text] {
-  width: 600px;
+  width: 100%;
+  max-width: 600px;
 }
 
 label,
@@ -70,17 +67,21 @@ select {
 }
 
 label {
-  margin-right: 10px;
+  color: #333;
+}
+.pure-menu-link {
+  color: #000;
 }
 a, .link {
   padding: 4px;
   display: inline-block;
   background-color: #eeeeee;
+  color: #000;
   border: 1px #333 solid;
-  height: 40px;
   font-size: 16px;
+  cursor: pointer;
 }
-a:active, a.clicked {
+a:active, a.clicked, .pure-menu-link:hover {
   background-color: green;
   color: white;
 }
@@ -101,4 +102,8 @@ a:active, a.clicked {
 }
 .box.nav .link, .box.nav a {
   margin-right: 10px;
+}
+
+.hidden {
+  display: none;
 }

--- a/test/apps/app/public/protected/index.html
+++ b/test/apps/app/public/protected/index.html
@@ -5,11 +5,11 @@
   <link rel="stylesheet" href="https://unpkg.com/purecss@2.0.6/build/pure-min.css" integrity="sha384-Uu6IeWbM+gzNVXJcM9XV3SohHtmWE+3VGi496jvgX1jyvDTXfdK+rfZc8C1Aehk5" crossorigin="anonymous">
   <link rel="stylesheet" href="/oidc-app.css"/>
 </head>
-<body class="oidc-app callback">
+<body class="oidc-app protected">
   <div id="root"></div>
   <script src="/oidc-app.js"></script>
   <script type="text/javascript">
-    bootstrapCallback();
+    bootstrapProtected();
   </script>
 </body>
 </html>

--- a/test/apps/app/public/server/index.html
+++ b/test/apps/app/public/server/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <link rel="stylesheet" href="/oidc-app.css"/>

--- a/test/apps/app/public/static/index.html
+++ b/test/apps/app/public/static/index.html
@@ -1,5 +1,8 @@
+<!DOCTYPE html>
 <html>
   <head>
+    <link rel="stylesheet" href="https://unpkg.com/purecss@2.0.6/build/pure-min.css" integrity="sha384-Uu6IeWbM+gzNVXJcM9XV3SohHtmWE+3VGi496jvgX1jyvDTXfdK+rfZc8C1Aehk5" crossorigin="anonymous">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="/oidc-app.css"/>
     <!-- for nav functions-->
     <script src="/oidc-app.js"></script>
@@ -11,7 +14,7 @@
     <script src="/okta-auth-js.min.js" type="text/javascript"></script>
   </head>
   <body>
-    <div class="box nav">
+    <div class="pure-menu pure-menu-horizontal">
       <a class="config-link" href="#" onclick="showConfigForm(event)">⚙️</a>
       <a href="/" onclick="navigateToApp('/', event)">Webpack SPA App</a>
       <a href="/server" onclick="navigateToApp('/server', event)">Server-side Web App</a>

--- a/test/apps/app/src/config.ts
+++ b/test/apps/app/src/config.ts
@@ -123,7 +123,11 @@ export function saveConfigToStorage(config: Config): void {
 }
 
 export function getConfigFromStorage(): Config {
-  const config = JSON.parse(localStorage.getItem(STORAGE_KEY));
+  const storedValue = localStorage.getItem(STORAGE_KEY);
+  if (!storedValue) {
+    return getDefaultConfig();
+  }
+  const config = JSON.parse(storedValue);
   return config;
 }
 

--- a/test/apps/app/src/config.ts
+++ b/test/apps/app/src/config.ts
@@ -36,23 +36,23 @@ export function getDefaultConfig(): Config {
   const CLIENT_SECRET = process.env.CLIENT_SECRET || '';
 
   return {
+    issuer: ISSUER,
+    clientId: CLIENT_ID,
+    redirectUri: REDIRECT_URI,
+    useInteractionCodeFlow: false,
+    responseType: ['token', 'id_token'],
+    scopes: ['openid', 'email', 'offline_access'],
+    pkce: true,
     forceRedirect: false,
     siwVersion: DEFAULT_SIW_VERSION,
     siwAuthClient: false,
     idps: '',
-    redirectUri: REDIRECT_URI,
     postLogoutRedirectUri: POST_LOGOUT_REDIRECT_URI,
-    issuer: ISSUER,
-    clientId: CLIENT_ID,
     clientSecret: CLIENT_SECRET,
-    responseType: ['token', 'id_token'],
-    scopes: ['openid', 'email', 'offline_access'],
     defaultScopes: false,
-    pkce: true,
     cookies: {
       secure: true
     },
-    useInteractionCodeFlow: false,
     enableSharedStorage: true
   };
 }
@@ -82,21 +82,22 @@ export function getConfigFromUrl(): Config {
   const enableSharedStorage = url.searchParams.get('enableSharedStorage') !== 'false'; // on by default
 
   return {
-    forceRedirect,
-    siwVersion,
-    siwAuthClient,
-    idps,
-    enableSharedStorage,
-    redirectUri,
-    postLogoutRedirectUri,
     issuer,
     clientId,
-    clientSecret,
+    redirectUri,
+    useInteractionCodeFlow,
     pkce,
     defaultScopes,
     scopes,
     responseType,
     responseMode,
+    postLogoutRedirectUri,
+    forceRedirect,
+    siwVersion,
+    siwAuthClient,
+    idps,
+    enableSharedStorage,
+    clientSecret,
     cookies: {
       secure: secureCookies,
       sameSite
@@ -108,7 +109,6 @@ export function getConfigFromUrl(): Config {
     transactionManager: {
       enableSharedStorage
     },
-    useInteractionCodeFlow
   };
 }
 

--- a/test/apps/app/src/form.ts
+++ b/test/apps/app/src/form.ts
@@ -14,7 +14,7 @@
 /* eslint-disable max-statements */
 /* eslint-disable complexity */
 /* eslint-disable max-len */
-import { flattenConfig, Config } from './config';
+import { flattenConfig, Config, saveConfigToStorage } from './config';
 import { FormDataEvent } from './types';
 import { htmlString, makeClickHandler } from './util';
 
@@ -192,6 +192,7 @@ export function onSubmitForm(event: Event): void {
 
 // Take the data from the form and update query parameters on the current page
 export function onFormData(event: FormDataEvent): void {
+
   const formData = event.formData;
   const params: any = {};
   formData.forEach((value, key) => {

--- a/test/apps/app/src/form.ts
+++ b/test/apps/app/src/form.ts
@@ -14,7 +14,7 @@
 /* eslint-disable max-statements */
 /* eslint-disable complexity */
 /* eslint-disable max-len */
-import { flattenConfig, Config } from './config';
+import { flattenConfig, Config, clearStorage } from './config';
 import { FormDataEvent } from './types';
 import { htmlString, makeClickHandler } from './util';
 
@@ -116,6 +116,7 @@ const Form = `
   </div>
   <div class="pure-controls">
   <input id="f_submit" type="submit" value="Update Config" class="pure-button pure-button-primary"/>
+  <a href="#clear" onclick="resetConfig(event)" class="pure-button">Reset Config</a>
   </div>
   </form>
 `;
@@ -210,6 +211,13 @@ export function hideConfig(): void {
 }
 
 (window as any).hideConfig = makeClickHandler(hideConfig);
+
+export function resetConfig(): void {
+  clearStorage();
+  window.location.reload();
+}
+
+(window as any).resetConfig = makeClickHandler(resetConfig);
 
 export function showConfigForm(config: Config): void {
   let el = document.getElementById('config-area');

--- a/test/apps/app/src/form.ts
+++ b/test/apps/app/src/form.ts
@@ -14,7 +14,7 @@
 /* eslint-disable max-statements */
 /* eslint-disable complexity */
 /* eslint-disable max-len */
-import { flattenConfig, Config, saveConfigToStorage } from './config';
+import { flattenConfig, Config } from './config';
 import { FormDataEvent } from './types';
 import { htmlString, makeClickHandler } from './util';
 

--- a/test/apps/app/src/form.ts
+++ b/test/apps/app/src/form.ts
@@ -16,30 +16,56 @@
 /* eslint-disable max-len */
 import { flattenConfig, Config } from './config';
 import { FormDataEvent } from './types';
-import { htmlString } from './util';
+import { htmlString, makeClickHandler } from './util';
 
 const id = 'config-form';
 const Form = `
-  <form id="${id}" method="GET" onsubmit="onSubmitForm(event)" onformdata="onFormData(event)">
-  <label for="issuer">Issuer</label><input id="f_issuer" name="issuer" type="text" /><br/>
-  <label for="clientId">Client ID</label><input id="f_clientId" name="clientId" type="text" /><br/>
-  <label for="clientSecret">Client Secret</label><input id="f_clientSecret" name="clientSecret" type="text" /><br/>
-  <label for="responseType">Response Type (comma separated)</label><input id="f_responseType" name="responseType" type="text" /><br/>
-  <label for="defaultScopes">Use DEFAULT scopes (defined by authorization server)</label><br/>
-  <input id="f_default-scopes-yes" name="defaultScopes" type="radio" value="true"/>YES<br/>
-  <input id="f_default-scopes-no" name="defaultScopes" type="radio" value="false"/>NO (list scopes below)<br/>
-  <label for="scopes">Scopes (comma separated)</label><input id="f_scopes" name="scopes" type="text" /><br/>
-  <label for="redirectUri">Redirect URI</label><input id="f_redirectUri" name="redirectUri" type="text" /><br/>
-  <label for="postLogoutRedirectUri">Post Logout Redirect URI</label><input id="f_postLogoutRedirectUri" name="postLogoutRedirectUri" type="text" /><br/>
+  <form id="${id}" method="GET" onsubmit="onSubmitForm(event)" onformdata="onFormData(event)" class="pure-form pure-form-aligned">
+  <div class="pure-control-group">
+  <label for="issuer">Issuer</label><input id="f_issuer" name="issuer" type="text" />
+  </div>
+  <div class="pure-control-group">
+  <label for="clientId">Client ID</label><input id="f_clientId" name="clientId" type="text" />
+  </div>
+  <div class="pure-control-group">
+  <label for="redirectUri">Redirect URI</label><input id="f_redirectUri" name="redirectUri" type="text" />
+  </div>
+  <div class="pure-control-group">
+  <label for="useInteractionCodeFlow">Use <strong>interaction_code</strong> grant (in signin widget flow)</label>
+  <input id="f_useInteractionCodeFlow-on" name="useInteractionCodeFlow" type="radio" value="true"/>YES
+  <input id="f_useInteractionCodeFlow-off" name="useInteractionCodeFlow" type="radio" value="false"/>NO
+  </div>
+  <div class="pure-control-group">
+  <label for="clientSecret">Client Secret</label><input id="f_clientSecret" name="clientSecret" type="text" />
+  </div>
+  <div class="pure-control-group">
+  <label for="responseType">Response Type (comma separated)</label><input id="f_responseType" name="responseType" type="text" />
+  </div>
+  <div class="pure-control-group">
+  <label for="defaultScopes">Use DEFAULT scopes (defined by authorization server)</label>
+  <input id="f_default-scopes-yes" name="defaultScopes" type="radio" value="true"/>YES
+  <input id="f_default-scopes-no" name="defaultScopes" type="radio" value="false"/>NO (list scopes below)
+  </div>
+  <div class="pure-control-group">
+  <label for="scopes">Scopes (comma separated)</label><input id="f_scopes" name="scopes" type="text" />
+  </div>
+  <div class="pure-control-group">
+  <label for="postLogoutRedirectUri">Post Logout Redirect URI</label><input id="f_postLogoutRedirectUri" name="postLogoutRedirectUri" type="text" />
+  </div>
+  <div class="pure-control-group">
   <label for="responseMode">Response Mode</label>
   <select id="f_responseMode" name="responseMode">
     <option value="" selected>Auto</option>
     <option value="fragment">Fragment</option>
     <option value="query">Query</option>
-  </select><br/>
-  <label for="pkce">PKCE</label><br/>
-  <input id="f_pkce-on" name="pkce" type="radio" value="true"/>ON<br/>
-  <input id="f_pkce-off" name="pkce" type="radio" value="false"/>OFF<br/>
+  </select>
+  </div>
+  <div class="pure-control-group">
+  <label for="pkce">PKCE</label>
+  <input id="f_pkce-on" name="pkce" type="radio" value="true"/>ON
+  <input id="f_pkce-off" name="pkce" type="radio" value="false"/>OFF
+  </div>
+  <div class="pure-control-group">
   <label for="storage">Storage</label>
   <select id="f_storage" name="storage">
     <option value="" selected>Auto</option>
@@ -47,36 +73,50 @@ const Form = `
     <option value="sessionStorage">Session Storage</option>
     <option value="cookie">Cookie</option>
     <option value="memory">Memory</option>
-  </select><br/>
-  <label for="enableSharedStorage">Enable shared transaction storage (to continue flow in another tab)</label><br/>
-  <input id="f_enableSharedStorage-on" name="enableSharedStorage" type="radio" value="true"/>YES<br/>
-  <input id="f_enableSharedStorage-off" name="enableSharedStorage" type="radio" value="false"/>NO<br/>
-  <label for="expireEarlySeconds">ExpireEarlySeconds</label><input id="f_expireEarlySeconds" name="expireEarlySeconds" type="number" /><br/>
-  <label for="secure">Secure Cookies</label><br/>
-  <input id="f_secureCookies-on" name="secure" type="radio" value="true"/>ON<br/>
-  <input id="f_secureCookies-off" name="secure" type="radio" value="false"/>OFF<br/>
+  </select>
+  </div>
+  <div class="pure-control-group">
+  <label for="enableSharedStorage">Enable shared transaction storage (to continue flow in another tab)</label>
+  <input id="f_enableSharedStorage-on" name="enableSharedStorage" type="radio" value="true"/>YES
+  <input id="f_enableSharedStorage-off" name="enableSharedStorage" type="radio" value="false"/>NO
+  </div>
+  <div class="pure-control-group">
+  <label for="expireEarlySeconds">ExpireEarlySeconds</label><input id="f_expireEarlySeconds" name="expireEarlySeconds" type="number" />
+  </div>
+  <div class="pure-control-group">
+  <label for="secure">Secure Cookies</label>
+  <input id="f_secureCookies-on" name="secure" type="radio" value="true"/>ON
+  <input id="f_secureCookies-off" name="secure" type="radio" value="false"/>OFF
+  </div>
+  <div class="pure-control-group">
   <label for="sameSite">SameSite</label>
   <select id="f_sameSite" name="sameSite">
     <option value="" selected>Auto</option>
     <option value="none">None</option>
     <option value="lax">Lax</option>
     <option value="strict">Strict</option>
-  </select><br/>
-  <label for="siwVersion">Sign-in Widget version (leave blank for bundled version)</label><input id="f_siwVersion" name="siwVersion" type="text" /><br/>
-  <label for="siwAuthClient">Use authClient option? (requires widget version >= 5.3)</label><br/>
-  <input id="f_authClient-on" name="f_siwAuthClient" type="radio" value="true"/>YES (inject current instance)<br/>
-  <input id="f_authClient-off" name="f_siwAuthClient" type="radio" value="false"/>NO (use widget bundled auth-js)<br/>
-
-  <label for="forceRedirect">Force redirect (for SPA applications)?</label><br/>
-  <input id="f_forceRedirect-on" name="forceRedirect" type="radio" value="true"/>YES<br/>
-  <input id="f_forceRedirect-off" name="forceRedirect" type="radio" value="false"/>NO<br/>
-  <label for="useInteractionCodeFlow">Use <strong>interaction_code</strong> grant (in signin widget flow)</label><br/>
-  <input id="f_useInteractionCodeFlow-on" name="useInteractionCodeFlow" type="radio" value="true"/>YES<br/>
-  <input id="f_useInteractionCodeFlow-off" name="useInteractionCodeFlow" type="radio" value="false"/>NO<br/>
+  </select>
+  </div>
+  <div class="pure-control-group">
+  <label for="siwVersion">Sign-in Widget version (leave blank for bundled version)</label><input id="f_siwVersion" name="siwVersion" type="text" />
+  </div>
+  <div class="pure-control-group">
+  <label for="siwAuthClient">Use authClient option? (requires widget version >= 5.3)</label>
+  <input id="f_authClient-on" name="f_siwAuthClient" type="radio" value="true"/>YES (inject current instance)
+  <input id="f_authClient-off" name="f_siwAuthClient" type="radio" value="false"/>NO (use widget bundled auth-js)
+  </div>
+  <div class="pure-control-group">
+  <label for="forceRedirect">Force redirect (for SPA applications)?</label>
+  <input id="f_forceRedirect-on" name="forceRedirect" type="radio" value="true"/>YES
+  <input id="f_forceRedirect-off" name="forceRedirect" type="radio" value="false"/>NO
+  </div>
+  <div class="pure-control-group">
   <label for="idps">IDPs (in format "type:id" space-separated, example: "Facebook:111aaa Google:222bbb")</label>
-  <input id="f_idps" name="idps" type="text" /><br/>
-  <hr/>
-  <input id="f_submit" type="submit" value="Update Config"/>
+  <input id="f_idps" name="idps" type="text" />
+  </div>
+  <div class="pure-controls">
+  <input id="f_submit" type="submit" value="Update Config" class="pure-button pure-button-primary"/>
+  </div>
   </form>
 `;
 
@@ -162,11 +202,18 @@ export function onFormData(event: FormDataEvent): void {
   window.location.replace(newUri);
 }
 
+
+export function hideConfig(): void {
+  const configArea = document.getElementById('config-dump');
+  configArea.style.display = 'none';
+}
+
+(window as any).hideConfig = makeClickHandler(hideConfig);
+
 export function showConfigForm(config: Config): void {
   let el = document.getElementById('config-area');
   if (el) {
     el.remove();
-    return; // act as a toggle
   }
   el = document.createElement('DIV');
   document.body.appendChild(el);
@@ -179,7 +226,9 @@ export function showConfigForm(config: Config): void {
 
   updateForm(config);
   document.getElementById('config-dump').innerHTML = `
-    <h2>Config</h2>
+    <div class="flex-row">
+      <a href="#edit" onclick="hideConfig(event)">Hide Config</a>
+    </div>
     ${ htmlString(config) }
   `;
 }

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -311,6 +311,7 @@ class TestApp {
   }
 
   async loginWidget(): Promise<void> {
+    this.config.state = 'widget-login-' + Math.round(Math.random() * 1000);
     saveConfigToStorage(this.config);
     return this.renderWidget();
   }

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -316,11 +316,14 @@ class TestApp {
     return this.renderWidget();
   }
 
-  async renderWidget(options?: unknown): Promise<void> {
+  async renderWidget(options?: any): Promise<void> {
     const tokens: Tokens = await renderWidget(this.config, this.oktaAuth, options);
 
     // save tokens
     this.oktaAuth.tokenManager.setTokens(tokens);
+
+    // shared storage can be cleared now
+    this.oktaAuth.transactionManager.clear({ clearSharedStorage: true, state: options?.state });
 
     // re-render
     this.render();

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -30,7 +30,7 @@ import {
 } from '@okta/okta-auth-js';
 import { saveConfigToStorage, flattenConfig, Config } from './config';
 import { MOUNT_PATH } from './constants';
-import { htmlString, toQueryString } from './util';
+import { htmlString, toQueryString, makeClickHandler } from './util';
 import { showConfigForm } from './form';
 import { tokensHTML } from './tokens';
 import { renderWidget } from './widget';
@@ -39,22 +39,79 @@ function homeLink(app: TestApp): string {
   return `<a id="return-home" href="${app.originalUrl}">Return Home</a>`;
 }
 
+function loginLinks(app: TestApp, onProtectedPage?: boolean): string {
+  let protectedPageLink = '';
+  if (!onProtectedPage) {
+    protectedPageLink = `
+      <li class="pure-menu-item">
+        <a id="nav-to-protected" href="${app.protectedUrl}" class="pure-menu-link">Navigate to PROTECTED page</a>
+      </li>
+    `;
+  }
+  return `
+    <div class="pure-menu">
+      <ul class="pure-menu-list actions">
+        <li class="pure-menu-item">
+          <a id="login-widget" href="/" onclick="loginWidget(event)" class="pure-menu-link">Login using SIGNIN WIDGET</a>
+        </li>
+        <li class="pure-menu-item">
+          <a id="login-redirect" href="/" onclick="loginRedirect(event)" class="pure-menu-link">Login using REDIRECT</a>
+        </li>
+        <li class="pure-menu-item">
+          <a id="login-popup" href="/" onclick="loginPopup(event)" class="pure-menu-link">Login using POPUP</a>
+        </li>
+        <li class="pure-menu-item">
+        <a id="get-token" href="/" onclick="getToken(event)" class="pure-menu-link">Get Token (without prompt)</a>
+        </li>
+        <li class="pure-menu-item">
+          <a id="test-concurrent-login" href="/" onclick="testConcurrentLogin(event)" class="pure-menu-link">Test Concurrent Login</a>
+        </li>
+        ${protectedPageLink}
+      </ul>
+    </div>
+    <div class="box">
+      <form>
+        <input name="username" id="username" placeholder="username" type="email"/>
+        <input name="password" id="password" placeholder="password" type="password"/>
+        <a href="/" id="login-direct" onclick="loginDirect(event)">Login DIRECT</a>
+      </form>
+    </div>
+  `;
+}
+
 function logoutLink(app: TestApp): string {
   return `
-    <div class="actions signout">
-      <a id="logout-redirect" href="${app.originalUrl}" onclick="logoutRedirect(event)">Logout (and redirect here)</a>
-      <a id="logout-xhr" href="${app.originalUrl}" onclick="logoutXHR(event)">Logout (XHR + reload)</a>
-      <a id="logout-app" href="${app.originalUrl}" onclick="logoutApp(event)">Logout (app only)</a>
+    <div class="actions signout pure-menu">
+      <ul class="pure-menu-list">
+        <li class="pure-menu-item">
+          <a id="logout-redirect" href="${app.originalUrl}" onclick="logoutRedirect(event)" class="pure-menu-link">Logout (and redirect here)</a>
+        </li>
+        <li class="pure-menu-item">
+          <a id="logout-xhr" href="${app.originalUrl}" onclick="logoutXHR(event)" class="pure-menu-link">Logout (XHR + reload)</a>
+        </li>
+        <li class="pure-menu-item">
+          <a id="logout-app" href="${app.originalUrl}" onclick="logoutApp(event)" class="pure-menu-link">Logout (app only)</a>
+        </li>
+      </ul>
     </div>
   `;
 }
 
 const Toolbar = `
-  <div class="actions subscribe">
-    <a id="start-service" onclick="startService(event)">Start service</a>
-    <a id="stop-service" onclick="stopService(event)">Stop service</a>
-    <a id="subscribe-auth-state" onclick="subscribeToAuthState(event)">Subscribe to AuthState</a>
-    <a id="subscribe-token-events" onclick="subscribeToTokenEvents(event)">Subscribe to TokenManager events</a>
+  <div class="actions subscribe pure-menu pure-menu-horizontal">
+    <ul class="pure-menu-list">
+      <li class="pure-menu-item">
+        <a id="start-service" onclick="startService(event)" class="pure-menu-link">Start service</a>
+      </li>
+      <li class="pure-menu-item">
+        <a id="stop-service" onclick="stopService(event)" class="pure-menu-link">Stop service</a>
+      </li>
+      <li class="pure-menu-item">
+        <a id="subscribe-auth-state" onclick="subscribeToAuthState(event)" class="pure-menu-link">Subscribe to AuthState</a>
+      </li>
+      <li class="pure-menu-item">
+        <a id="subscribe-token-events" onclick="subscribeToTokenEvents(event)" class="pure-menu-link">Subscribe to TokenManager events</a>
+      </li>
   </div>
 `;
 
@@ -63,17 +120,10 @@ const Layout = `
     <div id="session-expired" style="color: orange"></div>
     <div id="token-error" style="color: red"></div>
     <div id="token-msg" style="color: green"></div>
-    <div id="page-content"></div>
     ${Toolbar}
+    <div id="page-content"></div>
   </div>
 `;
-
-function makeClickHandler(fn: () => void): Function {
-  return function(event: Event): any {
-    event && event.preventDefault(); // prevent navigation / page reload
-    return fn();
-  };
-}
 
 function bindFunctions(testApp: TestApp, window: Window): void {
   const boundFunctions = {
@@ -109,6 +159,7 @@ function bindFunctions(testApp: TestApp, window: Window): void {
 class TestApp {
   config: Config;
   originalUrl?: string;
+  protectedUrl?: string;
   rootElem?: Element;
   contentElem?: Element;
   oktaAuth?: OktaAuth;
@@ -124,6 +175,7 @@ class TestApp {
   mount(window: Window, rootElem: Element): void {
     const queryParams = toQueryString(flattenConfig(this.config));
     this.originalUrl = MOUNT_PATH + queryParams;
+    this.protectedUrl = MOUNT_PATH + 'protected/' + queryParams;
     this.rootElem = rootElem;
     this.rootElem.innerHTML = Layout;
     this.contentElem = document.getElementById('page-content');
@@ -131,7 +183,7 @@ class TestApp {
     showConfigForm(this.config);
   }
 
-  async getSDKInstance(): Promise<OktaAuth> {
+  getSDKInstance(): OktaAuth {
     // can throw
     this.oktaAuth = this.oktaAuth || new OktaAuth(Object.assign({}, this.config, {
       scopes: this.config.defaultScopes ? [] : this.config.scopes
@@ -183,21 +235,47 @@ class TestApp {
     document.getElementById('token-error').innerText = error as string;
   }
 
-  async bootstrapCallback(): Promise<void> {
+  async bootstrapProtected(): Promise<void> {
+    this.getSDKInstance();
+    const { idToken, accessToken } = this.oktaAuth.tokenManager.getTokensSync();
+    let content;
+    if (idToken || accessToken) {
+      content = `
+        ${homeLink(this)}
+        <hr/>
+        <strong>You are authenticated</strong>
+      `;
+    } else {
+      content = `
+        ${homeLink(this)}
+        <hr/>
+        <strong>You are NOT authenticated. Login using one of these methods:</strong>
+        ${loginLinks(this, true)}
+      `;
+      this.config.state = 'protected-route-' + Math.round(Math.random() * 1000);
+      this.oktaAuth.setOriginalUri(this.protectedUrl, this.config.state);
+    }
+
+    this._setContent(content);
+    this._afterRender('protected');
+  }
+
+  bootstrapCallback(): void {
     const content = `
       <a id="handle-callback" href="/" onclick="handleCallback(event)">Handle callback (Continue Login)</a>
       <hr/>
       ${homeLink(this)}
     `;
-    return this.getSDKInstance(/*{ subscribeAuthStateChange: false }*/)
-      .then(() => this._setContent(content))
-      .then(() => this._afterRender('callback'));
+    this.getSDKInstance(/*{ subscribeAuthStateChange: false }*/);
+    this._setContent(content);
+    this._afterRender('callback');
   }
 
   async bootstrapHome(): Promise<void> {
     // Default home page
-    return this.getSDKInstance()
-      .then(() => this.render());
+    this.getSDKInstance();
+    this.oktaAuth.removeOriginalUri();
+    return this.render();
   }
 
   render(forceUnauth = false): Promise<void> {
@@ -306,10 +384,12 @@ class TestApp {
   }
 
   async loginRedirect(options: TokenParams): Promise<void> {
+    this.config.state = this.config.state || 'login-redirect' + Math.round(Math.random() * 1000);
     saveConfigToStorage(this.config);
     options = Object.assign({}, {
       responseType: this.config.responseType,
       scopes: this.config.defaultScopes ? [] : this.config.scopes,
+      state: this.config.state
     }, options);
     return this.oktaAuth.token.getWithRedirect(options)
       .catch(e => {
@@ -542,20 +622,46 @@ class TestApp {
       // Authenticated user home page
       return `
         <strong>Welcome back</strong>
-        <hr/>
-        ${logoutLink(this)}
-        <hr/>
-        <div class="actions authenticated">
-            <a id="get-userinfo" href="/" onclick="getUserInfo(event)">Get User Info</a>
-            <a id="renew-token" href="/" onclick="renewToken(event)">Renew Token</a>
-            <a id="renew-tokens" href="/" onclick="renewTokens(event)">Renew Tokens</a>
-            <a id="get-token" href="/" onclick="getToken(event)">Get Token (without prompt)</a>
-            <a id="clear-tokens" href="/" onclick="clearTokens(event)">Clear Tokens</a>
-            <a id="revoke-token" href="/" onclick="revokeToken(event)">Revoke Access Token</a>
-            <a id="revoke-refresh-token" href="/" onclick="revokeRefreshToken(event)">Revoke Refresh Token</a>
-            <a id="refresh-session" href="/" onclick="refreshSession(event)">Refresh Session</a>
-            <a id="test-concurrent-get-token" href="/" onclick="testConcurrentGetToken(event)">Test Concurrent getToken</a>
-            <a id="test-concurrent-login-via-token-renew-failure" href="/" onclick="testConcurrentLoginViaTokenRenewFailure(event)">Test Concurrent login via token renew failure</a>
+        <div class="pure-g">
+          <div class="pure-u-1-2">
+            <div class="actions authenticated pure-menu">
+              <ul class="pure-menu-list">
+                <li class="pure-menu-item">
+                  <a id="get-userinfo" href="/" onclick="getUserInfo(event)" class="pure-menu-link">Get User Info</a>
+                </li>
+                <li class="pure-menu-item">
+                  <a id="renew-token" href="/" onclick="renewToken(event)" class="pure-menu-link">Renew Token</a>
+                </li>
+                <li class="pure-menu-item">
+                  <a id="renew-tokens" href="/" onclick="renewTokens(event)" class="pure-menu-link">Renew Tokens</a>
+                </li>
+                <li class="pure-menu-item">
+                  <a id="get-token" href="/" onclick="getToken(event)" class="pure-menu-link">Get Token (without prompt)</a>
+                </li>
+                <li class="pure-menu-item"> 
+                  <a id="clear-tokens" href="/" onclick="clearTokens(event)" class="pure-menu-link">Clear Tokens</a>
+                </li>
+                <li class="pure-menu-item">
+                  <a id="revoke-token" href="/" onclick="revokeToken(event)" class="pure-menu-link">Revoke Access Token</a>
+                </li>
+                <li class="pure-menu-item">
+                  <a id="revoke-refresh-token" href="/" onclick="revokeRefreshToken(event)" class="pure-menu-link">Revoke Refresh Token</a>
+                </li>
+                <li class="pure-menu-item">
+                  <a id="refresh-session" href="/" onclick="refreshSession(event)" class="pure-menu-link">Refresh Session</a>
+                </li>
+                <li class="pure-menu-item">
+                  <a id="test-concurrent-get-token" href="/" onclick="testConcurrentGetToken(event)" class="pure-menu-link">Test Concurrent getToken</a>
+                </li>
+                <li class="pure-menu-item">
+                  <a id="test-concurrent-login-via-token-renew-failure" href="/" onclick="testConcurrentLoginViaTokenRenewFailure(event)" class="pure-menu-link pure-menu-item">Test Concurrent login via token renew failure</a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="pure-u-1-2">
+            ${logoutLink(this)}
+          </div>
         </div>
         <div id="user-info"></div>
         <hr/>
@@ -565,33 +671,10 @@ class TestApp {
 
     // Unauthenticated user, Login page
     return `
-      <strong>Greetings, unknown user!</strong>
-      <hr/>
-      <ul>
-        <li>
-          <a id="login-widget" href="/" onclick="loginWidget(event)">Login using SIGNIN WIDGET</a>
-        </li>
-        <li>
-          <a id="login-redirect" href="/" onclick="loginRedirect(event)">Login using REDIRECT</a>
-        </li>
-        <li>
-          <a id="login-popup" href="/" onclick="loginPopup(event)">Login using POPUP</a>
-        </li>
-        <li>
-         <a id="get-token" href="/" onclick="getToken(event)">Get Token (without prompt)</a>
-        </li>
-        <li>
-          <a id="test-concurrent-login" href="/" onclick="testConcurrentLogin(event)">Test Concurrent Login</a>
-        </li>
-      </ul>
-      <h4/>
       <div class="box">
-        <form>
-          <input name="username" id="username" placeholder="username" type="email"/>
-          <input name="password" id="password" placeholder="password" type="password"/>
-          <a href="/" id="login-direct" onclick="loginDirect(event)">Login DIRECT</a>
-        </form>
+      <strong>Greetings, unknown user!</strong>
       </div>
+      ${loginLinks(this)}
       `;
   }
 
@@ -601,12 +684,14 @@ class TestApp {
     const errorMessage = success ? '' :  'Tokens not returned. Check error console for more details';
     const successMessage = success ?
       'Successfully received tokens on the callback page: ' + tokensReceived.join(', ') : '';
+    const originalUri = this.oktaAuth.getOriginalUri(res.state);
     const content = `
       <div id="callback-result">
         <strong><div id="success">${successMessage}</div></strong>
         <div id="error">${errorMessage}</div>
         <div id="xhr-error"></div>
         <div id="res-state">State: <strong>${res.state}</strong></div>
+        <div id="original-uri">Original Uri: <a href="${originalUri}">${originalUri}</a></div>
       </div>
       <hr/>
       ${homeLink(this)}

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -404,7 +404,7 @@ class TestApp {
       return this.renderInteractionRequired();
     }
 
-    if (isEmailVerifyCallback()) {
+    if (isEmailVerifyCallback(window.location.search)) {
       return this.renderEmailVerifyCallback();
     }
 
@@ -436,7 +436,7 @@ class TestApp {
   }
 
   async renderEmailVerifyCallback(): Promise<void> {
-    const { state, stateTokenExternalId } = parseEmailVerifyCallback();
+    const { state, stateTokenExternalId } = parseEmailVerifyCallback(window.location.search);
     await this.render(true);
     return this.renderWidget({ state, stateTokenExternalId });
   }

--- a/test/apps/app/src/util.js
+++ b/test/apps/app/src/util.js
@@ -35,7 +35,15 @@ function toQueryString(obj) {
   }
 }
 
+function makeClickHandler(fn) {
+  return function(event) {
+    event && event.preventDefault(); // prevent navigation / page reload
+    return fn();
+  };
+}
+
 module.exports = {
   htmlString,
-  toQueryString 
+  toQueryString,
+  makeClickHandler
 };

--- a/test/apps/app/src/widget.ts
+++ b/test/apps/app/src/widget.ts
@@ -156,7 +156,8 @@ export async function renderWidget(config: Config, authClient?: OktaAuth, option
   showModal();
   const widgetConfig = buildWidgetConfig(config, options);
   const { issuer, clientId, clientSecret, redirectUri, forceRedirect, scopes } = config;
-  const state = widgetConfig.state || JSON.stringify({ issuer, clientId, clientSecret, redirectUri });
+  const state = widgetConfig.state ||
+    JSON.stringify({ issuer, clientId, clientSecret, redirectUri, rand: Math.random() });
 
   // This test app allows selecting arbitrary widget versions.
   // We must use `renderEl` for compatibility with older versions.

--- a/test/apps/app/src/widget.ts
+++ b/test/apps/app/src/widget.ts
@@ -39,7 +39,8 @@ declare class OktaSignIn {
 let widgetInstance: OktaSignIn; // static variable. Only one widget instance is allowed to exist at a time
 
 export function buildIdpsConfig(config: Config): any {
-  return config.idps.split(/\s+/).map(idpToken => {
+  const idps = config.idps || '';
+  return idps.split(/\s+/).map(idpToken => {
       const [type, id] = idpToken.split(/:/);
       if (!type || !id) {
         return null;
@@ -156,8 +157,9 @@ export async function renderWidget(config: Config, authClient?: OktaAuth, option
   showModal();
   const widgetConfig = buildWidgetConfig(config, options);
   const { issuer, clientId, clientSecret, redirectUri, forceRedirect, scopes } = config;
-  const state = widgetConfig.state ||
-    JSON.stringify({ issuer, clientId, clientSecret, redirectUri, rand: Math.random() });
+  const state = widgetConfig.state || 
+    // Server-side test app reads config from state. This is bad security but is convenient for quick testing.
+    JSON.stringify({ issuer, clientId, clientSecret, redirectUri, rand: Math.round(Math.random() * 1000) });
 
   // This test app allows selecting arbitrary widget versions.
   // We must use `renderEl` for compatibility with older versions.

--- a/test/apps/app/src/window.ts
+++ b/test/apps/app/src/window.ts
@@ -113,7 +113,6 @@ Object.assign(window, {
   // Callback, read config from storage
   bootstrapCallback: function(): void {
     config = getConfigFromStorage() || getDefaultConfig();
-    clearStorage();
     mount();
     app.bootstrapCallback();
   }

--- a/test/apps/app/src/window.ts
+++ b/test/apps/app/src/window.ts
@@ -18,10 +18,10 @@ import * as Cookies from 'js-cookie';
 import TestApp from './testApp';
 import {
   Config,
-  getDefaultConfig,
   getConfigFromUrl,
   getConfigFromStorage,
-  flattenConfig
+  flattenConfig,
+  saveConfigToStorage
 } from './config';
 import { onSubmitForm, onFormData, showConfigForm } from './form';
 import { toQueryString } from './util';
@@ -54,6 +54,8 @@ window.addEventListener('load', () => {
 });
 
 function mount(): TestApp {
+  saveConfigToStorage(config);
+
   // Create the app as a function of config
   app = new TestApp(config);
 
@@ -71,7 +73,7 @@ Object.assign(window, {
   onFormData: onFormData,
 
   getConfig: function(): Config {
-    return window.location.search ? getConfigFromUrl() : getDefaultConfig();
+    return window.location.search ? getConfigFromUrl() : getConfigFromStorage();
   },
   constructAppUrl: function(basePath = ''): string {
     const config = window.getConfig();
@@ -92,7 +94,7 @@ Object.assign(window, {
   },
   // Login page, read config from URL
   getWidgetConfig: function(): any {
-    const siwConfig = window.location.search ? getConfigFromUrl() : getDefaultConfig();
+    const siwConfig = window.getConfig();
     return buildWidgetConfig(siwConfig);
   },
   renderWidget: function(event?: Event, extraConfig?: Config): any {
@@ -104,20 +106,20 @@ Object.assign(window, {
   },
   // Regular landing, read config from URL
   bootstrapLanding: function(): void {
-    config = window.location.search ? getConfigFromUrl() : getDefaultConfig();
+    config = window.getConfig();
     mount();
     app.bootstrapHome();
   },
 
   // Callback, read config from storage
   bootstrapCallback: function(): void {
-    config = getConfigFromStorage() || getDefaultConfig();
+    config = getConfigFromStorage();
     mount();
     app.bootstrapCallback();
   },
 
   bootstrapProtected: function(): void {
-    config = window.location.search ? getConfigFromUrl() : getDefaultConfig();
+    config = window.getConfig();
     mount();
     app.bootstrapProtected();
   }

--- a/test/apps/app/src/window.ts
+++ b/test/apps/app/src/window.ts
@@ -114,5 +114,11 @@ Object.assign(window, {
     config = getConfigFromStorage() || getDefaultConfig();
     mount();
     app.bootstrapCallback();
+  },
+
+  bootstrapProtected: function(): void {
+    config = window.location.search ? getConfigFromUrl() : getDefaultConfig();
+    mount();
+    app.bootstrapProtected();
   }
 });

--- a/test/apps/app/src/window.ts
+++ b/test/apps/app/src/window.ts
@@ -21,7 +21,6 @@ import {
   getDefaultConfig,
   getConfigFromUrl,
   getConfigFromStorage,
-  clearStorage,
   flattenConfig
 } from './config';
 import { onSubmitForm, onFormData, showConfigForm } from './form';

--- a/test/apps/react-mfa-v1/package.json
+++ b/test/apps/react-mfa-v1/package.json
@@ -14,7 +14,8 @@
     "web-vitals": "^1.0.1"
   },
   "devDependencies": {
-    "react-app-rewired": "^2.1.8"
+    "react-app-rewired": "^2.1.8",
+    "webpack": "^4.46.0"
   },
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true PORT=8080 react-app-rewired start",

--- a/test/apps/react-oie/config-overrides.js
+++ b/test/apps/react-oie/config-overrides.js
@@ -24,6 +24,7 @@ module.exports = {
       }),
     ]);
 
+    config.mode = 'development';
     config.devtool = 'source-map';
     config.module.rules.push({
       test: /\.js$/,

--- a/test/apps/react-oie/package.json
+++ b/test/apps/react-oie/package.json
@@ -14,7 +14,8 @@
     "web-vitals": "^1.0.1"
   },
   "devDependencies": {
-    "react-app-rewired": "^2.1.8"
+    "react-app-rewired": "^2.1.8",
+    "webpack": "^4.46.0"
   },
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true PORT=8080 react-app-rewired start",

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -24,6 +24,8 @@ USERNAME=mytestuser
 PASSWORD=testPassword1
 ```
 
+You may need to set the `CHROMEDRIVER_VERSION` environment variable to match the version of Chrome on your machine. For example, `CHROMEDRIVER_VERSION=94.0.4606.41` can be added to the `testenv` file to work with Chrome version 94. Latest version numbers can be found at [chromedriver.chromium.org](https://chromedriver.chromium.org/downloads)
+
 ## Commands
 
 If running from the workspace directory: `yarn workspace @okta/test.e2e start`

--- a/test/e2e/pageobjects/TestApp.js
+++ b/test/e2e/pageobjects/TestApp.js
@@ -46,6 +46,7 @@ class TestApp {
   get username() { return $('#username'); }
   get password() { return $('#password'); }
   get testConcurrentLoginBtn() { return $('#test-concurrent-login'); }
+  get navigateToProtectedBtn() { return $('#nav-to-protected'); }
 
   // Form
   get responseModeQuery() { return $('#f_responseMode [value="query"]'); }
@@ -58,7 +59,8 @@ class TestApp {
   // Callback
   get callbackSelector() { return $('#root.rendered.loaded.callback'); }
   get callbackHandledSelector() { return $('#root.callback-handled'); }
-
+  get callbackOriginalUri() { return $('#original-uri > a'); }
+  
   // Toolbar
   get subscribeAuthStateBtn() { return $('#subscribe-auth-state'); }
   get subscribeTokenEventsBtn() { return $('#subscribe-token-events'); }
@@ -107,6 +109,11 @@ class TestApp {
   async loginDirect() {
     await this.waitForLoginBtn();
     await this.loginDirectBtn.then(el => el.click());
+  }
+
+  async navigateToProtectedPage() {
+    const btn = await this.navigateToProtectedBtn;
+    await btn.click(); 
   }
 
   // renew the accessToken, using refreshToken if available

--- a/test/e2e/specs/emailVerify.js
+++ b/test/e2e/specs/emailVerify.js
@@ -1,0 +1,42 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+import TestApp from '../pageobjects/TestApp';
+import OktaLogin from '../pageobjects/OktaLogin';
+import { openPKCE } from '../util/appUtils';
+import { handleCallback } from '../util/loginUtils';
+
+const USERNAME = process.env.USERNAME;
+const PASSWORD = process.env.PASSWORD;
+
+describe('email verify', () => {
+
+  it('can handle callback in another tab', async () => {
+    await openPKCE({});
+    await TestApp.loginRedirect();
+    await OktaLogin.signin(USERNAME, PASSWORD);
+    await TestApp.waitForCallback();
+
+    const url = await browser.getUrl();
+
+    browser.newWindow(url, { windowFeatures: 'noopener=yes' });
+
+    // Now handle the callback
+    await handleCallback('pkce');
+
+    // Test app should be signed in on the new tab
+    await TestApp.getUserInfo();
+    await TestApp.assertUserInfo();
+    await TestApp.logoutRedirect();
+  });
+});

--- a/test/e2e/specs/originalUri.js
+++ b/test/e2e/specs/originalUri.js
@@ -1,0 +1,57 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import assert from 'assert';
+import TestApp from '../pageobjects/TestApp';
+import OktaLogin from '../pageobjects/OktaLogin';
+import { openPKCE } from '../util/appUtils';
+
+const USERNAME = process.env.USERNAME;
+const PASSWORD = process.env.PASSWORD;
+
+describe('original uri', () => {
+  it('can restore orginal uri from callback in a single tab', async () => {
+    await openPKCE({});
+    await TestApp.navigateToProtectedPage();
+    await TestApp.loginRedirect();
+    await OktaLogin.signin(USERNAME, PASSWORD);
+    await TestApp.waitForCallback();
+    await TestApp.handleCallback();
+    await TestApp.assertCallbackSuccess();
+    await TestApp.callbackOriginalUri.then(el => el.getAttribute('href')).then(value => {
+      assert(value.indexOf('/protected') >= 0);
+    });
+    await TestApp.returnHome();
+    await TestApp.logoutRedirect();
+  });
+
+  it('can restore orginal uri from callback in another tab', async () => {
+    await openPKCE({});
+    await TestApp.navigateToProtectedPage();
+    await TestApp.loginRedirect();
+    await OktaLogin.signin(USERNAME, PASSWORD);
+    await TestApp.waitForCallback();
+
+    const url = await browser.getUrl();
+    browser.newWindow(url, { windowFeatures: 'noopener=yes' });
+
+    // Handle callback in the new tab
+    await TestApp.handleCallback();
+    await TestApp.assertCallbackSuccess();
+    await TestApp.callbackOriginalUri.then(el => el.getAttribute('href')).then(value => {
+      assert(value.indexOf('/protected') >= 0);
+    });
+    await TestApp.returnHome();
+    await TestApp.logoutRedirect();
+  });
+
+});

--- a/test/e2e/specs/transactionStorage.js
+++ b/test/e2e/specs/transactionStorage.js
@@ -15,6 +15,7 @@ import TestApp from '../pageobjects/TestApp';
 import OktaLogin from '../pageobjects/OktaLogin';
 import { openPKCE } from '../util/appUtils';
 import { handleCallback } from '../util/loginUtils';
+import { switchToMainWindow } from '../util/browserUtils';
 
 const USERNAME = process.env.USERNAME;
 const PASSWORD = process.env.PASSWORD;
@@ -37,6 +38,7 @@ describe('transaction storage', () => {
     await TestApp.getUserInfo();
     await TestApp.assertUserInfo();
     await TestApp.logoutRedirect();
+    await switchToMainWindow();
   });
 
   it('if sharedStorage is disabled, will see PKCE error when handling callback in another tab', async () => {
@@ -56,5 +58,6 @@ describe('transaction storage', () => {
     });
     await TestApp.returnHome();
     await TestApp.assertLoggedOut();
+    await switchToMainWindow();
   });
 });

--- a/test/e2e/wdio.conf.js
+++ b/test/e2e/wdio.conf.js
@@ -28,7 +28,7 @@ if (CI) {
         '--headless',
         '--disable-gpu',
         '--window-size=1600x1200',
-        // '--no-sandbox',
+        '--no-sandbox',
         '--whitelisted-ips',
         '--disable-extensions',
         '--verbose',

--- a/test/e2e/wdio.conf.js
+++ b/test/e2e/wdio.conf.js
@@ -28,7 +28,7 @@ if (CI) {
         '--headless',
         '--disable-gpu',
         '--window-size=1600x1200',
-        '--no-sandbox',
+        // '--no-sandbox',
         '--whitelisted-ips',
         '--disable-extensions',
         '--verbose',

--- a/test/spec/OktaAuth/commonJS.js
+++ b/test/spec/OktaAuth/commonJS.js
@@ -40,7 +40,14 @@ describe('commonJS interface', () => {
         oidc.isInteractionRequired.mockReturnValue(true);
         const res = auth.isInteractionRequired();
         expect(res).toBe(true);
-        expect(oidc.isInteractionRequired).toHaveBeenCalledWith(auth);
+        expect(oidc.isInteractionRequired).toHaveBeenCalledWith(auth, undefined);
+      });
+      it('accepts a hash or search string', () => {
+        oidc.isInteractionRequired.mockReturnValue(true);
+        const str = 'abc=def';
+        const res = auth.isInteractionRequired(str);
+        expect(res).toBe(true);
+        expect(oidc.isInteractionRequired).toHaveBeenCalledWith(auth, str);
       });
     });
     describe('isInteractionRequiredError', () => {

--- a/test/spec/TransactionManager.ts
+++ b/test/spec/TransactionManager.ts
@@ -117,6 +117,41 @@ describe('TransactionManager', () => {
       expect(storageManager.getLegacyPKCEStorage).toHaveBeenNthCalledWith(1, { storageType: 'localStorage' });
       expect(storageManager.getLegacyPKCEStorage).toHaveBeenNthCalledWith(2, { storageType: 'sessionStorage' });
     });
+
+    describe('shared transaction storage', () => {
+      beforeEach(() => {
+        jest.spyOn(mocked.sharedStorage, 'clearTransactionFromSharedStorage');
+      });
+      it('by default, does not clear shared transaction', () => {
+        const { transactionManager } = testContext;
+        transactionManager.clear();
+        expect(mocked.sharedStorage.clearTransactionFromSharedStorage).not.toHaveBeenCalled();
+      });
+      it('`clearSharedStorage` option with `state` in saved transaction meta will clear shared transaction meta', () => {
+        const { transactionManager, transactionStorage, meta, storageManager } = testContext;
+        transactionStorage.getStorage.mockReturnValue(meta);
+        expect(meta.state).toBeTruthy();
+        transactionManager.clear({ clearSharedStorage: true });
+        expect(mocked.sharedStorage.clearTransactionFromSharedStorage).toHaveBeenCalledWith(storageManager, meta.state);
+      });
+      it('`clearSharedStorage` + `state` option will clear shared transaction meta', () => {
+        const { transactionManager, storageManager } = testContext;
+        const state = 'abc';
+        transactionManager.clear({ clearSharedStorage: true, state });
+        expect(mocked.sharedStorage.clearTransactionFromSharedStorage).toHaveBeenCalledWith(storageManager, state);
+      });
+      it('`clearSharedStorage` option without saved transaction meta will not clear shared transaction meta', () => {
+        const { transactionManager } = testContext;
+        transactionManager.clear({ clearSharedStorage: true });
+        expect(mocked.sharedStorage.clearTransactionFromSharedStorage).not.toHaveBeenCalled();
+      });
+      it('can be disabled via TransactionManager `enableSharedStorage` option', () => {
+        createInstance({ enableSharedStorage: false });
+        const { transactionManager } = testContext;
+        transactionManager.clear({ clearSharedStorage: true, state: 'abc' });
+        expect(mocked.sharedStorage.clearTransactionFromSharedStorage).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('save', () => {

--- a/test/spec/idx/authenticate.ts
+++ b/test/spec/idx/authenticate.ts
@@ -213,11 +213,13 @@ describe('idx/authenticate', () => {
 
     it('returns terminal error when invalid password is provided', async () => {
       const { authClient } = testContext;
-      const errorResponse = RawIdxResponseFactory.build({
-        messages: IdxMessagesFactory.build({
-          value: [
-            IdxErrorIncorrectPassword.build()
-          ]
+      const errorResponse = IdxResponseFactory.build({
+        rawIdxState: RawIdxResponseFactory.build({
+          messages: IdxMessagesFactory.build({
+            value: [
+              IdxErrorIncorrectPassword.build()
+            ]
+          })
         })
       });
 
@@ -238,11 +240,13 @@ describe('idx/authenticate', () => {
 
     it('returns terminal error when user account is deactivated or is not assigned to the application', async () => {
       const { authClient } = testContext;
-      const errorResponse = RawIdxResponseFactory.build({
-        messages: IdxMessagesFactory.build({
-          value: [
-            IdxErrorUserNotAssignedFactory.build()
-          ]
+      const errorResponse = IdxResponseFactory.build({
+        rawIdxState: RawIdxResponseFactory.build({
+          messages: IdxMessagesFactory.build({
+            value: [
+              IdxErrorUserNotAssignedFactory.build()
+            ]
+          })
         })
       });
       const identifyResponse = IdentifyResponseFactory.build();
@@ -287,11 +291,13 @@ describe('idx/authenticate', () => {
 
     it('returns terminal error when user account is locked or suspeneded', async () => {
       const { authClient } = testContext;
-      const errorResponse = RawIdxResponseFactory.build({
-        messages: IdxMessagesFactory.build({
-          value: [
-            IdxErrorAuthenticationFailedFactory.build()
-          ]
+      const errorResponse = IdxResponseFactory.build({
+        rawIdxState: RawIdxResponseFactory.build({
+          messages: IdxMessagesFactory.build({
+            value: [
+              IdxErrorAuthenticationFailedFactory.build()
+            ]
+          })
         })
       });
       const identifyResponse = IdentifyResponseFactory.build();
@@ -615,28 +621,35 @@ describe('idx/authenticate', () => {
               EnrollPhoneAuthenticatorRemediationFactory.build()
             ]
           });
-          const errorInvalidCodeResponse = RawIdxResponseFactory.build({
-            remediation: {
-              value: [
-                ChallengeAuthenticatorRemediationFactory.build({
+
+          const challengeAuthenticatorRemediation = ChallengeAuthenticatorRemediationFactory.build({
+            value: [
+              CredentialsValueFactory.build({
+                form: {
                   value: [
-                    CredentialsValueFactory.build({
-                      form: {
+                    PasscodeValueFactory.build({
+                      messages: IdxMessagesFactory.build({
                         value: [
-                          PasscodeValueFactory.build({
-                            messages: IdxMessagesFactory.build({
-                              value: [
-                                IdxErrorPasscodeInvalidFactory.build()
-                              ]
-                            })
-                          })
+                          IdxErrorPasscodeInvalidFactory.build()
                         ]
-                      }
+                      })
                     })
                   ]
-                })
-              ]
-            }
+                }
+              })
+            ]
+          });
+          const errorInvalidCodeResponse = IdxResponseFactory.build({
+            neededToProceed: [
+              challengeAuthenticatorRemediation
+            ],
+            rawIdxState: RawIdxResponseFactory.build({
+              remediation: {
+                value: [
+                  challengeAuthenticatorRemediation
+                ]
+              }
+            })
           });
           Object.assign(testContext, {
             selectAuthenticatorResponse,
@@ -809,26 +822,32 @@ describe('idx/authenticate', () => {
               EnrollPhoneAuthenticatorRemediationFactory.build()
             ]
           });
-          const errorInvalidPhoneResponse = RawIdxResponseFactory.build({
-            messages: IdxMessagesFactory.build({
-              value: [
-                IdxErrorEnrollmentInvalidPhoneFactory.build()
-              ]
-            }),
-            remediation: {
-              type: 'array',
-              value: [
-                SelectAuthenticatorEnrollRemediationFactory.build({
-                  value: [
-                    AuthenticatorValueFactory.build({
-                      options: [
-                        PhoneAuthenticatorOptionFactory.build(),
-                      ]
-                    })
-                  ]
-                })
-              ]
-            }
+          const selectAuthenticatorRemediation = SelectAuthenticatorEnrollRemediationFactory.build({
+            value: [
+              AuthenticatorValueFactory.build({
+                options: [
+                  PhoneAuthenticatorOptionFactory.build(),
+                ]
+              })
+            ]
+          });
+          const errorInvalidPhoneResponse = IdxResponseFactory.build({
+            neededToProceed: [
+              selectAuthenticatorRemediation,
+            ],
+            rawIdxState: RawIdxResponseFactory.build({
+              messages: IdxMessagesFactory.build({
+                value: [
+                  IdxErrorEnrollmentInvalidPhoneFactory.build()
+                ]
+              }),
+              remediation: {
+                type: 'array',
+                value: [
+                  selectAuthenticatorRemediation
+                ]
+              }
+            })
           });
 
           Object.assign(testContext, {
@@ -1069,29 +1088,36 @@ describe('idx/authenticate', () => {
               VerifyEmailRemediationFactory.build()
             ]
           });
-          const errorInvalidCodeResponse = RawIdxResponseFactory.build({
-            remediation: {
-              value: [
-                ChallengeAuthenticatorRemediationFactory.build({
+          const challengeAuthenticatorRemediation = ChallengeAuthenticatorRemediationFactory.build({
+            value: [
+              CredentialsValueFactory.build({
+                form: {
                   value: [
-                    CredentialsValueFactory.build({
-                      form: {
+                    PasscodeValueFactory.build({
+                      messages: IdxMessagesFactory.build({
                         value: [
-                          PasscodeValueFactory.build({
-                            messages: IdxMessagesFactory.build({
-                              value: [
-                                IdxErrorPasscodeInvalidFactory.build()
-                              ]
-                            })
-                          })
+                          IdxErrorPasscodeInvalidFactory.build()
                         ]
-                      }
+                      })
                     })
                   ]
-                })
-              ]
-            }
+                }
+              })
+            ]
           });
+          const errorInvalidCodeResponse = IdxResponseFactory.build({
+            neededToProceed: [
+              challengeAuthenticatorRemediation
+            ],
+            rawIdxState: RawIdxResponseFactory.build({
+              remediation: {
+                value: [
+                  challengeAuthenticatorRemediation
+                ]
+              }
+            })
+          });
+    
           Object.assign(testContext, {
             selectAuthenticatorResponse,
             verifyEmailResponse,
@@ -1184,26 +1210,25 @@ describe('idx/authenticate', () => {
     describe('google authenticator', () => {
       let errorInvalidCodeResponse;
       beforeEach(() => {
-        errorInvalidCodeResponse = RawIdxResponseFactory.build({
-          messages: IdxMessagesFactory.build({
-            value: [
-              IdxErrorGoogleAuthenticatorPasscodeInvalidFactory.build()
-            ]
+        errorInvalidCodeResponse = IdxResponseFactory.build({
+          rawIdxState: RawIdxResponseFactory.build({
+            messages: IdxMessagesFactory.build({
+              value: [
+                IdxErrorGoogleAuthenticatorPasscodeInvalidFactory.build()
+              ]
+            })
           }),
-          remediation: {
-            type: 'array',
-            value: [
-              SelectAuthenticatorEnrollRemediationFactory.build({
-                value: [
-                  AuthenticatorValueFactory.build({
-                    options: [
-                      PhoneAuthenticatorOptionFactory.build(),
-                    ]
-                  })
-                ]
-              })
-            ]
-          }
+          neededToProceed:[
+            SelectAuthenticatorEnrollRemediationFactory.build({
+              value: [
+                AuthenticatorValueFactory.build({
+                  options: [
+                    PhoneAuthenticatorOptionFactory.build(),
+                  ]
+                })
+              ]
+            })
+          ]
         });
       });
 

--- a/test/spec/idx/authenticate.ts
+++ b/test/spec/idx/authenticate.ts
@@ -125,6 +125,7 @@ describe('idx/authenticate', () => {
     jest.spyOn(mocked.introspect, 'introspect').mockResolvedValue(identifyResponse);
     const res = await authenticate(authClient, {});
     expect(res).toEqual({
+      _idxResponse: expect.any(Object),
       status: IdxStatus.PENDING,
       nextStep: {
         name: 'identify',
@@ -359,6 +360,7 @@ describe('idx/authenticate', () => {
         jest.spyOn(mocked.introspect, 'introspect').mockResolvedValue(identifyResponse);
         const res = await authenticate(authClient, { username: 'fakeuser', password: 'fakepass' });
         expect(res).toEqual({
+          _idxResponse: expect.any(Object),
           status: IdxStatus.SUCCESS,
           tokens: tokenResponse.tokens,
         });
@@ -469,6 +471,7 @@ describe('idx/authenticate', () => {
         res = await authenticate(authClient, { password: 'mypass' });
         expect(verifyPasswordResponse.proceed).toHaveBeenCalledWith('challenge-authenticator', { credentials: { passcode: 'mypass' } });
         expect(res).toEqual({
+          _idxResponse: expect.any(Object),
           'status': IdxStatus.SUCCESS,
           'tokens': tokenResponse.tokens,
         });
@@ -505,6 +508,7 @@ describe('idx/authenticate', () => {
         const { authClient, identifyResponse, tokenResponse, interactionCode } = testContext;
         const res = await authenticate(authClient, { username: 'fakeuser', password: 'fakepass' });
         expect(res).toEqual({
+          _idxResponse: expect.any(Object),
           status: IdxStatus.SUCCESS,
           tokens: tokenResponse.tokens,
         });
@@ -554,6 +558,7 @@ describe('idx/authenticate', () => {
           }
         });
         expect(res).toEqual({
+          _idxResponse: expect.any(Object),
           'status': IdxStatus.SUCCESS,
           'tokens': tokenResponse.tokens,
         });
@@ -658,6 +663,7 @@ describe('idx/authenticate', () => {
           });
           expect(selectAuthenticatorResponse.proceed).toHaveBeenCalledWith('select-authenticator-authenticate', { authenticator: { id: 'id-phone' } });
           expect(res).toEqual({
+            _idxResponse: expect.any(Object),
             status: IdxStatus.PENDING,
             nextStep: {
               name: 'authenticator-verification-data',
@@ -705,6 +711,7 @@ describe('idx/authenticate', () => {
             }
           });
           expect(res).toEqual({
+            _idxResponse: expect.any(Object),
             status: IdxStatus.SUCCESS,
             tokens: {
               fakeToken: true
@@ -743,6 +750,7 @@ describe('idx/authenticate', () => {
             }
           });
           expect(res).toEqual({
+            _idxResponse: expect.any(Object),
             status: IdxStatus.PENDING,
             messages: [{
               class: 'ERROR',
@@ -868,6 +876,7 @@ describe('idx/authenticate', () => {
             }
           });
           expect(res).toEqual({
+            _idxResponse: expect.any(Object),
             status: IdxStatus.PENDING,
             nextStep: {
               name: 'enroll-authenticator',
@@ -916,6 +925,7 @@ describe('idx/authenticate', () => {
               authenticator: { id: 'id-phone' }
             });
           expect(res).toEqual({
+            _idxResponse: expect.any(Object),
             status: IdxStatus.PENDING,
             nextStep: {
               name: 'authenticator-enrollment-data',
@@ -999,6 +1009,7 @@ describe('idx/authenticate', () => {
             }
           });
           expect(res).toEqual({
+            _idxResponse: expect.any(Object),
             status: IdxStatus.PENDING,
             messages: [{
               class: 'ERROR',
@@ -1107,6 +1118,7 @@ describe('idx/authenticate', () => {
             }
           });
           expect(res).toEqual({
+            _idxResponse: expect.any(Object),
             status: IdxStatus.SUCCESS,
             tokens: {
               fakeToken: true
@@ -1132,6 +1144,7 @@ describe('idx/authenticate', () => {
             }
           });
           expect(res).toEqual({
+            _idxResponse: expect.any(Object),
             status: IdxStatus.PENDING,
             messages: [{
               class: 'ERROR',
@@ -1240,6 +1253,7 @@ describe('idx/authenticate', () => {
             authenticator: { id: 'id-google-authenticator' } 
           });
           expect(res).toEqual({
+            _idxResponse: expect.any(Object),
             status: IdxStatus.PENDING,
             nextStep: {
               name: 'challenge-authenticator',
@@ -1293,6 +1307,7 @@ describe('idx/authenticate', () => {
             }
           });
           expect(res).toEqual({
+            _idxResponse: expect.any(Object),
             status: IdxStatus.SUCCESS,
             tokens: {
               fakeToken: true
@@ -1318,6 +1333,7 @@ describe('idx/authenticate', () => {
             }
           });
           expect(res).toEqual({
+            _idxResponse: expect.any(Object),
             status: IdxStatus.PENDING,
             messages: [{
               class: 'ERROR',
@@ -1409,6 +1425,7 @@ describe('idx/authenticate', () => {
             }
           });
           expect(res).toEqual({
+            _idxResponse: expect.any(Object),
             status: IdxStatus.PENDING,
             nextStep: {
               name: 'enroll-authenticator',
@@ -1459,6 +1476,7 @@ describe('idx/authenticate', () => {
             }
           });
           expect(res).toEqual({
+            _idxResponse: expect.any(Object),
             status: IdxStatus.PENDING,
             messages: [{
               class: 'ERROR',

--- a/test/spec/idx/headers.ts
+++ b/test/spec/idx/headers.ts
@@ -81,7 +81,7 @@ describe('idx headers', () => {
         }),
         credentials: 'include',
         headers: {
-          'X-Okta-User-Agent-Extended': 'okta-idx-js/0.19.0',
+          'X-Okta-User-Agent-Extended': 'okta-idx-js/0.22.0',
           'accept': 'application/ion+json; okta-version=fake-version',
           'content-type': 'application/ion+json; okta-version=fake-version',
         },
@@ -101,7 +101,7 @@ describe('idx headers', () => {
         }),
         credentials: 'include',
         headers: {
-          'X-Okta-User-Agent-Extended': 'okta-idx-js/0.19.0',
+          'X-Okta-User-Agent-Extended': 'okta-idx-js/0.22.0',
           'accept': 'application/ion+json; okta-version=fake-version',
           'content-type': 'application/ion+json; okta-version=fake-version',
         },

--- a/test/spec/idx/recoverPassword.ts
+++ b/test/spec/idx/recoverPassword.ts
@@ -189,13 +189,16 @@ describe('idx/recoverPassword', () => {
       identifyRecoveryResponse,
     } = testContext;
     
-    const idxError = RawIdxResponseFactory.build({
-      messages: IdxMessagesFactory.build({
-        value: [
-          IdxErrorResetPasswordNotAllowedFactory.build()
-        ]
+    const idxError = IdxResponseFactory.build({
+      rawIdxState: RawIdxResponseFactory.build({
+        messages: IdxMessagesFactory.build({
+          value: [
+            IdxErrorResetPasswordNotAllowedFactory.build()
+          ]
+        })
       })
     });
+
     jest.spyOn(identifyRecoveryResponse, 'proceed').mockRejectedValue(idxError);
     jest.spyOn(mocked.introspect, 'introspect')
       .mockResolvedValueOnce(identifyResponse);

--- a/test/spec/idx/recoverPassword.ts
+++ b/test/spec/idx/recoverPassword.ts
@@ -160,6 +160,7 @@ describe('idx/recoverPassword', () => {
     jest.spyOn(mocked.introspect, 'introspect').mockResolvedValue(identifyResponse);
     const res = await recoverPassword(authClient, {});
     expect(res).toEqual({
+      _idxResponse: expect.any(Object),
       status: IdxStatus.PENDING,
       nextStep: {
         name: 'identify-recovery',
@@ -201,6 +202,7 @@ describe('idx/recoverPassword', () => {
 
     const res = await recoverPassword(authClient, { username: 'myname' });
     expect(res).toEqual({
+      _idxResponse: expect.any(Object),
       status: IdxStatus.TERMINAL,
       messages: [{
         class: 'ERROR',
@@ -241,6 +243,7 @@ describe('idx/recoverPassword', () => {
 
     const res = await recoverPassword(authClient, { username });
     expect(res).toEqual({
+      _idxResponse: expect.any(Object),
       status: IdxStatus.PENDING,
       nextStep: {
         name: 'identify-recovery',
@@ -278,6 +281,7 @@ describe('idx/recoverPassword', () => {
 
     const res = await recoverPassword(authClient, { username: 'myname' });
     expect(res).toEqual({
+      _idxResponse: expect.any(Object),
       status: IdxStatus.PENDING,
       nextStep: {
         name: 'reenroll-authenticator',
@@ -351,6 +355,7 @@ describe('idx/recoverPassword', () => {
         }
       });
     expect(res).toEqual({
+      _idxResponse: expect.any(Object),
       status: IdxStatus.PENDING,
       nextStep: {
         name: 'authenticator-verification-data',
@@ -412,6 +417,7 @@ describe('idx/recoverPassword', () => {
     // First call, get recovery form
     let res = await recoverPassword(authClient, {});
     expect(res).toEqual({
+      _idxResponse: expect.any(Object),
       status: IdxStatus.PENDING,
       nextStep: {
         name: 'identify-recovery',
@@ -427,6 +433,7 @@ describe('idx/recoverPassword', () => {
     res = await recoverPassword(authClient, { username: 'myname' });
     expect(identifyRecoveryResponse.proceed).toHaveBeenCalledWith('identify-recovery', { identifier: 'myname' });
     expect(res).toEqual({
+      _idxResponse: expect.any(Object),
       status: IdxStatus.PENDING,
       nextStep: {
         name: 'reenroll-authenticator',
@@ -476,6 +483,7 @@ describe('idx/recoverPassword', () => {
       }
     });
     expect(res).toEqual({
+      _idxResponse: expect.any(Object),
       status: IdxStatus.PENDING,
       nextStep: {
         name: 'authenticator-verification-data',

--- a/test/spec/idx/register.ts
+++ b/test/spec/idx/register.ts
@@ -286,6 +286,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'select-authenticator-enroll',
@@ -322,6 +323,7 @@ describe('idx/register', () => {
       let res = await register(authClient, {});
       expect(identifyResponse.proceed).toHaveBeenCalledWith('select-enroll-profile', { });
       expect(res).toMatchObject({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'enroll-profile',
@@ -345,6 +347,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'select-authenticator-enroll',
@@ -396,6 +399,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'select-authenticator-enroll',
@@ -438,6 +442,7 @@ describe('idx/register', () => {
       const password = 'my-password';
       let res = await register(authClient, {});
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'select-authenticator-enroll',
@@ -463,6 +468,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'select-authenticator-enroll',
@@ -512,6 +518,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'enroll-authenticator',
@@ -554,6 +561,7 @@ describe('idx/register', () => {
 
       let res = await register(authClient, {});
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'select-authenticator-enroll',
@@ -585,6 +593,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'enroll-authenticator',
@@ -627,6 +636,7 @@ describe('idx/register', () => {
 
       let res = await register(authClient, {});
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'enroll-authenticator',
@@ -660,6 +670,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           canSkip: true,
@@ -732,6 +743,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         messages: [{
           class: 'ERROR',
@@ -823,6 +835,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'enroll-authenticator',
@@ -853,6 +866,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.SUCCESS,
         tokens: tokenResponse.tokens,
       });
@@ -904,6 +918,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'authenticator-enrollment-data',
@@ -942,6 +957,7 @@ describe('idx/register', () => {
           }
         });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'enroll-authenticator',
@@ -973,6 +989,7 @@ describe('idx/register', () => {
           }
         });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.SUCCESS,
         tokens: tokenResponse.tokens,
       });
@@ -1011,6 +1028,7 @@ describe('idx/register', () => {
 
       let res = await register(authClient, {});
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'enroll-authenticator',
@@ -1041,6 +1059,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         'status': IdxStatus.SUCCESS,
         'tokens': tokenResponse.tokens,
       });
@@ -1103,6 +1122,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         messages: [{
           class: 'ERROR',
@@ -1164,6 +1184,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'enroll-authenticator',
@@ -1212,6 +1233,7 @@ describe('idx/register', () => {
 
       let res = await register(authClient, {});
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'select-authenticator-enroll',
@@ -1242,6 +1264,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'enroll-authenticator',
@@ -1290,6 +1313,7 @@ describe('idx/register', () => {
 
       let res = await register(authClient, {});
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           name: 'enroll-authenticator',
@@ -1329,6 +1353,7 @@ describe('idx/register', () => {
         }
       });
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.PENDING,
         nextStep: {
           canSkip: true,
@@ -1369,6 +1394,7 @@ describe('idx/register', () => {
 
       let res = await register(authClient, {});
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         nextStep: {
           inputs: [
             {
@@ -1390,6 +1416,7 @@ describe('idx/register', () => {
       res = await register(authClient, { skip: true });
       expect(selectPhoneResponse.proceed).toHaveBeenCalledWith('skip', {});
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         status: IdxStatus.SUCCESS,
         tokens: tokenResponse.tokens,
       });

--- a/test/spec/idx/register.ts
+++ b/test/spec/idx/register.ts
@@ -1081,26 +1081,25 @@ describe('idx/register', () => {
         phoneEnrollmentDataResponse,
       } = testContext;
 
-      const errorResponse = RawIdxResponseFactory.build({
-        messages: IdxMessagesFactory.build({
-          value: [
-            IdxErrorEnrollmentInvalidPhoneFactory.build()
-          ]
+      const errorResponse = IdxResponseFactory.build({
+        rawIdxState: RawIdxResponseFactory.build({
+          messages: IdxMessagesFactory.build({
+            value: [
+              IdxErrorEnrollmentInvalidPhoneFactory.build()
+            ]
+          })
         }),
-        remediation: {
-          type: 'array',
-          value: [
-            SelectAuthenticatorAuthenticateRemediationFactory.build({
-              value: [
-                AuthenticatorValueFactory.build({
-                  options: [
-                    PhoneAuthenticatorOptionFactory.build(),
-                  ]
-                })
-              ]
-            })
-          ]
-        }
+        neededToProceed: [
+          SelectAuthenticatorAuthenticateRemediationFactory.build({
+            value: [
+              AuthenticatorValueFactory.build({
+                options: [
+                  PhoneAuthenticatorOptionFactory.build(),
+                ]
+              })
+            ]
+          })
+        ]
       });
 
       jest.spyOn(phoneEnrollmentDataResponse, 'proceed').mockRejectedValue(errorResponse);

--- a/test/spec/idx/run.ts
+++ b/test/spec/idx/run.ts
@@ -89,6 +89,7 @@ describe('idx/run', () => {
     const { authClient, options } = testContext;
     const res = await run(authClient, options);
     expect(res).toEqual({
+      _idxResponse: expect.any(Object),
       status: IdxStatus.PENDING,
       nextStep: 'remediate-nextStep',
     });
@@ -107,6 +108,17 @@ describe('idx/run', () => {
       interactionHandle: 'meta-interactionHandle'
     });
   });
+
+  it('calls introspect with stateTokenExternalId', async () => {
+    const { authClient, options } = testContext;
+    options.stateTokenExternalId = 'abc';
+    await run(authClient, options);
+    expect(mocked.introspect.introspect).toHaveBeenCalledWith(authClient, { 
+      interactionHandle: 'meta-interactionHandle',
+      stateTokenExternalId: 'abc'
+    });
+  });
+
 
   it('calls remediate, passing options and values through', async () => {
     const { authClient, options, idxResponse } = testContext;
@@ -131,6 +143,7 @@ describe('idx/run', () => {
     const { authClient, options } = testContext;
     const res = await run(authClient, options);
     expect(res).toEqual({
+      _idxResponse: expect.any(Object),
       messages: ['remediate-message-1'],
       nextStep: 'remediate-nextStep',
       status: IdxStatus.PENDING,
@@ -148,6 +161,7 @@ describe('idx/run', () => {
       const res = await run(authClient, options);
       expect(authClient.transactionManager.clear).not.toHaveBeenCalledWith();
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         nextStep: 'remediate-nextStep',
         status: IdxStatus.PENDING,
       });
@@ -165,6 +179,7 @@ describe('idx/run', () => {
       const res = await run(authClient, options);
       expect(authClient.transactionManager.clear).toHaveBeenCalledWith();
       expect(res).toEqual({
+        _idxResponse: expect.any(Object),
         nextStep: 'remediate-nextStep',
         status: IdxStatus.TERMINAL,
       });
@@ -200,9 +215,10 @@ describe('idx/run', () => {
       });
 
       expect(res).toEqual({
-       nextStep: 'remediate-nextStep',
-       status: IdxStatus.SUCCESS,
-       tokens: tokenResponse.tokens,
+        _idxResponse: expect.any(Object),
+        nextStep: 'remediate-nextStep',
+        status: IdxStatus.SUCCESS,
+        tokens: tokenResponse.tokens,
       });
     });
 
@@ -251,9 +267,10 @@ describe('idx/run', () => {
       });
 
       expect(res).toEqual({
-       error,
-       nextStep: 'remediate-nextStep',
-       status: IdxStatus.FAILURE,
+        _idxResponse: expect.any(Object),
+        error,
+        nextStep: 'remediate-nextStep',
+        status: IdxStatus.FAILURE,
       });
     });
   });

--- a/test/spec/oidc/getWithRedirect.ts
+++ b/test/spec/oidc/getWithRedirect.ts
@@ -117,17 +117,6 @@ describe('getWithRedirect', () => {
         urls
       }, { oauth: true });
     });
-
-    it('retrieves and saves the originalUri', async () => {
-      const { sdk, urls } = testContext;
-      const originalUri = '/original';
-      jest.spyOn(sdk, 'getOriginalUri').mockReturnValue(originalUri);
-      await getWithRedirect(sdk, {});
-      expect(sdk.transactionManager.save).toHaveBeenCalledWith({
-        originalUri,
-        urls
-      }, { oauth: true });
-    });
   });
 
 

--- a/test/spec/util/emailVerify.ts
+++ b/test/spec/util/emailVerify.ts
@@ -1,0 +1,64 @@
+import { isEmailVerifyCallback, parseEmailVerifyCallback, EmailVerifyCallbackResponse } from '../../../lib/util/emailVerify';
+
+
+
+describe('emailVerify', () => {
+  let originalLocation;
+  
+  beforeEach(() => {
+    // Window will be undefined on a node platform
+    if (typeof global.window === 'undefined') {
+      Object.assign(global, {
+        window: {
+          location: {}
+        }
+      });
+    }
+    originalLocation = global.window.location;
+  });
+
+  afterEach(() => {
+    global.window.location = originalLocation;
+  });
+
+  function mockWindowSearch(search) {
+    delete global.window.location;
+    global.window.location = {
+      search
+    } as Location;
+  }
+
+  describe('isEmailVerifyCallback', () => {
+    it('by default, it returns false', () => {
+      expect(isEmailVerifyCallback()).toBe(false);
+    });
+
+    it('it tests against window.location.search', () => {
+      mockWindowSearch('state=a&stateTokenExternalId=b');
+      expect(isEmailVerifyCallback()).toBe(true);
+    });
+    it('it tests against a urlPath passed as a parameter', () => {
+      expect(isEmailVerifyCallback('state=a&stateTokenExternalId=b')).toBe(true);
+    });
+  });
+
+  describe('parseEmailVerifyCallback', () => {
+    it('returns an empty object by default', () => {
+      const res: EmailVerifyCallbackResponse = parseEmailVerifyCallback();
+      expect(res).toEqual({});
+    });
+    it('returns state and stateTokenExternalId from the URL', () => {
+      mockWindowSearch('state=a&stateTokenExternalId=b');
+      expect(parseEmailVerifyCallback()).toEqual({
+        state: 'a',
+        stateTokenExternalId: 'b'
+      });
+    });
+    it('returns state and stateTokenExternalId from a url path passed as a parameter', () => {
+      expect(parseEmailVerifyCallback('state=a&stateTokenExternalId=b')).toEqual({
+        state: 'a',
+        stateTokenExternalId: 'b'
+      });
+    });
+  });
+});

--- a/test/spec/util/emailVerify.ts
+++ b/test/spec/util/emailVerify.ts
@@ -3,56 +3,26 @@ import { isEmailVerifyCallback, parseEmailVerifyCallback, EmailVerifyCallbackRes
 
 
 describe('emailVerify', () => {
-  let originalLocation;
-  
-  beforeEach(() => {
-    // Window will be undefined on a node platform
-    if (typeof global.window === 'undefined') {
-      Object.assign(global, {
-        window: {
-          location: {}
-        }
-      });
-    }
-    originalLocation = global.window.location;
-  });
-
-  afterEach(() => {
-    global.window.location = originalLocation;
-  });
-
-  function mockWindowSearch(search) {
-    delete global.window.location;
-    global.window.location = {
-      search
-    } as Location;
-  }
 
   describe('isEmailVerifyCallback', () => {
     it('by default, it returns false', () => {
-      expect(isEmailVerifyCallback()).toBe(false);
+      expect(isEmailVerifyCallback('foo=bar')).toBe(false);
     });
-
-    it('it tests against window.location.search', () => {
-      mockWindowSearch('state=a&stateTokenExternalId=b');
-      expect(isEmailVerifyCallback()).toBe(true);
+    it('returns false if only state exist', () => {
+      expect(isEmailVerifyCallback('state=a&foo=bar')).toBe(true);
     });
-    it('it tests against a urlPath passed as a parameter', () => {
+    it('returns false if only stateTokenExternalId exist', () => {
+      expect(isEmailVerifyCallback('stateTokenExternalId=a&foo=bar')).toBe(true);
+    });
+    it('returns true if both state and stateTokenExternalId exist', () => {
       expect(isEmailVerifyCallback('state=a&stateTokenExternalId=b')).toBe(true);
     });
   });
 
   describe('parseEmailVerifyCallback', () => {
     it('returns an empty object by default', () => {
-      const res: EmailVerifyCallbackResponse = parseEmailVerifyCallback();
+      const res: EmailVerifyCallbackResponse = parseEmailVerifyCallback('');
       expect(res).toEqual({});
-    });
-    it('returns state and stateTokenExternalId from the URL', () => {
-      mockWindowSearch('state=a&stateTokenExternalId=b');
-      expect(parseEmailVerifyCallback()).toEqual({
-        state: 'a',
-        stateTokenExternalId: 'b'
-      });
     });
     it('returns state and stateTokenExternalId from a url path passed as a parameter', () => {
       expect(parseEmailVerifyCallback('state=a&stateTokenExternalId=b')).toEqual({

--- a/test/spec/util/emailVerify.ts
+++ b/test/spec/util/emailVerify.ts
@@ -9,10 +9,10 @@ describe('emailVerify', () => {
       expect(isEmailVerifyCallback('foo=bar')).toBe(false);
     });
     it('returns false if only state exist', () => {
-      expect(isEmailVerifyCallback('state=a&foo=bar')).toBe(true);
+      expect(isEmailVerifyCallback('state=a&foo=bar')).toBe(false);
     });
     it('returns false if only stateTokenExternalId exist', () => {
-      expect(isEmailVerifyCallback('stateTokenExternalId=a&foo=bar')).toBe(true);
+      expect(isEmailVerifyCallback('stateTokenExternalId=a&foo=bar')).toBe(false);
     });
     it('returns true if both state and stateTokenExternalId exist', () => {
       expect(isEmailVerifyCallback('state=a&stateTokenExternalId=b')).toBe(true);

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -43,7 +43,8 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.ts'],
     alias: {
-      './node$': './browser' // use browser built-in objects and functions
+      './node$': './browser', // use browser built-in objects and functions
+      'node-cache': false // do not webpack node-only modules
     }
   },
   plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2831,10 +2831,26 @@
   resolved "https://registry.yarnpkg.com/@types/elasticlunr/-/elasticlunr-0.9.1.tgz#75bd34567447235c26422c6d00de9151ba12ca3e"
   integrity sha512-FOS+tbeQKVIq8HAQ5WkWXMPIEeLFJViIMnWfLsxtRKX0jtWSM+emZe43+sKZgwny7EIfVdbbqdtr+RL2h18ykw==
 
+"@types/eslint-scope@^3.7.0":
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.1.tgz#8dc390a7b4f9dd9f1284629efce982e41612116e"
+  integrity sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==
+  dependencies:
+    "@types/eslint" "*"
+    "@types/estree" "*"
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/eslint@*":
+  version "7.28.2"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.28.2.tgz#0ff2947cdd305897c52d5372294e8c76f351db68"
+  integrity sha512-KubbADPkfoU75KgKeKLsFHXnU4ipH7wYg0TRT33NK3N3yiu7jlFAAoygIWBV+KbuHx/G+AvuGX6DllnK35gfJA==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
 
 "@types/eslint@^7.2.13":
   version "7.2.13"
@@ -2861,6 +2877,11 @@
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/estree@^0.0.50":
+  version "0.0.50"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
+  integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
 
 "@types/fs-extra@^9.0.1", "@types/fs-extra@^9.0.4":
   version "9.0.11"
@@ -3762,6 +3783,14 @@
     "@wdio/logger" "7.7.0"
     "@wdio/types" "7.7.3"
 
+"@webassemblyjs/ast@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
+  integrity sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==
+  dependencies:
+    "@webassemblyjs/helper-numbers" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -3771,15 +3800,30 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
 
+"@webassemblyjs/floating-point-hex-parser@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz#f6c61a705f0fd7a6aecaa4e8198f23d9dc179e4f"
+  integrity sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==
+
 "@webassemblyjs/floating-point-hex-parser@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz#3c3d3b271bddfc84deb00f71344438311d52ffb4"
   integrity sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==
 
+"@webassemblyjs/helper-api-error@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz#1a63192d8788e5c012800ba6a7a46c705288fd16"
+  integrity sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==
+
 "@webassemblyjs/helper-api-error@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz#203f676e333b96c9da2eeab3ccef33c45928b6a2"
   integrity sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==
+
+"@webassemblyjs/helper-buffer@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz#832a900eb444884cde9a7cad467f81500f5e5ab5"
+  integrity sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==
 
 "@webassemblyjs/helper-buffer@1.9.0":
   version "1.9.0"
@@ -3805,10 +3849,34 @@
   dependencies:
     "@webassemblyjs/ast" "1.9.0"
 
+"@webassemblyjs/helper-numbers@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz#64d81da219fbbba1e3bd1bfc74f6e8c4e10a62ae"
+  integrity sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser" "1.11.1"
+    "@webassemblyjs/helper-api-error" "1.11.1"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/helper-wasm-bytecode@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz#f328241e41e7b199d0b20c18e88429c4433295e1"
+  integrity sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==
+
 "@webassemblyjs/helper-wasm-bytecode@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz#4fed8beac9b8c14f8c58b70d124d549dd1fe5790"
   integrity sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==
+
+"@webassemblyjs/helper-wasm-section@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz#21ee065a7b635f319e738f0dd73bfbda281c097a"
+  integrity sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
 
 "@webassemblyjs/helper-wasm-section@1.9.0":
   version "1.9.0"
@@ -3820,12 +3888,26 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
     "@webassemblyjs/wasm-gen" "1.9.0"
 
+"@webassemblyjs/ieee754@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz#963929e9bbd05709e7e12243a099180812992614"
+  integrity sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
 "@webassemblyjs/ieee754@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz#15c7a0fbaae83fb26143bbacf6d6df1702ad39e4"
   integrity sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/leb128@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.1.tgz#ce814b45574e93d76bae1fb2644ab9cdd9527aa5"
+  integrity sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==
+  dependencies:
+    "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/leb128@1.9.0":
   version "1.9.0"
@@ -3834,10 +3916,29 @@
   dependencies:
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/utf8@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.1.tgz#d1f8b764369e7c6e6bae350e854dec9a59f0a3ff"
+  integrity sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==
+
 "@webassemblyjs/utf8@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.9.0.tgz#04d33b636f78e6a6813227e82402f7637b6229ab"
   integrity sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==
+
+"@webassemblyjs/wasm-edit@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz#ad206ebf4bf95a058ce9880a8c092c5dec8193d6"
+  integrity sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/helper-wasm-section" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
+    "@webassemblyjs/wasm-opt" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    "@webassemblyjs/wast-printer" "1.11.1"
 
 "@webassemblyjs/wasm-edit@1.9.0":
   version "1.9.0"
@@ -3853,6 +3954,17 @@
     "@webassemblyjs/wasm-parser" "1.9.0"
     "@webassemblyjs/wast-printer" "1.9.0"
 
+"@webassemblyjs/wasm-gen@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz#86c5ea304849759b7d88c47a32f4f039ae3c8f76"
+  integrity sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/ieee754" "1.11.1"
+    "@webassemblyjs/leb128" "1.11.1"
+    "@webassemblyjs/utf8" "1.11.1"
+
 "@webassemblyjs/wasm-gen@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz#50bc70ec68ded8e2763b01a1418bf43491a7a49c"
@@ -3864,6 +3976,16 @@
     "@webassemblyjs/leb128" "1.9.0"
     "@webassemblyjs/utf8" "1.9.0"
 
+"@webassemblyjs/wasm-opt@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz#657b4c2202f4cf3b345f8a4c6461c8c2418985f2"
+  integrity sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+
 "@webassemblyjs/wasm-opt@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz#2211181e5b31326443cc8112eb9f0b9028721a61"
@@ -3873,6 +3995,18 @@
     "@webassemblyjs/helper-buffer" "1.9.0"
     "@webassemblyjs/wasm-gen" "1.9.0"
     "@webassemblyjs/wasm-parser" "1.9.0"
+
+"@webassemblyjs/wasm-parser@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz#86ca734534f417e9bd3c67c7a1c75d8be41fb199"
+  integrity sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-api-error" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/ieee754" "1.11.1"
+    "@webassemblyjs/leb128" "1.11.1"
+    "@webassemblyjs/utf8" "1.11.1"
 
 "@webassemblyjs/wasm-parser@1.9.0":
   version "1.9.0"
@@ -3898,6 +4032,14 @@
     "@webassemblyjs/helper-fsm" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/wast-printer@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz#d0c73beda8eec5426f10ae8ef55cee5e7084c2f0"
+  integrity sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@xtuc/long" "4.2.2"
+
 "@webassemblyjs/wast-printer@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz#4935d54c85fef637b00ce9f52377451d00d47899"
@@ -3912,10 +4054,22 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.0.4.tgz#f03ce6311c0883a83d04569e2c03c6238316d2aa"
   integrity sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==
 
+"@webpack-cli/configtest@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.1.0.tgz#8342bef0badfb7dfd3b576f2574ab80c725be043"
+  integrity sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==
+
 "@webpack-cli/info@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.3.0.tgz#9d78a31101a960997a4acd41ffd9b9300627fe2b"
   integrity sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==
+  dependencies:
+    envinfo "^7.7.3"
+
+"@webpack-cli/info@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.4.0.tgz#b9179c3227ab09cbbb149aa733475fcf99430223"
+  integrity sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==
   dependencies:
     envinfo "^7.7.3"
 
@@ -3934,6 +4088,11 @@
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.5.1.tgz#b5fde2f0f79c1e120307c415a4c1d5eb15a6f278"
   integrity sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==
+
+"@webpack-cli/serve@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.6.0.tgz#2c275aa05c895eccebbfc34cfb223c6e8bd591a2"
+  integrity sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==
 
 "@webpack-cli/utils@^0.2.2":
   version "0.2.3"
@@ -4024,6 +4183,11 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
+acorn-import-assertions@^1.7.6:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
+  integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
+
 acorn-jsx@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
@@ -4063,6 +4227,11 @@ acorn@^8.2.4:
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.4.1.tgz#56c36251fc7cabc7096adc18f05afe814321a28c"
   integrity sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==
+
+acorn@^8.4.1:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
+  integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
 
 address@1.1.2, address@^1.0.1:
   version "1.1.2"
@@ -5425,6 +5594,17 @@ browserslist@^4.12.2, browserslist@^4.16.6:
     escalade "^3.1.1"
     node-releases "^1.1.71"
 
+browserslist@^4.14.5:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.17.5.tgz#c827bbe172a4c22b123f5e337533ceebadfdd559"
+  integrity sha512-I3ekeB92mmpctWBoLXe0d5wPS2cBuRvvW0JyyJHMrk9/HmP2ZjrTboNAZ8iuGqaEIlKguljbQY32OkOJIRrgoA==
+  dependencies:
+    caniuse-lite "^1.0.30001271"
+    electron-to-chromium "^1.3.878"
+    escalade "^3.1.1"
+    node-releases "^2.0.1"
+    picocolors "^1.0.0"
+
 bs-logger@0.x:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
@@ -5472,10 +5652,15 @@ buffer-fill@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
   integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
-buffer-from@1.x, buffer-from@^1.0.0:
+buffer-from@1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
 buffer-indexof@^1.0.0:
   version "1.1.1"
@@ -5746,6 +5931,11 @@ caniuse-lite@^1.0.30001166, caniuse-lite@^1.0.30001219:
   version "1.0.30001240"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001240.tgz#ec15d125b590602c8731545c5351ff054ad2d52f"
   integrity sha512-nb8mDzfMdxBDN7ZKx8chWafAdBp5DAAlpWvNyUGe5tcDWd838zpzDN3Rah9cjCqhfOKkrvx40G2SDtP0qiWX/w==
+
+caniuse-lite@^1.0.30001271:
+  version "1.0.30001271"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz#0dda0c9bcae2cf5407cd34cac304186616cc83e8"
+  integrity sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -6264,6 +6454,11 @@ colorette@^1.2.1, colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
+colorette@^2.0.14:
+  version "2.0.16"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
+  integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
+
 colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
@@ -6539,10 +6734,15 @@ core-js@^3.15.1, core-js@^3.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.15.1.tgz#6c08ab88abdf56545045ccf5fd81f47f407e7f1a"
   integrity sha512-h8VbZYnc9pDzueiS2610IULDkpFFPunHwIpl8yRwFahAEEdSpHlTy3h3z3rKq5h11CaUdBEeRViu9AYvbxiMeg==
 
-core-util-is@1.0.2, core-util-is@~1.0.0:
+core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cors@^2.8.5:
   version "2.8.5"
@@ -7769,6 +7969,11 @@ electron-to-chromium@^1.3.723:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.759.tgz#b0d652d376831470a4c230ba721da2427bfb996a"
   integrity sha512-nM76xH0t2FBH5iMEZDVc3S/qbdKjGH7TThezxC8k1Q7w7WHvIAyJh8lAe2UamGfdRqBTjHfPDn82LJ0ksCiB9g==
 
+electron-to-chromium@^1.3.878:
+  version "1.3.879"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.879.tgz#4aba9700cfb241fb95c6ed69e31785e3d1605a43"
+  integrity sha512-zJo+D9GwbJvM31IdFmwcGvychhk4KKbKYo2GWlsn+C/dxz2NwmbhGJjWwTfFSF2+eFH7VvfA8MCZ8SOqTrlnpw==
+
 elliptic@^6.5.3:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
@@ -7842,6 +8047,14 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0, enhan
     graceful-fs "^4.1.2"
     memory-fs "^0.5.0"
     tapable "^1.0.0"
+
+enhanced-resolve@^5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
+  integrity sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
 
 enquirer@^2.3.5:
   version "2.3.6"
@@ -7956,6 +8169,11 @@ es-get-iterator@^1.0.2:
     is-set "^2.0.2"
     is-string "^1.0.5"
     isarray "^2.0.5"
+
+es-module-lexer@^0.9.0:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
+  integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -8274,20 +8492,20 @@ eslint-rule-docs@^1.1.5:
   resolved "https://registry.yarnpkg.com/eslint-rule-docs/-/eslint-rule-docs-1.1.229.tgz#6a11305084f6671b220858a235cc87a6330d2504"
   integrity sha512-blQpqOoFiGr9wcH+MEgfMHcxizaXUaXXEc07R0avaZeivVmoPhvepHsh1UfdbtvC/KNZPcLzdpPIEpZIdgUSdQ==
 
+eslint-scope@5.1.1, eslint-scope@^5.0.0, eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
   integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
   dependencies:
     esrecurse "^4.1.0"
-    estraverse "^4.1.1"
-
-eslint-scope@^5.0.0, eslint-scope@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
-  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
-  dependencies:
-    esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
 eslint-utils@^2.0.0, eslint-utils@^2.1.0:
@@ -8450,10 +8668,15 @@ estraverse@^4.1.1, estraverse@^4.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
+
+estraverse@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
 estree-walker@^0.6.1:
   version "0.6.1"
@@ -8501,7 +8724,7 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events@^3.0.0:
+events@^3.0.0, events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -9527,6 +9750,11 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
+glob-to-regexp@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
+
 glob-watcher@^5.0.3:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/glob-watcher/-/glob-watcher-5.0.5.tgz#aa6bce648332924d9a8489be41e3e5c52d4186dc"
@@ -9552,10 +9780,22 @@ glob@7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.7, glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
+glob@7.1.7, glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.6, glob@~7.1.1:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.3, glob@^7.1.4:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -9776,10 +10016,15 @@ got@^8.3.1:
     url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.0.0, graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.0.0, graceful-fs@^4.1.10, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
+  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
 grapheme-splitter@^1.0.2:
   version "1.0.4"
@@ -10925,9 +11170,9 @@ is-glob@^3.1.0:
     is-extglob "^2.1.0"
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
-  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
@@ -12239,6 +12484,15 @@ jest-worker@^26.5.0, jest-worker@^26.6.2:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jest-worker@^27.0.6:
+  version "27.3.1"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.3.1.tgz#0def7feae5b8042be38479799aeb7b5facac24b2"
+  integrity sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
+
 jest@24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-24.9.0.tgz#987d290c05a08b52c56188c1002e368edb007171"
@@ -12806,6 +13060,11 @@ loader-runner@^2.3.0, loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
+
+loader-runner@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
+  integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
 
 loader-utils@1.2.3:
   version "1.2.3"
@@ -13836,9 +14095,9 @@ mz@^2.7.0:
     thenify-all "^1.0.0"
 
 nan@^2.12.1:
-  version "2.14.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
-  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
 nanoid@3.1.20:
   version "3.1.20"
@@ -14006,6 +14265,11 @@ node-releases@^1.1.61, node-releases@^1.1.71, node-releases@^1.1.73:
   version "1.1.73"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
   integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
+
+node-releases@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
+  integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
 
 nodemon@^2.0.7:
   version "2.0.7"
@@ -14515,7 +14779,7 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -14890,6 +15154,11 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3:
   version "2.3.0"
@@ -17248,7 +17517,7 @@ schema-utils@^2.6.5, schema-utils@^2.7.0, schema-utils@^2.7.1:
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
 
-schema-utils@^3.0.0:
+schema-utils@^3.0.0, schema-utils@^3.1.0, schema-utils@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
   integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==
@@ -17423,6 +17692,13 @@ serialize-javascript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
   integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
+
+serialize-javascript@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
+  integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
   dependencies:
     randombytes "^2.1.0"
 
@@ -17720,10 +17996,18 @@ source-map-resolve@^0.6.0:
     atob "^2.1.2"
     decode-uri-component "^0.2.0"
 
-source-map-support@0.5.19, source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.19, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.19:
+source-map-support@0.5.19, source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.19, source-map-support@^0.5.6, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@~0.5.12, source-map-support@~0.5.20:
+  version "0.5.20"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.20.tgz#12166089f8f5e5e8c56926b377633392dd2cb6c9"
+  integrity sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -18257,7 +18541,7 @@ suffix@^0.1.0:
   resolved "https://registry.yarnpkg.com/suffix/-/suffix-0.1.1.tgz#cc58231646a0ef1102f79478ef3a9248fd9c842f"
   integrity sha1-zFgjFkag7xEC95R47zqSSP2chC8=
 
-supports-color@8.1.1, supports-color@^8.1.0:
+supports-color@8.1.1, supports-color@^8.0.0, supports-color@^8.1.0:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -18363,6 +18647,11 @@ tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
+
+tapable@^2.1.1, tapable@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
+  integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
 tar-fs@^2.0.0:
   version "2.1.1"
@@ -18474,6 +18763,18 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
+terser-webpack-plugin@^5.1.3:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.2.4.tgz#ad1be7639b1cbe3ea49fab995cbe7224b31747a1"
+  integrity sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==
+  dependencies:
+    jest-worker "^27.0.6"
+    p-limit "^3.1.0"
+    schema-utils "^3.1.1"
+    serialize-javascript "^6.0.0"
+    source-map "^0.6.1"
+    terser "^5.7.2"
+
 terser@^4.1.2, terser@^4.6.2, terser@^4.6.3:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
@@ -18491,6 +18792,15 @@ terser@^5.3.4:
     commander "^2.20.0"
     source-map "~0.7.2"
     source-map-support "~0.5.19"
+
+terser@^5.7.2:
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.9.0.tgz#47d6e629a522963240f2b55fcaa3c99083d2c351"
+  integrity sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.20"
 
 test-exclude@^5.2.3:
   version "5.2.3"
@@ -19631,6 +19941,14 @@ watchpack@^1.4.0, watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
+watchpack@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.2.0.tgz#47d78f5415fe550ecd740f99fe2882323a58b1ce"
+  integrity sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
@@ -19812,6 +20130,24 @@ webpack-cli@^4.4.0:
     v8-compile-cache "^2.2.0"
     webpack-merge "^5.7.3"
 
+webpack-cli@^4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.9.1.tgz#b64be825e2d1b130f285c314caa3b1ba9a4632b3"
+  integrity sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==
+  dependencies:
+    "@discoveryjs/json-ext" "^0.5.0"
+    "@webpack-cli/configtest" "^1.1.0"
+    "@webpack-cli/info" "^1.4.0"
+    "@webpack-cli/serve" "^1.6.0"
+    colorette "^2.0.14"
+    commander "^7.0.0"
+    execa "^5.0.0"
+    fastest-levenshtein "^1.0.12"
+    import-local "^3.0.2"
+    interpret "^2.2.0"
+    rechoir "^0.7.0"
+    webpack-merge "^5.7.3"
+
 webpack-dev-middleware@^3.7.2:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.7.3.tgz#0639372b143262e2b84ab95d3b91a7597061c2c5"
@@ -19935,6 +20271,11 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
+webpack-sources@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.1.tgz#251a7d9720d75ada1469ca07dbb62f3641a05b6d"
+  integrity sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==
+
 webpack@4.44.2:
   version "4.44.2"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.44.2.tgz#6bfe2b0af055c8b2d1e90ed2cd9363f841266b72"
@@ -19992,7 +20333,7 @@ webpack@^3.0.0:
     webpack-sources "^1.0.1"
     yargs "^8.0.2"
 
-webpack@^4.29.6, webpack@^4.43.0:
+webpack@^4.29.6:
   version "4.46.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
   integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==
@@ -20020,6 +20361,36 @@ webpack@^4.29.6, webpack@^4.43.0:
     terser-webpack-plugin "^1.4.3"
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
+
+webpack@^5.60.0:
+  version "5.60.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.60.0.tgz#9c26f38a57c9688b0a8c5c885e05197344eae67d"
+  integrity sha512-OL5GDYi2dKxnwJPSOg2tODgzDxAffN0osgWkZaBo/l3ikCxDFP+tuJT3uF7GyBE3SDBpKML/+a8EobyWAQO3DQ==
+  dependencies:
+    "@types/eslint-scope" "^3.7.0"
+    "@types/estree" "^0.0.50"
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/wasm-edit" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    acorn "^8.4.1"
+    acorn-import-assertions "^1.7.6"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.8.3"
+    es-module-lexer "^0.9.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.4"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.1.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.3"
+    watchpack "^2.2.0"
+    webpack-sources "^3.2.0"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
   version "0.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2378,10 +2378,10 @@
     rasha "^1.2.5"
     safe-flat "^2.0.2"
 
-"@okta/okta-signin-widget@^5.12.1":
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/@okta/okta-signin-widget/-/okta-signin-widget-5.12.1.tgz#b3a8027d882a5055467833a7943452311fc435d9"
-  integrity sha512-K+EtXbM/JBHKyEtc7CZyh8aETqO9SzWtcc6WiRrskNoUfPahb8llPyBjLBWv0UIIFL9dwX6ONhkgvxtrtPV6pQ==
+"@okta/okta-signin-widget@^5.12.2":
+  version "5.12.2"
+  resolved "https://registry.yarnpkg.com/@okta/okta-signin-widget/-/okta-signin-widget-5.12.2.tgz#979384e082d29b56528532c3f0a078ba6f3dbd66"
+  integrity sha512-0vpSBYiW6lHRWOtqYYAfQ1etevg6yuC3hvC/V9MIXEWCQ9fkFZDtCzPRzIclMyeEplZJZYohGRs2sxOmNa/dYQ==
   dependencies:
     "@babel/polyfill" "^7.10.1"
     "@babel/runtime" "^7.10.3"
@@ -20343,7 +20343,7 @@ webpack@^3.0.0:
     webpack-sources "^1.0.1"
     yargs "^8.0.2"
 
-webpack@^4.29.6:
+webpack@^4.29.6, webpack@^4.46.0:
   version "4.46.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
   integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2378,10 +2378,10 @@
     rasha "^1.2.5"
     safe-flat "^2.0.2"
 
-"@okta/okta-signin-widget@^5.12.2":
-  version "5.12.2"
-  resolved "https://registry.yarnpkg.com/@okta/okta-signin-widget/-/okta-signin-widget-5.12.2.tgz#979384e082d29b56528532c3f0a078ba6f3dbd66"
-  integrity sha512-0vpSBYiW6lHRWOtqYYAfQ1etevg6yuC3hvC/V9MIXEWCQ9fkFZDtCzPRzIclMyeEplZJZYohGRs2sxOmNa/dYQ==
+"@okta/okta-signin-widget@^5.13.0":
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-signin-widget/-/okta-signin-widget-5.13.0.tgz#85cac56f5e9beeb3eecaf529acd0de202e339c0d"
+  integrity sha512-yyUF2z1qZEgRw0Q2qoLxocm/CC/gLuQt/utecTcxzOlaiGqu91tUwNVfFJ6W+C3dNOR9qxhvTEOEPkJrFpekgg==
   dependencies:
     "@babel/polyfill" "^7.10.1"
     "@babel/runtime" "^7.10.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2352,10 +2352,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@okta/okta-idx-js@0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-idx-js/-/okta-idx-js-0.21.0.tgz#2ecf0b04014b496e439b5cd18f7eb1a3fa4a8fd3"
-  integrity sha512-OsMdhTel7lOecuAsRJJBDjb4J7S9dDRqXlyYmksQvU22Gm1gl5JhWMBBp77LrjZogr7cbZ6sXxjMXUMh6TaJOw==
+"@okta/okta-idx-js@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-idx-js/-/okta-idx-js-0.22.0.tgz#c5dbebd155be2c8a8e2bbceb2e92701b6ba59349"
+  integrity sha512-SehJVwQI51xWrB1YaMn6UB54cOzhrM7z5k2xOI62I3B7qOQ3uFOZJvRCJnBcZ6TEcQuqJ3/6q93h6n8omw0tVQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2352,10 +2352,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@okta/okta-idx-js@0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-idx-js/-/okta-idx-js-0.19.0.tgz#f54a6692e530c481d41fac8f4e6d9d1f07683ff5"
-  integrity sha512-gtgPXIA5w/fQH5rqI1ZjrMhTE+seKSj1Xb5ryzeqW/+1YIo630pzk/JPZ1Svc8yth92uxN9M9wJLTYyUcdzI5w==
+"@okta/okta-idx-js@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-idx-js/-/okta-idx-js-0.21.0.tgz#2ecf0b04014b496e439b5cd18f7eb1a3fa4a8fd3"
+  integrity sha512-OsMdhTel7lOecuAsRJJBDjb4J7S9dDRqXlyYmksQvU22Gm1gl5JhWMBBp77LrjZogr7cbZ6sXxjMXUMh6TaJOw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.5"
@@ -8048,7 +8048,7 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0, enhan
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.8.3:
+enhanced-resolve@^5.0.0, enhanced-resolve@^5.8.3:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
   integrity sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==
@@ -19128,7 +19128,7 @@ ts-jest@^26.4.3:
     semver "7.x"
     yargs-parser "20.x"
 
-ts-loader@^8.0.0, ts-loader@^8.0.1:
+ts-loader@^8.0.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.3.0.tgz#83360496d6f8004fab35825279132c93412edf33"
   integrity sha512-MgGly4I6cStsJy27ViE32UoqxPTN9Xly4anxxVyaIWR+9BGxboV4EyJBGfR3RePV7Ksjj3rHmPZJeIt+7o4Vag==
@@ -19136,6 +19136,16 @@ ts-loader@^8.0.0, ts-loader@^8.0.1:
     chalk "^4.1.0"
     enhanced-resolve "^4.0.0"
     loader-utils "^2.0.0"
+    micromatch "^4.0.0"
+    semver "^7.3.4"
+
+ts-loader@^9.2.6:
+  version "9.2.6"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.2.6.tgz#9937c4dd0a1e3dbbb5e433f8102a6601c6615d74"
+  integrity sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^5.0.0"
     micromatch "^4.0.0"
     semver "^7.3.4"
 


### PR DESCRIPTION
- passes stateTokenExternalId to introspect
- allows shared storage without "oauth" flag (meant for legacy oauth cookies)
- clears shared storage if a matching state exists in sessionStorage
- do not bundle node-cache for browser version
- add _idxResponse to auth-js methods (to help widget conversion)
- separate shared storage for originalUri
- upgrades idx-js and fixes tests (no longer throws a "raw" idx response)
- shared storage is automatically enabled only in browser environment
- isInteractionRequired now supported on node platform
- updates express-embedded-auth-with-sdk sample:
  - handles email verify callback (on /login/callback)
  - displays more error types (instead of "Internal Error!")