### PR TITLE
Adds fields for `Input` type in NextStep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#981](https://github.com/okta/okta-auth-js/pull/981) TypeScript: Allows optional paramters for IDX methods
 - [#986](https://github.com/okta/okta-auth-js/pull/986) TypeScript: Interface `SignInWithRedirectOptions` should extend `TokenParams`
+- [#992](https://github.com/okta/okta-auth-js/pull/992) TypeScript: Adds fields for `Input` type in NextStep object
 
 ## 5.6.0
 

--- a/lib/idx/remediators/Base/Remediator.ts
+++ b/lib/idx/remediators/Base/Remediator.ts
@@ -13,7 +13,7 @@
 
 /* eslint-disable complexity */
 import { AuthSdkError } from '../../../errors';
-import { NextStep, IdxMessage, Authenticator } from '../../types';
+import { NextStep, IdxMessage, Authenticator, Input } from '../../types';
 import { IdxAuthenticator, IdxRemediation } from '../../types/idx-js';
 import { getAllValues, getRequiredValues, titleCase } from '../util';
 
@@ -130,7 +130,7 @@ export class Remediator {
   }
 
   // Get inputs for the next step
-  private getInputs() {
+  private getInputs(): Input[] {
     if (!this.map) {
       return [];
     }
@@ -141,7 +141,7 @@ export class Remediator {
         return inputs;
       }
 
-      let input;
+      let input: Input;
       const aliases = this.map[key];
       const { type } = inputFromRemediation;
       if (typeof this[`getInput${titleCase(key)}`] === 'function') {

--- a/lib/idx/types/index.ts
+++ b/lib/idx/types/index.ts
@@ -38,7 +38,7 @@ export enum AuthenticatorKey {
   GOOGLE_AUTHENTICATOR = 'google_otp',
 }
 
-type Input = {
+export type Input = {
   name: string;
   label?: string;
   value?: string;

--- a/lib/idx/types/index.ts
+++ b/lib/idx/types/index.ts
@@ -40,6 +40,9 @@ export enum AuthenticatorKey {
 
 type Input = {
   name: string;
+  label?: string;
+  value?: string;
+  secret?: boolean;
   required?: boolean;
 }
 


### PR DESCRIPTION
`Input` type returned from the `nextStep` object should list more fields in its type definition.