### PR TITLE
fix: browser field point to UMD bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
   "license": "Apache-2.0",
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
-  "browser": {
-    "build/cjs/index.js": "./build/dist/okta-auth-js.umd.js"
-  },
+  "browser": "build/dist/okta-auth-js.umd.js",
   "types": "build/lib/index.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
incorrect value in the field was causing fallback to CJS, leading to inclusion of node code. OKTA-458043