### PR TITLE
Added SyncService for cross-tabs tokens renewal

### DIFF
--- a/lib/StorageManager.ts
+++ b/lib/StorageManager.ts
@@ -20,7 +20,8 @@ import {
   ORIGINAL_URI_STORAGE_NAME,
   IDX_RESPONSE_STORAGE_NAME,
   CACHE_STORAGE_NAME,
-  REDIRECT_OAUTH_PARAMS_NAME
+  REDIRECT_OAUTH_PARAMS_NAME,
+  SYNC_STORAGE_NAME
 } from './constants';
 import {
   StorageUtil,
@@ -197,6 +198,14 @@ export default class StorageManager {
     options = this.getOptionsForSection('legacy-oauth-params', options);
     const storage = this.getStorage(options);
     const storageKey = options.storageKey || REDIRECT_OAUTH_PARAMS_NAME;
+    return new SavedObject(storage, storageKey);
+  }
+
+  // sync cross tabs
+  getSyncStorage(options?: StorageOptions): StorageProvider {
+    options = this.getOptionsForSection('sync', options);
+    const storage = this.getStorage(options);
+    const storageKey = options.storageKey || SYNC_STORAGE_NAME;
     return new SavedObject(storage, storageKey);
   }
 }

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -61,7 +61,7 @@ interface TokenManagerState {
 function defaultState(): TokenManagerState {
   return {
     expireTimeouts: {},
-    renewPromise: null,
+    renewPromise: null
   };
 }
 
@@ -422,7 +422,7 @@ export class TokenManager implements TokenManagerInterface {
     // Store the renew promise state, to avoid renewing again
     this.state.renewPromise = this.syncService.renewTokenCrossTabs(key).then(newToken => {
       if (newToken) {
-        // Token was renewed from another tab
+        // Token has been renewed from another tab
         return newToken;
       } else {
         // Renew in current tab
@@ -434,10 +434,10 @@ export class TokenManager implements TokenManagerInterface {
         });
       }
     }).catch(e => {
-      return Promise.reject(e);
       // Token renewal in another tab failed
-      // Retry
-      //return this.renew(key);
+      return Promise.reject(e);
+      // TODO: Retry instead?
+      // return this.renew(key);
     });
     return this.state.renewPromise;
   }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -28,6 +28,7 @@ export const ACCESS_TOKEN_STORAGE_KEY = 'accessToken';
 export const ID_TOKEN_STORAGE_KEY =  'idToken';
 export const REFRESH_TOKEN_STORAGE_KEY =  'refreshToken';
 export const REFERRER_PATH_STORAGE_KEY = 'referrerPath';
+export const SYNC_STORAGE_NAME = 'okta-sync';
 
 // Code verifier: Random URL-safe string with a minimum length of 43 characters.
 // Code challenge: Base64 URL-encoded SHA-256 hash of the code verifier.

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -53,6 +53,11 @@ const BROWSER_STORAGE: StorageManagerOptions = {
     storageTypes: [
       'localStorage'
     ]
+  },
+  sync: {
+    storageTypes: [
+      'localStorage'
+    ]
   }
 };
 

--- a/lib/services/SyncService.ts
+++ b/lib/services/SyncService.ts
@@ -1,0 +1,144 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { OktaAuth, StorageProvider, Token, EventEmitter, StorageOptions } from '../types';
+import { TokenManager } from '../TokenManager';
+import { AuthSdkError } from '../errors';
+import { SYNC_STORAGE_NAME } from '../constants';
+
+const STALLED_TIMEOUT = 1000*30;
+const RENEWED_EVENT_TIMEOUT = 1000*10;
+const RACE_WAIT_TIMEOUT = 5;
+
+export const EVENT_RENEWED_SYNC = 'renewed_sync';
+
+declare type SyncEventHandler = () => void;
+
+// const DEFAULT_OPTIONS = {
+//   storageKey: SYNC_STORAGE_NAME,
+// };
+
+export class SyncService {
+  private syncStorage: StorageProvider;
+  private tokenManager: TokenManager;
+  private emitter: EventEmitter;
+  private storageOptions: StorageOptions;
+
+  on: (event: string, handler: SyncEventHandler) => void;
+  off: (event: string, handler?: SyncEventHandler) => void;
+
+  constructor(sdk: OktaAuth, tokenManager: TokenManager, storageOptions?: StorageOptions) {
+    this.emitter = (sdk as any).emitter;
+    this.storageOptions = storageOptions;
+    this.syncStorage = sdk.storageManager.getSyncStorage(storageOptions);
+    this.tokenManager = tokenManager;
+
+    this.on = this.emitter.on.bind(this.emitter);
+    this.off = this.emitter.off.bind(this.emitter);
+  }
+
+  get storageKey() {
+    return this.storageOptions.storageKey;
+  }
+
+  emitEventsForCrossTabsRenew(newValue, oldValue) {
+    Object.keys(oldValue).forEach(key => {
+      if (!newValue || !newValue[key]) {
+        this.emitRenewCompleted(key);
+      }
+    });
+  }
+
+  emitRenewCompleted(key) {
+    this.emitter.emit(EVENT_RENEWED_SYNC, key);
+  }
+
+  finishRenewToken(key: string) {
+    if (!this.tokenManager.getOptions().syncStorage) {
+      return;
+    }
+
+    this.syncStorage.removeItem(key);
+  }
+
+  async renewTokenCrossTabs(key: string): Promise<Token> | null {
+    if (!this.tokenManager.getOptions().syncStorage) {
+      return null;
+    }
+
+    const tabId = Math.random().toString();
+    let syncItem = this.syncStorage.getItem(key);
+    const token: Token = this.tokenManager.getSync(key);
+
+    if (syncItem && (new Date().getTime() - syncItem.date) > STALLED_TIMEOUT) {
+      // stalled renew in another tab
+      this.syncStorage.removeItem(key);
+      syncItem = null;
+    }
+
+    if (syncItem) {
+      return makePromise();
+    }
+
+    // Notify other tabs about start of renewal process
+    this.syncStorage.setItem(key, {date: new Date().getTime(), id: tabId});
+
+    // Wait for race condition
+    await new Promise(resolve => setTimeout(resolve, RACE_WAIT_TIMEOUT));
+
+    const syncItem2 = this.syncStorage.getItem(key);
+    if (!syncItem2) {
+      // race condition - anoter tab won race in 5ms
+      // renew as usual
+      return null;
+    }
+    if (syncItem2 && syncItem2.id != tabId) {
+      // race condition - not win
+      return makePromise();
+    }
+
+    function makePromise(): Promise<Token> {
+      return new Promise((resolve, reject) => {
+
+        const timeoutId = setTimeout(() => {
+          this.off(EVENT_RENEWED_SYNC, handler);
+          reject(new AuthSdkError('Token renew timed out'));
+        }, RENEWED_EVENT_TIMEOUT);
+
+        const handler = (ekey) => {
+          if (ekey != key) {
+            // skip handler for another key
+            return;
+          }
+          // off
+          this.off(EVENT_RENEWED_SYNC, handler);
+          clearTimeout(timeoutId);
+
+          const newToken = this.tokenManager.getSync(key);
+
+          if (newToken && JSON.stringify(newToken) !== JSON.stringify(token)) {
+            // Token has been renewed in another tab
+            resolve(newToken);
+          } else {
+            // Token renewal in another tab failed
+            reject(new AuthSdkError('Token renew failed'));
+          }
+        }
+        
+        this.on(EVENT_RENEWED_SYNC, handler);
+      });
+    };
+
+  }
+
+}
+

--- a/lib/services/SyncService.ts
+++ b/lib/services/SyncService.ts
@@ -36,8 +36,12 @@ export class SyncService {
   constructor(sdk: OktaAuth, tokenManager: TokenManager, storageOptions: StorageOptions) {
     this.emitter = (sdk as any).emitter;
     this.storageOptions = storageOptions;
-    if (this.canUseCrossTabsStorage(sdk, storageOptions)) {
-      this.syncStorage = sdk.storageManager.getSyncStorage(storageOptions);
+    if (this.canUseCrossTabsStorage()) {
+      try {
+        this.syncStorage = sdk.storageManager.getSyncStorage(storageOptions);
+      } catch(_e) {
+        // Local storage is unavailable
+      }
     }
     this.tokenManager = tokenManager;
 
@@ -50,8 +54,9 @@ export class SyncService {
     return this.storageOptions.storageKey;
   }
 
-  canUseCrossTabsStorage(sdk: OktaAuth, storageOptions: StorageOptions) {
-    return (typeof window !== 'undefined' && sdk.storageManager.storageUtil.testStorageType(storageOptions.storageType));
+  canUseCrossTabsStorage() {
+    // We need to listen to StorageEvent from window (which is not available on sever-side)
+    return (typeof window !== 'undefined');
   }
 
   isSyncStorageEnabled() {

--- a/lib/services/SyncService.ts
+++ b/lib/services/SyncService.ts
@@ -50,10 +50,12 @@ export class SyncService {
   }
 
   emitEventsForCrossTabsRenew(newValue, oldValue) {
-    if (typeof newValue === 'string')
+    if (typeof newValue === 'string') {
       newValue = JSON.parse(newValue);
-    if (typeof oldValue === 'string')
+    }
+    if (typeof oldValue === 'string') {
       oldValue = JSON.parse(oldValue);
+    }
     Object.keys(oldValue).forEach(key => {
       if (!newValue || !newValue[key]) {
         this.emitRenewCompleted(key);
@@ -62,7 +64,7 @@ export class SyncService {
   }
 
   emitRenewCompleted(key) {
-    console.log('____ EVENT_RENEWED_SYNC', key)
+    console.log('____ EVENT_RENEWED_SYNC', key);
     this.emitter.emit(EVENT_RENEWED_SYNC, key);
   }
 
@@ -90,12 +92,14 @@ export class SyncService {
     }
 
     const makePromise = () => new Promise((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
+      let timeoutId, handler;
+
+      timeoutId = setTimeout(() => {
         this.off(EVENT_RENEWED_SYNC, handler);
         reject(new AuthSdkError('Token renew timed out'));
       }, RENEWED_EVENT_TIMEOUT);
 
-      const handler = (ekey) => {
+      handler = (ekey) => {
         if (ekey != key) {
           // skip handler for another key
           return;

--- a/lib/services/SyncService.ts
+++ b/lib/services/SyncService.ts
@@ -13,7 +13,6 @@
 import { OktaAuth, StorageProvider, Token, EventEmitter, StorageOptions } from '../types';
 import { TokenManager } from '../TokenManager';
 import { AuthSdkError } from '../errors';
-import { SYNC_STORAGE_NAME } from '../constants';
 
 const STALLED_TIMEOUT = 1000*30;
 const RENEWED_EVENT_TIMEOUT = 1000*10;
@@ -22,10 +21,6 @@ const RACE_WAIT_TIMEOUT = 5;
 export const EVENT_RENEWED_SYNC = 'renewed_sync';
 
 declare type SyncEventHandler = (key: string) => void;
-
-// const DEFAULT_OPTIONS = {
-//   storageKey: SYNC_STORAGE_NAME,
-// };
 
 export class SyncService {
   private syncStorage: StorageProvider;
@@ -41,7 +36,9 @@ export class SyncService {
     this.storageOptions = storageOptions;
     try {
       this.syncStorage = sdk.storageManager.getSyncStorage(storageOptions);
-    } catch(_e) {}
+    } catch(_e) {
+      //todo: server doen't support and throws exception
+    }
     this.tokenManager = tokenManager;
 
     this.on = this.emitter.on.bind(this.emitter);
@@ -53,6 +50,10 @@ export class SyncService {
   }
 
   emitEventsForCrossTabsRenew(newValue, oldValue) {
+    if (typeof newValue === 'string')
+      newValue = JSON.parse(newValue);
+    if (typeof oldValue === 'string')
+      oldValue = JSON.parse(oldValue);
     Object.keys(oldValue).forEach(key => {
       if (!newValue || !newValue[key]) {
         this.emitRenewCompleted(key);
@@ -61,6 +62,7 @@ export class SyncService {
   }
 
   emitRenewCompleted(key) {
+    console.log('____ EVENT_RENEWED_SYNC', key)
     this.emitter.emit(EVENT_RENEWED_SYNC, key);
   }
 

--- a/lib/services/TokenService.ts
+++ b/lib/services/TokenService.ts
@@ -69,8 +69,6 @@ export class TokenService {
       // https://developer.mozilla.org/en-US/docs/Web/API/StorageEvent
 
       this.storageListener = ({ key, newValue, oldValue }: StorageEvent) => {
-        // if(key != 'okta-test-storage')
-        //   console.log('^^^ Crosstabs ^^^', key, newValue, oldValue, this.options.storageKey)
         const handleCrossTabsStorageChange = () => {
           if (key === this.syncService.storageKey) {
             this.syncService.emitEventsForCrossTabsRenew(newValue, oldValue);

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -26,6 +26,7 @@ export interface TokenManagerOptions {
   storageKey?: string;
   expireEarlySeconds?: number;
   syncStorage?: boolean;
+  syncStorageKey?: string;
   _storageEventDelay?: number;
 }
 export interface CustomUserAgent {

--- a/samples/generated/webpack-spa/src/index.js
+++ b/samples/generated/webpack-spa/src/index.js
@@ -135,13 +135,6 @@ function loadConfig() {
   var newConfig = {};
   Object.assign(newConfig, state);
   Object.assign(newConfig, {
-
-    tokenManager: {
-      expireEarlySeconds: 5*60,
-      syncStorage: true,
-    },
-    startService: true,
-
     // ephemeral options, will not survive a redirect
     appUri,
     redirectUri,
@@ -342,7 +335,6 @@ function startApp() {
   // Calculates initial auth state and fires change event for listeners
   // Also starts the token auto-renew service
   authClient.start();
-
 }
 
 function renderApp() {
@@ -452,13 +444,6 @@ window._getUserInfo = bindClick(getUserInfo);
 
 // called when the "renew token" link is clicked
 function renewToken() {
-
-
-  setTimeout( () => {
-    console.log('>>>>');
-    document.getElementById('renew-token').click();
-  }, (10 - new Date().getSeconds() % 10) * 1000 );
-
   // when the token is written to storage, the authState will change and we will re-render.
   return authClient.tokenManager.renew('accessToken')
     .catch(function(error) {

--- a/samples/generated/webpack-spa/src/index.js
+++ b/samples/generated/webpack-spa/src/index.js
@@ -135,6 +135,13 @@ function loadConfig() {
   var newConfig = {};
   Object.assign(newConfig, state);
   Object.assign(newConfig, {
+
+    tokenManager: {
+      expireEarlySeconds: 5*60,
+      syncStorage: true,
+    },
+    startService: true,
+
     // ephemeral options, will not survive a redirect
     appUri,
     redirectUri,
@@ -298,8 +305,11 @@ function main() {
   // Config is valid
   createAuthClient();
 
+  console.log('subscribing')
   // Subscribe to authState change event. Logic based on authState is done here.
   authClient.authStateManager.subscribe(function(authState) {
+    console.log('event about updated authState', authState)
+
     if (!authState.isAuthenticated) {
       // If not authenticated, reset values related to user session
       updateAppState({ userInfo: null });
@@ -335,10 +345,12 @@ function startApp() {
   // Calculates initial auth state and fires change event for listeners
   // Also starts the token auto-renew service
   authClient.start();
+
 }
 
 function renderApp() {
   const authState = authClient.authStateManager.getAuthState();
+  console.log('... authState', authState)
   document.getElementById('authState').innerText = stringify(authState);
 
   // Setting auth state is an asynchronous operation. If authState is not available yet, render in the loading state
@@ -444,6 +456,13 @@ window._getUserInfo = bindClick(getUserInfo);
 
 // called when the "renew token" link is clicked
 function renewToken() {
+
+
+  setTimeout( () => {
+    console.log('>>>>')
+    document.getElementById('renew-token').click()
+  }, (10 - new Date().getSeconds() % 10) * 1000 )
+
   // when the token is written to storage, the authState will change and we will re-render.
   return authClient.tokenManager.renew('accessToken')
     .catch(function(error) {

--- a/samples/generated/webpack-spa/src/index.js
+++ b/samples/generated/webpack-spa/src/index.js
@@ -305,11 +305,8 @@ function main() {
   // Config is valid
   createAuthClient();
 
-  console.log('subscribing')
   // Subscribe to authState change event. Logic based on authState is done here.
   authClient.authStateManager.subscribe(function(authState) {
-    console.log('event about updated authState', authState)
-
     if (!authState.isAuthenticated) {
       // If not authenticated, reset values related to user session
       updateAppState({ userInfo: null });
@@ -350,7 +347,6 @@ function startApp() {
 
 function renderApp() {
   const authState = authClient.authStateManager.getAuthState();
-  console.log('... authState', authState)
   document.getElementById('authState').innerText = stringify(authState);
 
   // Setting auth state is an asynchronous operation. If authState is not available yet, render in the loading state
@@ -459,9 +455,9 @@ function renewToken() {
 
 
   setTimeout( () => {
-    console.log('>>>>')
-    document.getElementById('renew-token').click()
-  }, (10 - new Date().getSeconds() % 10) * 1000 )
+    console.log('>>>>');
+    document.getElementById('renew-token').click();
+  }, (10 - new Date().getSeconds() % 10) * 1000 );
 
   // when the token is written to storage, the authState will change and we will re-render.
   return authClient.tokenManager.renew('accessToken')

--- a/test/spec/TokenManager/core.ts
+++ b/test/spec/TokenManager/core.ts
@@ -37,8 +37,9 @@ function createAuth(options) {
       storageKey: options.tokenManager.storageKey,
       autoRenew: options.tokenManager.autoRenew || false,
       autoRemove: options.tokenManager.autoRemove || false,
-      secure: options.tokenManager.secure // used by cookie storage
-    }
+      secure: options.tokenManager.secure, // used by cookie storage
+      syncStorage: false, // don't use SyncService
+    },
   });
 }
 

--- a/test/spec/TokenManager/crossTabs.ts
+++ b/test/spec/TokenManager/crossTabs.ts
@@ -221,11 +221,6 @@ describe('cross tabs renew', () => {
       const oldValue = JSON.stringify(syncStorageMap);
       syncStorageMap[k] = v;
       const newValue = JSON.stringify(syncStorageMap);
-      console.log('eeeeee  set', {
-        key: SYNC_STORAGE_NAME, 
-        newValue,
-        oldValue,
-      });
       if (typeof window !== 'undefined') {
         window.dispatchEvent(new StorageEvent('storage', {
           key: SYNC_STORAGE_NAME, 
@@ -238,11 +233,6 @@ describe('cross tabs renew', () => {
       const oldValue = JSON.stringify(syncStorageMap);
       delete syncStorageMap[k];
       const newValue = JSON.stringify(syncStorageMap);
-      console.log('eeeeee  remove', {
-        key: SYNC_STORAGE_NAME, 
-        newValue,
-        oldValue,
-      });
       if (typeof window !== 'undefined') {
         window.dispatchEvent(new StorageEvent('storage', {
           key: SYNC_STORAGE_NAME, 

--- a/test/spec/TokenManager/crossTabs.ts
+++ b/test/spec/TokenManager/crossTabs.ts
@@ -22,16 +22,24 @@ const Emitter = require('tiny-emitter');
 describe('cross tabs communication', () => {
   let sdkMock;
   let instance;
+  let syncStorage, syncStorageMap;
   beforeEach(function() {
     jest.useFakeTimers();
     instance = null;
     const emitter = new Emitter();
+    syncStorageMap = {};
+    syncStorage = {
+      getItem: jest.fn().mockImplementation((k) => syncStorageMap[k]),
+      setItem: jest.fn().mockImplementation((k, v) => syncStorageMap[k] = v),
+      removeItem: jest.fn().mockImplementation((k) => delete syncStorageMap[k]),
+    };
     sdkMock = {
       options: {},
       storageManager: {
         getTokenStorage: jest.fn().mockReturnValue({
           getStorage: jest.fn().mockReturnValue({})
         }),
+        getSyncStorage: jest.fn().mockReturnValue(syncStorage),
         getOptionsForSection: jest.fn().mockReturnValue({})
       },
       emitter

--- a/test/spec/TokenManager/crossTabs.ts
+++ b/test/spec/TokenManager/crossTabs.ts
@@ -23,8 +23,6 @@ import {
 
 const Emitter = require('tiny-emitter');
 
-/* global window, StorageEvent */
-
 describe('cross tabs communication', () => {
   let sdkMock;
   let instance;
@@ -280,13 +278,14 @@ describe('cross tabs renew', () => {
       },
       emitter
     };
-
-    const instance = new TokenManager(sdkMock as any, {
+    const options = {
       _storageEventDelay: 0,
       // disable because we start service
       autoRenew: false,
       autoRemove: false
-    });
+    };
+
+    const instance = new TokenManager(sdkMock as any, options);
     jest.spyOn(instance, 'setTokens');
     jest.spyOn(instance, 'remove').mockImplementation(() => {});
     jest.spyOn(instance, 'emitRenewed').mockImplementation(() => {});
@@ -319,7 +318,7 @@ describe('cross tabs renew', () => {
 
   it('works for 2 tabs', async () => {
     sharedTokenStorage.setStorage(testContext.storage);
-    const tabs = [...Array(2)].map(_ => createContext(sharedTokenStorage));
+    const tabs = [...Array(2)].map(() => createContext(sharedTokenStorage));
     tabs.map(c => c.instance.start());
 
     const renewPromises = tabs.map(c => c.instance.renew('idToken'));

--- a/test/spec/TokenManager/crossTabs.ts
+++ b/test/spec/TokenManager/crossTabs.ts
@@ -318,7 +318,6 @@ describe('cross tabs renew', () => {
 
 
   it('works for 2 tabs', async () => {
-    console.log('-------------- start');
     sharedTokenStorage.setStorage(testContext.storage);
     const tabs = [...Array(2)].map(_ => createContext(sharedTokenStorage));
     tabs.map(c => c.instance.start());
@@ -335,33 +334,7 @@ describe('cross tabs renew', () => {
     expect(renewTokensCalls).toEqual(1);
 
     tabs.map(c => c.instance.stop());
-    console.log('-------------- end');
   });
-
-  // it('race', async () => {
-  //   console.log('-------------- start');
-
-  //   sharedTokenStorage.setStorage(testContext.storage);
-  //   const tabs = [...Array(2)].map(_ => createContext(sharedTokenStorage));
-  //   tabs.map(c => c.instance.start());
-
-  //   const renewPromises = tabs.map(c => c.instance.renew('idToken'));
-  //   const res = await Promise.allSettled(renewPromises);
-
-  //   console.log(111, res)
-
-  //   tabs.map(c => c.instance.stop());
-
-  //   console.log('-------------- end');
-  // });
-
-  // todo: simulate race
-
-//what if no event EVENT_RENEWED_SYNC
-//_storageEventDelay
-
-  // todo: what if error ?
-
 
 });
 

--- a/test/spec/TokenManager/expireEvents.ts
+++ b/test/spec/TokenManager/expireEvents.ts
@@ -20,7 +20,6 @@ describe('expire events', () => {
         getTokenStorage: jest.fn().mockReturnValue({
           getStorage: jest.fn().mockImplementation(() => testContext.storage)
         }),
-        getSyncStorage: jest.fn().mockReturnValue(null),
       },
       emitter
     };

--- a/test/spec/TokenManager/expireEvents.ts
+++ b/test/spec/TokenManager/expireEvents.ts
@@ -20,6 +20,7 @@ describe('expire events', () => {
         getTokenStorage: jest.fn().mockReturnValue({
           getStorage: jest.fn().mockImplementation(() => testContext.storage)
         }),
+        getSyncStorage: jest.fn().mockReturnValue(null),
       },
       emitter
     };

--- a/test/spec/TokenManager/remove.ts
+++ b/test/spec/TokenManager/remove.ts
@@ -15,6 +15,7 @@ describe('TokenManager remove', () => {
       options: {},
       storageManager: {
         getTokenStorage: jest.fn().mockReturnValue(tokenStorage),
+        getSyncStorage: jest.fn().mockReturnValue(null),
       },
       emitter
     };

--- a/test/spec/TokenManager/remove.ts
+++ b/test/spec/TokenManager/remove.ts
@@ -15,7 +15,6 @@ describe('TokenManager remove', () => {
       options: {},
       storageManager: {
         getTokenStorage: jest.fn().mockReturnValue(tokenStorage),
-        getSyncStorage: jest.fn().mockReturnValue(null),
       },
       emitter
     };

--- a/test/spec/TokenManager/renew.ts
+++ b/test/spec/TokenManager/renew.ts
@@ -25,6 +25,7 @@ describe('TokenManager renew', () => {
       },
       storageManager: {
         getTokenStorage: jest.fn().mockReturnValue(tokenStorage),
+        getSyncStorage: jest.fn().mockReturnValue(null),
       },
       emitter
     };

--- a/test/spec/TokenManager/renew.ts
+++ b/test/spec/TokenManager/renew.ts
@@ -13,10 +13,16 @@ describe('TokenManager renew', () => {
   let testContext;
 
   beforeEach(function() {
+    const syncStorageMap = {};
     const emitter = new Emitter();
     const tokenStorage = {
         getStorage: jest.fn().mockImplementation(() => testContext.storage),
         setStorage: jest.fn().mockImplementation(() => {})
+    };
+    const syncStorage = {
+      getItem: jest.fn().mockImplementation((k) => syncStorageMap[k]),
+      setItem: jest.fn().mockImplementation((k, v) => syncStorageMap[k] = v),
+      removeItem: jest.fn().mockImplementation((k) => delete syncStorageMap[k]),
     };
     const sdkMock = {
       options: {},
@@ -25,7 +31,7 @@ describe('TokenManager renew', () => {
       },
       storageManager: {
         getTokenStorage: jest.fn().mockReturnValue(tokenStorage),
-        getSyncStorage: jest.fn().mockReturnValue(null),
+        getSyncStorage: jest.fn().mockReturnValue(syncStorage),
       },
       emitter
     };

--- a/test/spec/TokenManager/renew.ts
+++ b/test/spec/TokenManager/renew.ts
@@ -3,89 +3,34 @@ import tokens from '@okta/test.support/tokens';
 import { 
   OktaAuth, 
   TOKEN_STORAGE_NAME,
-  SYNC_STORAGE_NAME
 } from '../../../lib';
 import { AuthApiError, AuthSdkError, OAuthError } from '../../../lib/errors';
 import { TokenManager } from '../../../lib/TokenManager';
-
-/* global window, StorageEvent */
 
 const Emitter = require('tiny-emitter');
 
 describe('TokenManager renew', () => {
   let testContext;
-  // syncStorage is shared (simulate LocalStorage which is shared across tabs)
-  let syncStorageMap = {};
-  let sharedTokenMap = {};
-  const syncStorage = {
-    getItem: jest.fn().mockImplementation((k) => syncStorageMap[k]),
-    setItem: jest.fn().mockImplementation((k, v) => {
-      const oldValue = JSON.stringify(syncStorageMap);
-      syncStorageMap[k] = v;
-      const newValue = JSON.stringify(syncStorageMap);
-      console.log('eeeeee  set', {
-        key: SYNC_STORAGE_NAME, 
-        newValue,
-        oldValue,
-      });
-      if (typeof window === 'undefined') {
-        return;
-      }
-      window.dispatchEvent(new StorageEvent('storage', {
-        key: SYNC_STORAGE_NAME, 
-        newValue,
-        oldValue,
-      }));
-    }),
-    removeItem: jest.fn().mockImplementation((k) => {
-      const oldValue = JSON.stringify(syncStorageMap);
-      delete syncStorageMap[k];
-      const newValue = JSON.stringify(syncStorageMap);
-      console.log('eeeeee  remove', {
-        key: SYNC_STORAGE_NAME, 
-        newValue,
-        oldValue,
-      });
-      if (typeof window === 'undefined') {
-        return;
-      }
-      window.dispatchEvent(new StorageEvent('storage', {
-        key: SYNC_STORAGE_NAME, 
-        newValue,
-        oldValue,
-      }));
-    }),
-  };
-  const sharedTokenStorage = {
-    getStorage: jest.fn().mockImplementation(() => sharedTokenMap),
-    setStorage: jest.fn().mockImplementation((v) => { sharedTokenMap = v; })
-  };
 
-  const createContext = (tokenStorage?) => {
-    let testContext;
-
+  beforeEach(function() {
     const emitter = new Emitter();
-    if (!tokenStorage) {
-      tokenStorage = {
-          getStorage: jest.fn().mockImplementation(() => testContext.storage),
-          setStorage: jest.fn().mockImplementation(() => {})
-      };
-    }
+    const tokenStorage = {
+        getStorage: jest.fn().mockImplementation(() => testContext.storage),
+        setStorage: jest.fn().mockImplementation(() => {})
+    };
     const sdkMock = {
       options: {},
       token: {
-        renewTokens: jest.fn().mockImplementation(() => Promise.resolve(testContext.freshTokens))
+        renewTokens: () => Promise.resolve(testContext.freshTokens)
       },
       storageManager: {
         getTokenStorage: jest.fn().mockReturnValue(tokenStorage),
-        getSyncStorage: jest.fn().mockReturnValue(syncStorage),
+        getSyncStorage: jest.fn().mockReturnValue(null),
       },
       emitter
     };
 
-    const instance = new TokenManager(sdkMock as any, {
-      _storageEventDelay: 0
-    });
+    const instance = new TokenManager(sdkMock as any);
     jest.spyOn(instance, 'setTokens');
     jest.spyOn(instance, 'remove').mockImplementation(() => {});
     jest.spyOn(instance, 'emitRenewed').mockImplementation(() => {});
@@ -105,41 +50,7 @@ describe('TokenManager renew', () => {
         idToken: tokens.standardIdToken2Parsed
       }
     };
-
-    return testContext;
-  };
-
-  beforeEach(function() {
-    syncStorageMap = {};
-    sharedTokenMap = {};
-    testContext = createContext();
-  });
-
-  describe('cross tabs', () => {
-    it('works for 2 tabs', async () => {
-      console.log('-------------- start');
-      sharedTokenStorage.setStorage(testContext.storage);
-      const tabs = [...Array(2)].map(_ => createContext(sharedTokenStorage));
-      tabs.map(c => c.instance.start());
-
-      const renewPromises = tabs.map(c => c.instance.renew('idToken'));
-      const res = await Promise.allSettled(renewPromises);
-
-      res.map(r => {
-        expect(r.status).toBe('fulfilled');
-        expect((r as any).value).toMatchObject(testContext.freshTokens.idToken);
-      });
-      
-      const renewTokensCalls = tabs.map(c => c.sdkMock.token.renewTokens.mock.calls.length).reduce((v, c) => (c + v), 0);
-      expect(renewTokensCalls).toEqual(1);
-
-      tabs.map(c => c.instance.stop());
-      console.log('-------------- end');
-    });
-
-    // todo: simulate race
-
-    // todo: what if error ?
+    
   });
 
   it('returns the fresh token', async () => {


### PR DESCRIPTION
Addresses issue https://github.com/okta/okta-auth-js/issues/1001

Internal ref: https://oktainc.atlassian.net/browse/OKTA-445148

Problem: When using `localStorage` as token storage with `syncStorage: true` and a user opens many tabs, the timer for token renewal will fire simultaneously in all tabs. Simultaneous requests can cause HTTP 429 (rate limit).

Proposed solution: As token renew should produce the same result in case of `syncStorage`, the optimal approach would be to run renew request in 1 tab and wait for it in other tabs.

For cross-tabs synchronization, we can use `localStorage` to store "lock item" (by key `okta-sync`). After item update, the `StorageEvent` will be triggered in all tabs. 
One caveat is there still can be race condition: if tab A reads lock item in local storage, receives null and immediately updates lock item  to some value, and tab B tries to do the same, they can both update item, one of tab will be winner. As there is no native mutex in JS, proposed algorithm is:

Given tab A and tab B run `TokenManager.renew('accessToken')` at the same time.

1.  Tab A reads lock item (`okta-sync`) from localStorage. (Lock item value is object, we are looking for key `accessToken` : same key as target token type to renew)
1.a. If value is null, set value to `{date, tabId}` where `tabId` is unique random identifier for tab A
1.b. If value is not null, this means there is some other tab currently processing token renew. Need to wait, see **`Wait`**
2. Wait for short period of time (5ms) to detect possible race condition.
3. Read value again. 
3.a. If `tabId` is same, it means there was no race condition or tab A won it (as the last that updated item).
So tab A can continue with actual token renew request. After renew is complete, set item value to null (in other words release lock). Done.
3.b. If `tabId` is not same, there is race condition with other tab, need to wait, see **`Wait`**


 **`Wait`**
1. Tab B does actual token renewal. On success it will save fresh tokens to local storage and set "lock item" value to null.
2. Tab A is listening to change of "lock item" (see `storageListener` in `TokenService`). Removing item `accessToken` in tab B will result to triggering `EVENT_RENEWED_SYNC` event in tab `A`
3. Get fresh token from token storage  (should be updated by tab B already). Resolve renew promise with this new value. Done.

Note 1: If event `EVENT_RENEWED_SYNC` would not fire in 10s for some reason (closing of tab B or error), reject renewal promise
Note 2: `date` in "lock item" value is used to release stalled "lock item" (if tab B is closed)