### PR TITLE
Emit any AuthApiError from renew()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## 5.10.0
 
+### Features
+
 - [#1010](https://github.com/okta/okta-auth-js/pull/1010) Supports `clearPendingRemoveTokens` option in `signOut` method. This option can be used to avoid cross tabs sign out issue with Okta's downstream client SDK's `SecureRoute` component
 - [#1035](https://github.com/okta/okta-auth-js/pull/1035) Adds `security question` authenticator support in idx module
+
+### Fixes
+
+- [#1028](https://github.com/okta/okta-auth-js/pull/1028) Any error caught in `token.renew()` will be emitted and contain `tokenKey` property
 
 ## 5.9.1
 

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -426,9 +426,8 @@ export class TokenManager implements TokenManagerInterface {
         if (isRefreshTokenError(err) || err.name === 'OAuthError' || err.name === 'AuthSdkError') {
           // remove token from storage
           this.remove(key);
-          
-          err.tokenKey = key;
         }
+        err.tokenKey = key;
         this.emitError(err);
         throw err;
       })

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -428,8 +428,8 @@ export class TokenManager implements TokenManagerInterface {
           this.remove(key);
           
           err.tokenKey = key;
-          this.emitError(err);
         }
+        this.emitError(err);
         throw err;
       })
       .finally(() => {

--- a/test/spec/TokenManager/core.ts
+++ b/test/spec/TokenManager/core.ts
@@ -345,6 +345,7 @@ describe('TokenManager', function() {
           util.expectErrorToEqual(result.reason, {
             name: 'Error',
             message: 'expected',
+            tokenKey: 'test-idToken'
           });
         });
       });
@@ -374,6 +375,7 @@ describe('TokenManager', function() {
         util.expectErrorToEqual(err, {
           name: 'Error',
           message: 'expected',
+          tokenKey: 'test-idToken'
         });
         var p2 = client.tokenManager.renew('test-idToken');
         expect(p1).not.toBe(p2);
@@ -384,6 +386,7 @@ describe('TokenManager', function() {
         util.expectErrorToEqual(err, {
           name: 'Error',
           message: 'expected',
+          tokenKey: 'test-idToken'
         });
       });
       return p1;

--- a/test/spec/TokenManager/renew.ts
+++ b/test/spec/TokenManager/renew.ts
@@ -192,6 +192,25 @@ describe('TokenManager renew', () => {
       expect(testContext.error.tokenKey).toBe('idToken');
     });
 
+    it('Other AuthApiError', async () => {
+      testContext.error = new AuthApiError({
+        errorSummary: 'Not Found'
+      }, {
+        status: 404,
+        responseText: 'Not Found',
+        headers: {}
+      });
+      try {
+        await testContext.instance.renew('idToken');
+      } catch (e) {
+        expect(e).toMatchObject({
+          name: 'AuthApiError'
+        });
+      }
+      expect(testContext.instance.remove).not.toHaveBeenCalledWith('idToken');
+      expect(testContext.instance.emitError).toHaveBeenCalledWith(testContext.error);
+    });
+
   });
 
 });


### PR DESCRIPTION
- Emit any error from `renew()` (not only `OAuthError` / `AuthSdkError` / `AuthApiError` with `invalid_grant`, other `AuthApiError`s will be emitted too)
- Add `tokenKey` to all errors when emitting

Resolves https://github.com/okta/okta-auth-js/issues/987
Internal ref: [OKTA-440715](https://oktainc.atlassian.net/browse/OKTA-440715)