### PR TITLE
chore: fix browser bundle exposure

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
   "browser": {
-    "./dist/index.js": "build/dist/okta-auth-js.umd.js",
-    "./dist/index.esm.js": "build/esm/index.js"
+    "build/cjs/index.js": "./build/dist/okta-auth-js.umd.js"
   },
   "types": "build/lib/index.d.ts",
   "repository": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -72,8 +72,8 @@ packageJSON.scripts.prepare = '';
   const value = packageJSON[key];
   if (typeof value === 'object' && value !== null) {
     packageJSON[key] = Object.keys(value).reduce((acc, curr) => {
-      console.log(acc, curr);
-      acc[curr] = value[curr].replace('build/', '');
+      const newKey = curr.replace('build/', '');
+      acc[newKey] = value[curr].replace('build/', '');
       return acc;
     }, {});
   } else {


### PR DESCRIPTION
`browser` field should only replace the cjs bundle, and leave the esm bundle untouched.