### PR TITLE
Add support of activationToken

### DIFF
--- a/docs/idx.md
+++ b/docs/idx.md
@@ -31,6 +31,7 @@
     - [`idx.startTransaction`](#idxstarttransaction)
     - [`idx.cancel`](#idxcancel)
     - [`idx.handleInteractionCodeRedirect`](#idxhandleinteractioncoderedirect)
+    - [`idx.activate`](#idxactivate)
 
 ## Introduction
 
@@ -351,4 +352,16 @@ try {
   }
   throw err;
 }
+```
+
+#### `idx.activate`
+
+The convenience method for user activation flow by activation token received in Magic Link.
+
+```javascript
+await authClient.idx.activate({
+  activationToken: 'xxxxx',
+  authenticator: 'okta_password',
+  password: 'xxx',
+});
 ```

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -109,6 +109,7 @@ import {
   recoverPassword,
   startTransaction,
   handleInteractionCodeRedirect,
+  activate,
 } from './idx';
 import { createGlobalRequestInterceptor, setGlobalRequestInterceptor } from './idx/headers';
 import { OktaUserAgent } from './OktaUserAgent';
@@ -268,6 +269,7 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
       recoverPassword: recoverPassword.bind(null, this),
       handleInteractionCodeRedirect: handleInteractionCodeRedirect.bind(null, this),
       startTransaction: startTransaction.bind(null, this),
+      activate: activate.bind(null, this),
     };
     setGlobalRequestInterceptor(createGlobalRequestInterceptor(this)); // to pass custom headers to IDX endpoints
 

--- a/lib/idx/activate.ts
+++ b/lib/idx/activate.ts
@@ -13,6 +13,7 @@
 
 import { run, RemediationFlow } from './run';
 import { transactionMetaExist } from './transactionMeta';
+import { startTransaction } from './startTransaction';
 import { 
   SelectAuthenticatorEnroll,
   SelectAuthenticatorEnrollValues,
@@ -52,6 +53,12 @@ export async function activate(
   if (!transactionMetaExist(authClient)) {
     if (!options.activationToken) {
       const error = new AuthSdkError('No activationToken passed');
+      return { status: IdxStatus.FAILURE, error };
+    }
+
+    const {availableSteps} = await startTransaction(authClient, options);
+    if (availableSteps?.some(({ name }) => name === 'identify')) {
+      const error = new AuthSdkError('activationToken is not supported based on your current org configuration.');
       return { status: IdxStatus.FAILURE, error };
     }
   }

--- a/lib/idx/activate.ts
+++ b/lib/idx/activate.ts
@@ -1,0 +1,58 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+import { run, RemediationFlow } from './run';
+import { transactionMetaExist } from './transactionMeta';
+import { startTransaction } from './startTransaction';
+import { 
+  SelectAuthenticatorEnroll,
+  SelectAuthenticatorEnrollValues,
+  EnrollAuthenticator,
+  EnrollAuthenticatorValues,
+  AuthenticatorEnrollmentData,
+  AuthenticatorEnrollmentDataValues,
+  Skip,
+  SkipValues,
+} from './remediators';
+import { ActivationFlowMonitor } from './flowMonitors';
+import { AuthSdkError } from '../errors';
+import { 
+  IdxOptions, 
+  IdxTransaction, 
+  OktaAuth, 
+} from '../types';
+
+const flow: RemediationFlow = {
+  'authenticator-enrollment-data': AuthenticatorEnrollmentData,
+  'select-authenticator-enroll': SelectAuthenticatorEnroll,
+  'enroll-authenticator': EnrollAuthenticator,
+  'skip': Skip,
+};
+
+export type ActivationOptions = IdxOptions 
+  & SelectAuthenticatorEnrollValues 
+  & EnrollAuthenticatorValues 
+  & AuthenticatorEnrollmentDataValues 
+  & SkipValues;
+
+export async function activate(
+  authClient: OktaAuth, options: ActivationOptions
+): Promise<IdxTransaction> {
+  console.log(1, options)
+  const flowMonitor = new ActivationFlowMonitor(authClient);
+  return run(authClient, { 
+    ...options, 
+    flow,
+    flowMonitor,
+  });
+}

--- a/lib/idx/activate.ts
+++ b/lib/idx/activate.ts
@@ -12,8 +12,6 @@
 
 
 import { run, RemediationFlow } from './run';
-import { transactionMetaExist } from './transactionMeta';
-import { startTransaction } from './startTransaction';
 import { 
   SelectAuthenticatorEnroll,
   SelectAuthenticatorEnrollValues,
@@ -25,7 +23,6 @@ import {
   SkipValues,
 } from './remediators';
 import { ActivationFlowMonitor } from './flowMonitors';
-import { AuthSdkError } from '../errors';
 import { 
   IdxOptions, 
   IdxTransaction, 
@@ -48,7 +45,6 @@ export type ActivationOptions = IdxOptions
 export async function activate(
   authClient: OktaAuth, options: ActivationOptions
 ): Promise<IdxTransaction> {
-  console.log(1, options)
   const flowMonitor = new ActivationFlowMonitor(authClient);
   return run(authClient, { 
     ...options, 

--- a/lib/idx/flowMonitors/ActivationFlowMonitor.ts
+++ b/lib/idx/flowMonitors/ActivationFlowMonitor.ts
@@ -11,12 +11,20 @@
  */
 
 
-export * from './authenticate';
-export * from './cancel';
-export * from './interact';
-export * from './introspect';
-export * from './register';
-export * from './recoverPassword';
-export * from './handleInteractionCodeRedirect';
-export * from './startTransaction';
-export * from './activate';
+import { FlowMonitor } from './FlowMonitor';
+
+export class ActivationFlowMonitor extends FlowMonitor {
+  isRemediatorCandidate(remediator, remediations?, values?) {
+    const prevRemediatorName = this.previousRemediator?.getName();
+    const remediatorName = remediator.getName();
+    if (remediatorName === 'select-authenticator-enroll' 
+      && [
+          'select-authenticator-enroll', 
+          'authenticator-enrollment-data'
+        ].includes(prevRemediatorName)) {
+      return false;
+    }
+
+    return super.isRemediatorCandidate(remediator, remediations, values);
+  }
+}

--- a/lib/idx/flowMonitors/index.ts
+++ b/lib/idx/flowMonitors/index.ts
@@ -15,3 +15,4 @@ export * from './FlowMonitor';
 export * from './RegistrationFlowMonitor';
 export * from './AuthenticationFlowMonitor';
 export * from './PasswordRecoveryFlowMonitor';
+export * from './ActivationFlowMonitor';

--- a/lib/idx/interact.ts
+++ b/lib/idx/interact.ts
@@ -18,6 +18,7 @@ import { getOAuthBaseUrl } from '../oidc';
 export interface InteractOptions {
   state?: string;
   scopes?: string[];
+  activationToken?: string;
 }
 
 export interface InteractResponse {
@@ -54,6 +55,9 @@ export async function interact (authClient: OktaAuth, options: InteractOptions =
   state = state || meta.state;
   const scopes = options.scopes || authClient.options.scopes || meta.scopes;
 
+  // These properties can be set in options
+  const { activationToken } = options;
+
   const baseUrl = getOAuthBaseUrl(authClient);
   return idx.interact({
     // OAuth
@@ -65,7 +69,10 @@ export async function interact (authClient: OktaAuth, options: InteractOptions =
 
     // PKCE
     codeChallenge,
-    codeChallengeMethod
+    codeChallengeMethod,
+
+    // Magic Link
+    activationToken
   }).then(interactionHandle => {
     const newMeta = { ...meta, interactionHandle, state, scopes };
     // Save transaction meta so it can be resumed

--- a/lib/idx/types/index.ts
+++ b/lib/idx/types/index.ts
@@ -21,6 +21,7 @@ export { AuthenticationOptions } from '../authenticate';
 export { RegistrationOptions } from '../register';
 export { PasswordRecoveryOptions } from '../recoverPassword';
 export { CancelOptions } from '../cancel';
+export { ActivationOptions } from '../activate';
 
 export enum IdxStatus {
   SUCCESS = 'SUCCESS',

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -27,6 +27,7 @@ import {
   CancelOptions,
   IdxOptions,
   IdxTransaction,
+  ActivationOptions
 } from '../idx/types';
 import { InteractOptions, InteractResponse } from '../idx/interact';
 import { IntrospectOptions } from '../idx/introspect';
@@ -268,4 +269,5 @@ export interface IdxAPI {
   startTransaction: (options?: IdxOptions) => Promise<IdxTransaction>;
   recoverPassword: (options?: PasswordRecoveryOptions) => Promise<IdxTransaction>;
   handleInteractionCodeRedirect: (url: string) => Promise<void>; 
+  activate: (options?: ActivationOptions) => Promise<IdxTransaction>;
 }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@okta/okta-idx-js": "0.22.0",
+    "@okta/okta-idx-js": "0.23.0",
     "@peculiar/webcrypto": "1.1.6",
     "Base64": "1.1.0",
     "atob": "^2.1.2",

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -48,6 +48,14 @@ function loginLinks(app: TestApp, onProtectedPage?: boolean): string {
       </li>
     `;
   }
+  const useActivationToken = app.config.useInteractionCodeFlow ? `
+    <div class="box">
+      <form>
+        <input name="activationToken" id="activationToken" placeholder="activation token" type="text"/>
+        <a href="/" id="activationToken-direct" onclick="useActivationToken(event)">Activate</a>
+      </form>
+    </div>
+    ` : '';
   return `
     <div class="pure-menu">
       <ul class="pure-menu-list actions">
@@ -76,6 +84,7 @@ function loginLinks(app: TestApp, onProtectedPage?: boolean): string {
         <a href="/" id="login-direct" onclick="loginDirect(event)">Login DIRECT</a>
       </form>
     </div>
+    ${useActivationToken}
   `;
 }
 
@@ -131,6 +140,7 @@ function bindFunctions(testApp: TestApp, window: Window): void {
     loginRedirect: testApp.loginRedirect.bind(testApp, {}),
     loginPopup: testApp.loginPopup.bind(testApp, {}),
     loginDirect: testApp.loginDirect.bind(testApp),
+    useActivationToken: testApp.useActivationToken.bind(testApp),
     getToken: testApp.getToken.bind(testApp, {}),
     clearTokens: testApp.clearTokens.bind(testApp),
     logoutRedirect: testApp.logoutRedirect.bind(testApp),
@@ -327,6 +337,35 @@ class TestApp {
 
     // re-render
     this.render();
+  }
+
+  async useActivationToken(): Promise<void> {
+    // Make sure we are starting a fresh transaction
+    this.oktaAuth.storageManager.getTransactionStorage().clearStorage();
+
+    // Get activationToken
+    const activationToken = (document.getElementById('activationToken') as HTMLInputElement).value;
+
+    try {
+      // Use interact with activationToken
+      const interactRes = await this.oktaAuth.idx.interact({ activationToken });
+      const {interactionHandle} = interactRes;
+
+      // Get stateHandle from introspect
+      const tx = await this.oktaAuth.idx.introspect({ interactionHandle });
+      const { rawIdxState: { stateHandle } } = tx;
+
+      // Render widget to continue user activation
+      return this.render(true).then(() => this.renderWidget({ 
+        authClient: this.oktaAuth,
+        stateToken: stateHandle
+      }));
+    } catch(e) {
+      console.error(e);
+      if (e.error_description) {
+        alert(e.error_description);
+      }
+    }
   }
 
   async loginDirect(): Promise<void> {

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -373,7 +373,7 @@ class TestApp {
     } else {
       console.error('IDX transaction:', tx);
       const error = tx?.error as any;
-      alert(error?.error_description || `${tx.status}`);
+      alert(error?.error_description || `${tx.status} ${tx?.messages?.map(m => m.message).join('. ')}`);
     }
   }
 

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -372,8 +372,8 @@ class TestApp {
       await this.render();
     } else {
       console.error('IDX transaction:', tx);
-      // @ts-ignore
-      alert(tx?.error?.error_description || `${tx.status}`);
+      const error = tx?.error as any;
+      alert(error?.error_description || `${tx.status}`);
     }
   }
 

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -373,7 +373,7 @@ class TestApp {
     } else {
       console.error('IDX transaction:', tx);
       const error = tx?.error as any;
-      alert(error?.error_description || `${tx.status} ${tx?.messages?.map(m => m.message).join('. ')}`);
+      alert(error?.error_description || error?.message || `${tx.status} ${tx?.messages?.map(m => m.message)?.join('. ') || ''}`);
     }
   }
 

--- a/test/spec/idx/activate.ts
+++ b/test/spec/idx/activate.ts
@@ -1,0 +1,264 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+/* eslint-disable max-statements */
+import { activate } from '../../../lib/idx/activate';
+import { IdxStatus, AuthenticatorKey } from '../../../lib/idx/types';
+import { AuthSdkError } from '../../../lib/errors';
+
+import {
+  IdxResponseFactory,
+  chainResponses,
+  SelectAuthenticatorEnrollRemediationFactory,
+  AuthenticatorValueFactory,
+  PasswordAuthenticatorOptionFactory,
+  EnrollPasswordAuthenticatorRemediationFactory,
+  OktaVerifyAuthenticatorOptionFactory
+} from '@okta/test.support/idx';
+
+jest.mock('../../../lib/idx/introspect', () => {
+  return {
+    introspect: () => {}
+  };
+});
+
+const mocked = {
+  interact: require('../../../lib/idx/interact'),
+  introspect: require('../../../lib/idx/introspect'),
+};
+
+describe('idx/activate', () => {
+   let testContext;
+   beforeEach(() => {
+     const issuer = 'test-issuer';
+     const clientId = 'test-clientId';
+     const redirectUri = 'test-redirectUri';
+     const interactionCode = 'test-interactionCode';
+     const transactionMeta = {
+       issuer,
+       clientId,
+       redirectUri,
+       state: 'meta-state',
+       codeVerifier: 'meta-code',
+       scopes: ['meta'],
+       urls: { authorizeUrl: 'meta-authorizeUrl' },
+       interactionHandle: 'meta-interactionHandle',
+       ignoreSignature: true
+     };
+     const tokenResponse = {
+       tokens: {
+         fakeToken: true
+       }
+     };
+     const authClient = {
+       options: {
+         issuer,
+         clientId,
+         redirectUri
+       },
+       transactionManager: {
+         exists: () => true,
+         load: () => transactionMeta,
+         clear: () => {},
+         save: () => {},
+         saveIdxResponse: () => {},
+         loadIdxResponse: () => {}
+       },
+       token: {
+         exchangeCodeForTokens: () => Promise.resolve(tokenResponse)
+       }
+     };
+     jest.spyOn(mocked.interact, 'interact').mockResolvedValue({ 
+       meta: transactionMeta,
+       interactionHandle: 'meta-interactionHandle',
+       state: transactionMeta.state
+     });
+ 
+     const selectPasswordResponse = IdxResponseFactory.build({
+       neededToProceed: [
+         SelectAuthenticatorEnrollRemediationFactory.build({
+           value: [
+             AuthenticatorValueFactory.build({
+               options: [
+                 PasswordAuthenticatorOptionFactory.build()
+               ]
+             })
+           ]
+         })
+       ]
+     });
+ 
+     const enrollPasswordResponse = IdxResponseFactory.build({
+       neededToProceed: [
+         EnrollPasswordAuthenticatorRemediationFactory.build()
+       ]
+     });
+ 
+     const selectAuthenticatorResponse = IdxResponseFactory.build({
+       neededToProceed: [
+         SelectAuthenticatorEnrollRemediationFactory.build({
+           value: [
+             AuthenticatorValueFactory.build({
+               options: [
+                 OktaVerifyAuthenticatorOptionFactory.build()
+               ]
+             })
+           ]
+         })
+       ]
+     });
+ 
+ 
+     testContext = {
+       authClient,
+       tokenResponse,
+       interactionCode,
+       transactionMeta,
+       selectPasswordResponse,
+       enrollPasswordResponse,
+       selectAuthenticatorResponse,
+     };
+   });
+
+   it('requires activationToken to start', async () => {
+    const { authClient } = testContext;
+    jest.spyOn(authClient.transactionManager, 'exists').mockReturnValue(false);
+    const res = await activate(authClient, {});
+    expect(res.status).toBe(IdxStatus.FAILURE);
+    expect(res.error).toBeInstanceOf(AuthSdkError);
+    expect(res.error.errorSummary).toBe('No activationToken passed');
+  });
+
+  describe('password', () => {
+    it('can set a password up front', async () => {
+      const {
+        authClient,
+        selectPasswordResponse,
+        enrollPasswordResponse,
+        selectAuthenticatorResponse,
+      } = testContext;
+      
+      chainResponses([
+        selectPasswordResponse,
+        enrollPasswordResponse,
+        selectAuthenticatorResponse,
+      ]);
+      jest.spyOn(selectPasswordResponse, 'proceed');
+      jest.spyOn(enrollPasswordResponse, 'proceed');
+      jest.spyOn(mocked.introspect, 'introspect')
+        .mockResolvedValueOnce(selectPasswordResponse);
+  
+      const password = 'my-password';
+      let res = await activate(authClient, {
+        activationToken: 'activation-token',
+        password,
+        authenticators: [AuthenticatorKey.OKTA_PASSWORD]
+      });
+      expect(selectPasswordResponse.proceed).toHaveBeenCalledWith('select-authenticator-enroll', {
+        authenticator: {
+          id: 'id-password'
+        }
+      });
+      expect(enrollPasswordResponse.proceed).toHaveBeenCalledWith('enroll-authenticator', {
+        credentials: {
+          passcode: 'my-password'
+        }
+      });
+      expect(res).toEqual({
+        _idxResponse: expect.any(Object),
+        status: IdxStatus.PENDING,
+        nextStep: {
+          name: 'select-authenticator-enroll',
+          inputs: [{
+            name: 'authenticator',
+            key: 'string',
+          }],
+          options: [{
+            label: 'Okta Verify',
+            value: 'okta_verify'
+          }]
+        }
+      });
+    });
+
+    it('can set a password on demand', async () => {
+      const {
+        authClient,
+        selectPasswordResponse,
+        enrollPasswordResponse,
+        selectAuthenticatorResponse,
+      } = testContext;
+      
+      chainResponses([
+        selectPasswordResponse,
+        enrollPasswordResponse,
+        selectAuthenticatorResponse,
+      ]);
+      jest.spyOn(selectPasswordResponse, 'proceed');
+      jest.spyOn(enrollPasswordResponse, 'proceed');
+      jest.spyOn(mocked.introspect, 'introspect')
+        .mockResolvedValue(selectPasswordResponse);
+  
+      const password = 'my-password';
+      let res = await activate(authClient, {
+        activationToken: 'activation-token',
+      });
+      expect(res).toEqual({
+        _idxResponse: expect.any(Object),
+        status: IdxStatus.PENDING,
+        nextStep: {
+          name: 'select-authenticator-enroll',
+          inputs: [{
+            name: 'authenticator',
+            key: 'string',
+          }],
+          options: [{
+            label: 'Password',
+            value: AuthenticatorKey.OKTA_PASSWORD
+          }]
+        }
+      });
+
+      res = await activate(authClient, {
+        password, 
+        authenticators: [AuthenticatorKey.OKTA_PASSWORD]
+      });
+      expect(selectPasswordResponse.proceed).toHaveBeenCalledWith('select-authenticator-enroll', {
+        authenticator: {
+          id: 'id-password'
+        }
+      });
+      expect(enrollPasswordResponse.proceed).toHaveBeenCalledWith('enroll-authenticator', {
+        credentials: {
+          passcode: 'my-password'
+        }
+      });
+      expect(res).toEqual({
+        _idxResponse: expect.any(Object),
+        status: IdxStatus.PENDING,
+        nextStep: {
+          name: 'select-authenticator-enroll',
+          inputs: [{
+            name: 'authenticator',
+            key: 'string',
+          }],
+          options: [{
+            label: 'Okta Verify',
+            value: 'okta_verify'
+          }]
+        }
+      });
+    });
+  });
+
+});

--- a/test/spec/idx/interact.ts
+++ b/test/spec/idx/interact.ts
@@ -147,6 +147,35 @@ describe('idx/interact', () => {
       });
     });
 
+    it('uses activationToken from function options', async () => {
+      const { authClient } = testContext;
+      const res = await interact(authClient, { activationToken: 'fn-activationToken' });
+      expect(mocked.idx.interact).toHaveBeenCalledWith({
+        'clientId': 'authClient-clientId',
+        'baseUrl': 'authClient-issuer/oauth2',
+        'codeChallenge': 'meta-codeChallenge',
+        'codeChallengeMethod': 'meta-codeChallengeMethod',
+        'redirectUri': 'authClient-redirectUri',
+        'scopes': ['authClient'],
+        'state': 'authClient-state',
+        'activationToken': 'fn-activationToken'
+      });
+      expect(res).toEqual({
+        'interactionHandle': 'idx-interactionHandle',
+        'meta': {
+          'codeChallenge': 'meta-codeChallenge',
+          'codeChallengeMethod': 'meta-codeChallengeMethod',
+          'codeVerifier': 'meta-codeVerifier',
+          'interactionHandle': 'idx-interactionHandle',
+          'scopes': [
+            'authClient',
+          ],
+          'state': 'authClient-state',
+        },
+        'state': 'authClient-state',
+      });
+    });
+
     it('saves returned interactionHandle', async () => {
       const { authClient } = testContext;
       jest.spyOn(mocked.transactionMeta, 'saveTransactionMeta');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2352,10 +2352,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@okta/okta-idx-js@0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-idx-js/-/okta-idx-js-0.22.0.tgz#c5dbebd155be2c8a8e2bbceb2e92701b6ba59349"
-  integrity sha512-SehJVwQI51xWrB1YaMn6UB54cOzhrM7z5k2xOI62I3B7qOQ3uFOZJvRCJnBcZ6TEcQuqJ3/6q93h6n8omw0tVQ==
+"@okta/okta-idx-js@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-idx-js/-/okta-idx-js-0.23.0.tgz#894bce38922537b27f168c78c38b6df3f203f419"
+  integrity sha512-aw4zAuP+xkZPxUXk2yTWLpuQZfGusuoWXyvb1QSMWTNQ4CAwZN40nlurBYOYqYOwQjj1MGqUxEgtDGVQYITcDQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.5"


### PR DESCRIPTION
- Accepts `activationToken` in `options` argument to `idx.interact`. Added unit tests.
- Added new method `idx.activate()`. Added docs and unit tests.
- Added to `test/apps/app` the examples of usage this feature 
  - with SIW (get `interactionHandle` with `idx.interact({ activationToken })` and continue flow in SIW)
  - with IDX API (enroll user in password authenticator with new `idx.activate()`)

Tested on CT11 account. 

Internal ref: [OKTA-436601](https://oktainc.atlassian.net/browse/OKTA-436601) 

!!! Requires `okta-idx-js 0.23.0` https://github.com/okta/okta-idx-js/pull/76
