### PR TITLE
Catch renew promise rejection in isAuthenticated()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - [#1028](https://github.com/okta/okta-auth-js/pull/1028) Any error caught in `token.renew()` will be emitted and contain `tokenKey` property
+- [#1027](https://github.com/okta/okta-auth-js/pull/1027) Don't reject `isAuthenticated()` because of failed token renewal
 
 ## 5.9.1
 

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -544,7 +544,11 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
     if (accessToken && this.tokenManager.hasExpired(accessToken)) {
       accessToken = null;
       if (autoRenew) {
-        accessToken = await this.tokenManager.renew('accessToken') as AccessToken;
+        try {
+          accessToken = await this.tokenManager.renew('accessToken') as AccessToken;
+        } catch {
+          // Renew errors will emit an "error" event 
+        }
       } else if (autoRemove) {
         this.tokenManager.remove('accessToken');
       }
@@ -553,7 +557,11 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
     if (idToken && this.tokenManager.hasExpired(idToken)) {
       idToken = null;
       if (autoRenew) {
-        idToken = await this.tokenManager.renew('idToken') as IDToken;
+        try {
+          idToken = await this.tokenManager.renew('idToken') as IDToken;
+        } catch {
+          // Renew errors will emit an "error" event 
+        }
       } else if (autoRemove) {
         this.tokenManager.remove('idToken');
       }


### PR DESCRIPTION
Don't throw error in `isAuthenticated()` because of failed token renew (if `autoRenew` if true).
Renew error events will be triggered anyway and can be caught with `authClient.tokenManager.on('error', myHandler)`

Resolves https://github.com/okta/okta-auth-js/issues/977
Internal ref: https://oktainc.atlassian.net/browse/OKTA-439435
