### PR TITLE
Add support of activationToken

### DIFF
--- a/docs/idx.md
+++ b/docs/idx.md
@@ -254,6 +254,19 @@ const {
 } = await authClient.idx.register({ password: 'xxx' });
 ```
 
+**Account activation**:
+
+```js
+const { 
+  status, // IdxStatus.SUCCESS
+  tokens 
+} = await authClient.idx.register({
+  activationToken: 'xxxxx',
+  authenticator: 'okta_password',
+  password: 'xxx'
+});
+```
+
 #### `idx.recoverPassword`
 
 The convenience method for `self service password recovery` flow.

--- a/lib/idx/interact.ts
+++ b/lib/idx/interact.ts
@@ -18,6 +18,7 @@ import { getOAuthBaseUrl } from '../oidc';
 export interface InteractOptions {
   state?: string;
   scopes?: string[];
+  activationToken?: string;
 }
 
 export interface InteractResponse {
@@ -54,6 +55,9 @@ export async function interact (authClient: OktaAuth, options: InteractOptions =
   state = state || meta.state;
   const scopes = options.scopes || authClient.options.scopes || meta.scopes;
 
+  // These properties can be set in options
+  const { activationToken } = options;
+
   const baseUrl = getOAuthBaseUrl(authClient);
   return idx.interact({
     // OAuth
@@ -65,7 +69,10 @@ export async function interact (authClient: OktaAuth, options: InteractOptions =
 
     // PKCE
     codeChallenge,
-    codeChallengeMethod
+    codeChallengeMethod,
+    
+    // Magic Link
+    activationToken
   }).then(interactionHandle => {
     const newMeta = {
       ...meta,

--- a/lib/idx/register.ts
+++ b/lib/idx/register.ts
@@ -43,9 +43,13 @@ export async function register(
 ): Promise<IdxTransaction> {
   // Only check at the beginning of the transaction
   if (!transactionMetaExist(authClient)) {
-    const { enabledFeatures } = await startTransaction(authClient, { flow: 'register', ...options });
-    if (enabledFeatures && !enabledFeatures.includes(IdxFeature.REGISTRATION)) {
+    const { enabledFeatures, availableSteps } = await startTransaction(authClient, { flow: 'register', ...options });
+    if (!options.activationToken && enabledFeatures && !enabledFeatures.includes(IdxFeature.REGISTRATION)) {
       const error = new AuthSdkError('Registration is not supported based on your current org configuration.');
+      return { status: IdxStatus.FAILURE, error };
+    }
+    if (options.activationToken && availableSteps?.some(({ name }) => name === 'identify')) {
+      const error = new AuthSdkError('activationToken is not supported based on your current org configuration.');
       return { status: IdxStatus.FAILURE, error };
     }
   }

--- a/lib/idx/register.ts
+++ b/lib/idx/register.ts
@@ -39,7 +39,7 @@ export type RegistrationOptions = IdxOptions
   & SkipValues;
 
 export async function register(
-  authClient: OktaAuth, options: RegistrationOptions
+  authClient: OktaAuth, options: RegistrationOptions = {}
 ): Promise<IdxTransaction> {
   // Only check at the beginning of the transaction
   if (!transactionMetaExist(authClient)) {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@okta/okta-idx-js": "0.22.0",
+    "@okta/okta-idx-js": "0.23.0",
     "@peculiar/webcrypto": "1.1.6",
     "Base64": "1.1.0",
     "atob": "^2.1.2",

--- a/test/spec/idx/headers.ts
+++ b/test/spec/idx/headers.ts
@@ -81,7 +81,7 @@ describe('idx headers', () => {
         }),
         credentials: 'include',
         headers: {
-          'X-Okta-User-Agent-Extended': 'okta-idx-js/0.22.0',
+          'X-Okta-User-Agent-Extended': 'okta-idx-js/0.23.0',
           'accept': 'application/ion+json; okta-version=fake-version',
           'content-type': 'application/ion+json; okta-version=fake-version',
         },
@@ -101,7 +101,7 @@ describe('idx headers', () => {
         }),
         credentials: 'include',
         headers: {
-          'X-Okta-User-Agent-Extended': 'okta-idx-js/0.22.0',
+          'X-Okta-User-Agent-Extended': 'okta-idx-js/0.23.0',
           'accept': 'application/ion+json; okta-version=fake-version',
           'content-type': 'application/ion+json; okta-version=fake-version',
         },

--- a/test/spec/idx/interact.ts
+++ b/test/spec/idx/interact.ts
@@ -147,6 +147,35 @@ describe('idx/interact', () => {
       });
     });
 
+    it('uses activationToken from function options', async () => {
+      const { authClient } = testContext;
+      const res = await interact(authClient, { activationToken: 'fn-activationToken' });
+      expect(mocked.idx.interact).toHaveBeenCalledWith({
+        'clientId': 'authClient-clientId',
+        'baseUrl': 'authClient-issuer/oauth2',
+        'codeChallenge': 'meta-codeChallenge',
+        'codeChallengeMethod': 'meta-codeChallengeMethod',
+        'redirectUri': 'authClient-redirectUri',
+        'scopes': ['authClient'],
+        'state': 'authClient-state',
+        'activationToken': 'fn-activationToken'
+      });
+      expect(res).toEqual({
+        'interactionHandle': 'idx-interactionHandle',
+        'meta': {
+          'codeChallenge': 'meta-codeChallenge',
+          'codeChallengeMethod': 'meta-codeChallengeMethod',
+          'codeVerifier': 'meta-codeVerifier',
+          'interactionHandle': 'idx-interactionHandle',
+          'scopes': [
+            'authClient',
+          ],
+          'state': 'authClient-state',
+        },
+        'state': 'authClient-state',
+      });
+    });
+
     it('saves returned interactionHandle', async () => {
       const { authClient } = testContext;
       jest.spyOn(mocked.transactionMeta, 'saveTransactionMeta');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2372,10 +2372,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@okta/okta-idx-js@0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-idx-js/-/okta-idx-js-0.22.0.tgz#c5dbebd155be2c8a8e2bbceb2e92701b6ba59349"
-  integrity sha512-SehJVwQI51xWrB1YaMn6UB54cOzhrM7z5k2xOI62I3B7qOQ3uFOZJvRCJnBcZ6TEcQuqJ3/6q93h6n8omw0tVQ==
+"@okta/okta-idx-js@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-idx-js/-/okta-idx-js-0.23.0.tgz#894bce38922537b27f168c78c38b6df3f203f419"
+  integrity sha512-aw4zAuP+xkZPxUXk2yTWLpuQZfGusuoWXyvb1QSMWTNQ4CAwZN40nlurBYOYqYOwQjj1MGqUxEgtDGVQYITcDQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.5"


### PR DESCRIPTION
- Updates `okta-idx-js 0.23.0`
- Accepts `activationToken` in `options` argument to `idx.interact`. Added unit tests.
- Accepts `activationToken` in `idx.register` for activation flow
- Added to `test/apps/app` the examples of usage this feature 
  - with SIW (get `interactionHandle` with `idx.interact({ activationToken })` and continue flow in SIW)
  - with IDX API (enroll user in password authenticator with new `idx.activate()`)

Tested on CT11 account. 

Internal ref: [OKTA-436601](https://oktainc.atlassian.net/browse/OKTA-436601) 
