### PR TITLE
revert: BREAKING CHANGE: bump min node version to 12.20 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Breaking Changes
 
 - [#1003](https://github.com/okta/okta-auth-js/pull/1003) Supports generic UserClaims type. Custom claims should be extended by typescript generics, like `UserClaims<{ groups: string[]; }>`
-- [#1049](https://github.com/okta/okta-auth-js/pull/1049) Bump minimum supported node version to 12.20
 - [#1050](https://github.com/okta/okta-auth-js/pull/1050) Removes `userAgent` field from oktaAuth instance
 - [#1014](https://github.com/okta/okta-auth-js/pull/1014) Shared transaction storage is automatically cleared on success and error states. Storage is not cleared for "terminal" state which is neither success nor error.
 - [#1051](https://github.com/okta/okta-auth-js/pull/1051) Removes `useMultipleCookies` from CookieStorage options

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "not IE_Mob 11"
   ],
   "engines": {
-    "node": ">=12.20",
+    "node": ">=11.0",
     "yarn": "^1.7.0"
   },
   "dependencies": {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,7 +5,7 @@ export PATH="${PATH}:$(yarn global bin)"
 
 # Install required node version
 export NVM_DIR="/root/.nvm"
-setup_service node v12.20.0
+setup_service node v12.13.0
 
 cd ${OKTA_HOME}/${REPO}
 


### PR DESCRIPTION
This reverts commit d053eee78c4d539847c4f29c090663d6c2636cb4.

We can bundle `p-cancelable` into the generated bundles with `@rollup/plugin-node-resolve` and `@rollup/plugin-commonjs`, no version upgrade will be needed.