### PR TITLE
feat: allow passing device context to interact call

### DIFF
--- a/test/spec/OktaAuth/constructor.ts
+++ b/test/spec/OktaAuth/constructor.ts
@@ -162,22 +162,6 @@ describe('OktaAuth (constructor)', () => {
     });
   });
 
-  // TODO: remove in 6.0
-  describe('userAgent', () => {
-    let sdkVersion;
-    beforeEach(async () => {
-      sdkVersion = (await import('../../../package.json')).version;
-    });
-
-    // browser env is tested in "./browser.ts"
-    it('initials userAgent field for node env', () => {
-      jest.spyOn(mocked.features, 'isBrowser').mockReturnValue(false);
-      const config = { issuer: 'http://fake' };
-      const oa = new OktaAuth(config);
-      expect(oa.userAgent).toBe(`okta-auth-js-server/${sdkVersion}`);
-    });
-  });
-
   it('sets global headers for idx requests', () => {
     const config = { issuer: 'http://fake' };
     // eslint-disable-next-line no-new

--- a/test/spec/idx/headers.ts
+++ b/test/spec/idx/headers.ts
@@ -28,7 +28,11 @@ jest.mock('cross-fetch', () => {
 
 import idx from '@okta/okta-idx-js';
 import { setRequestHeader } from '../../../lib/http';
-import { createGlobalRequestInterceptor, setGlobalRequestInterceptor } from '../../../lib/idx/headers';
+import { 
+  createGlobalRequestInterceptor, 
+  setGlobalRequestInterceptor,
+  clearGlobalRequestInterceptor 
+} from '../../../lib/idx/headers';
 const idxPackageJSON = require('@okta/okta-idx-js/package.json');
 
 describe('idx headers', () => {
@@ -117,6 +121,10 @@ describe('idx headers', () => {
       setGlobalRequestInterceptor(createGlobalRequestInterceptor(sdk));
     });
 
+    afterEach(() => {
+      clearGlobalRequestInterceptor();
+    });
+
     it('idx uses header values set in SDK options and SDK user agent', async () => {
       const { sdk } = testContext;
       sdk.options.headers = {
@@ -187,6 +195,54 @@ describe('idx headers', () => {
         },
         method: 'POST'
       });
+    });
+
+    describe('"X-Device-Token" header', () => {
+      it('idx uses header when clientSecret is in sdk.options', async () => {
+        const { sdk } = testContext;
+        sdk.options.headers = {
+          'X-Device-Token': 'fake-ip',
+        };
+        sdk.options.clientSecret = 'fake-clientSecret';
+        jest.spyOn(mocked.crossFetch, 'default');
+        await callIntrospect();
+        expect(mocked.crossFetch.default).toHaveBeenCalledWith('fake-domain/idp/idx/introspect', {
+          body: JSON.stringify({
+            stateToken: 'fake-stateHandle'
+          }),
+          credentials: 'include',
+          headers: {
+            'X-Okta-User-Agent-Extended': 'fake-sdk-user-agent',
+            'X-Device-Token': 'fake-ip',
+            'accept': 'application/ion+json; okta-version=fake-version',
+            'content-type': 'application/ion+json; okta-version=fake-version'
+          },
+          method: 'POST'
+        });
+      });
+
+      it('idx does not use header when clientSecret is not in options', async () => {
+        const { sdk } = testContext;
+        sdk.options.headers = {
+          'X-Device-Token': 'fake-ip',
+        };
+        sdk.options.clientSecret = undefined;
+        jest.spyOn(mocked.crossFetch, 'default');
+        await callIntrospect();
+        expect(mocked.crossFetch.default).toHaveBeenCalledWith('fake-domain/idp/idx/introspect', {
+          body: JSON.stringify({
+            stateToken: 'fake-stateHandle'
+          }),
+          credentials: 'include',
+          headers: {
+            'X-Okta-User-Agent-Extended': 'fake-sdk-user-agent',
+            'accept': 'application/ion+json; okta-version=fake-version',
+            'content-type': 'application/ion+json; okta-version=fake-version'
+          },
+          method: 'POST'
+        });
+      });
+
     });
   });
 });


### PR DESCRIPTION
This feature has been supported with `headers` in config or `setHeaders` method. 
This change handles a special case for `X-Device-Token` header and adds more tests.