### PR TITLE
Fixes null access when `crypto` is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#1005](https://github.com/okta/okta-auth-js/pull/1005)
   - Handles `rememberMe` boolean in IDX Identify remediation adapter
   - Typescript: Adds `type` field for `Input` type in NextStep object
+- [#1012](https://github.com/okta/okta-auth-js/pull/1012) Fixes null access when crypto is not present
 
 ## 5.8.0
 

--- a/lib/features.ts
+++ b/lib/features.ts
@@ -47,6 +47,7 @@ export function isPopupPostMessageSupported() {
 
 export function isTokenVerifySupported() {
   return typeof webcrypto !== 'undefined'
+    && webcrypto !== null
     && typeof webcrypto.subtle !== 'undefined'
     && typeof Uint8Array !== 'undefined';
 }


### PR DESCRIPTION
`./browser` crypto can be `null` if the browser is not running in a secure context. The `features` module only checks for `undefined` but the value can be `null` as well. This changes also checks for `null` to avoid attempting to access `.subtle` on the variable when its value is `null`.