### PR TITLE
chore: extends lib lint from eslint-plugin-import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,6 +78,10 @@ module.exports = {
         // https://github.com/import-js/eslint-plugin-import#typescript
         'import',
       ],
+      extends: [
+        'plugin:import/recommended',
+        'plugin:import/typescript'
+      ],
       parser: "@typescript-eslint/parser",
       parserOptions: {
         project: "./tsconfig.json",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,7 +101,8 @@ module.exports = {
         'node/no-unsupported-features/es-builtins': ['error', {
           // features that are not supported before v12 are transformed in babel.cjs.js for commonjs output
           version: '>=12.0.0'
-        }]
+        }],
+        'import/no-commonjs': 'error'
       },
       settings: {
         // https://github.com/import-js/eslint-plugin-import#typescript

--- a/lib/AuthStateManager.ts
+++ b/lib/AuthStateManager.ts
@@ -16,6 +16,7 @@ import { AuthState, AuthStateLogOptions } from './types';
 import { OktaAuth } from '.';
 import { getConsole } from './util';
 import { EVENT_ADDED, EVENT_REMOVED } from './TokenManager';
+// eslint-disable-next-line import/no-commonjs
 const PCancelable = require('p-cancelable');
 
 export const INITIAL_AUTH_STATE = null;

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -134,6 +134,7 @@ import {
   isTransactionMetaValid
 } from './idx/transactionMeta';
 
+// eslint-disable-next-line import/no-commonjs
 const Emitter = require('tiny-emitter');
 
 class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -19,7 +19,7 @@ import {
 } from './constants';
 import * as constants from './constants';
 import {
-  OktaAuth as SDKInterface,
+  OktaAuthInterface,
   OktaAuthOptions, 
   AccessToken, 
   IDToken,
@@ -101,7 +101,7 @@ import { get, httpRequest, setRequestHeader } from './http';
 import PromiseQueue from './PromiseQueue';
 import fingerprint from './browser/fingerprint';
 import { AuthStateManager } from './AuthStateManager';
-import StorageManager from './StorageManager';
+import { StorageManager } from './StorageManager';
 import TransactionManager from './TransactionManager';
 import { buildOptions } from './options';
 import {
@@ -136,7 +136,7 @@ import {
 
 const Emitter = require('tiny-emitter');
 
-class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
+class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
   options: OktaAuthOptions;
   storageManager: StorageManager;
   transactionManager: TransactionManager;

--- a/lib/StorageManager.ts
+++ b/lib/StorageManager.ts
@@ -45,7 +45,7 @@ function logServerSideMemoryStorageWarning(options: StorageOptions) {
   }
 }
 
-export default class StorageManager {
+export class StorageManager {
   storageManagerOptions: StorageManagerOptions;
   cookieOptions: CookieOptions;
   storageUtil: StorageUtil;

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -14,7 +14,6 @@ import { removeNils, clone } from './util';
 import { AuthSdkError } from './errors';
 import { validateToken  } from './oidc/util';
 import { isLocalhost, isIE11OrLess } from './features';
-import { TOKEN_STORAGE_NAME } from './constants';
 import SdkClock from './clock';
 import {
   EventEmitter,
@@ -27,14 +26,14 @@ import {
   isRefreshToken,
   StorageOptions,
   StorageType,
-  OktaAuth,
+  OktaAuthInterface,
   StorageProvider,
   TokenManagerErrorEventHandler,
   TokenManagerEventHandler,
   TokenManagerInterface,
   RefreshToken
 } from './types';
-import { REFRESH_TOKEN_STORAGE_KEY } from './constants';
+import { REFRESH_TOKEN_STORAGE_KEY, TOKEN_STORAGE_NAME } from './constants';
 import { TokenService } from './services/TokenService';
 
 const DEFAULT_OPTIONS = {
@@ -64,7 +63,7 @@ function defaultState(): TokenManagerState {
   };
 }
 export class TokenManager implements TokenManagerInterface {
-  private sdk: OktaAuth;
+  private sdk: OktaAuthInterface;
   private clock: SdkClock;
   private emitter: EventEmitter;
   private storage: StorageProvider;
@@ -75,7 +74,7 @@ export class TokenManager implements TokenManagerInterface {
   on: (event: string, handler: TokenManagerErrorEventHandler | TokenManagerEventHandler, context?: object) => void;
   off: (event: string, handler?: TokenManagerErrorEventHandler | TokenManagerEventHandler) => void;
 
-  constructor(sdk: OktaAuth, options: TokenManagerOptions = {}) {
+  constructor(sdk: OktaAuthInterface, options: TokenManagerOptions = {}) {
     this.sdk = sdk;
     this.emitter = (sdk as any).emitter;
     if (!this.emitter) {

--- a/lib/TransactionManager.ts
+++ b/lib/TransactionManager.ts
@@ -13,7 +13,7 @@
 
 import { AuthSdkError } from './errors';
 import { REDIRECT_NONCE_COOKIE_NAME, REDIRECT_OAUTH_PARAMS_NAME, REDIRECT_STATE_COOKIE_NAME } from './constants';
-import StorageManager from './StorageManager';
+import { StorageManager } from './StorageManager';
 import {
   StorageProvider,
   TransactionMeta,

--- a/lib/browser/browserStorage.ts
+++ b/lib/browser/browserStorage.ts
@@ -25,6 +25,7 @@ import {
 } from '../types';
 import { warn } from '../util';
 
+// eslint-disable-next-line import/no-commonjs
 const Cookies = require('js-cookie');
 
 // Building this as an object allows us to mock the functions in our tests

--- a/lib/browser/fingerprint.ts
+++ b/lib/browser/fingerprint.ts
@@ -11,16 +11,15 @@
  */
 
 
-import { OktaAuth } from '../types';
 import { AuthSdkError } from '../errors';
 import { isFingerprintSupported } from '../features';
 import {
   addListener,
   removeListener
 } from '../oidc';
-import { FingerprintOptions } from '../types';
+import { FingerprintOptions, OktaAuthInterface } from '../types';
 
-export default function fingerprint(sdk: OktaAuth, options?: FingerprintOptions): Promise<string> {
+export default function fingerprint(sdk: OktaAuthInterface, options?: FingerprintOptions): Promise<string> {
   options = options || {};
 
   if (!isFingerprintSupported()) {

--- a/lib/http/headers.ts
+++ b/lib/http/headers.ts
@@ -10,9 +10,9 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-import { OktaAuth } from '../types';
+import { OktaAuthInterface } from '../types';
 
-export function setRequestHeader(authClient: OktaAuth, headerName, headerValue) {
+export function setRequestHeader(authClient: OktaAuthInterface, headerName, headerValue) {
   authClient.options.headers = authClient.options.headers || {};
   authClient.options.headers[headerName] = headerValue;
 }

--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -16,9 +16,9 @@
 import { isString, clone, isAbsoluteUrl, removeNils } from '../util';
 import AuthApiError from '../errors/AuthApiError';
 import { STATE_TOKEN_KEY_NAME, DEFAULT_CACHE_DURATION } from '../constants';
-import { OktaAuth, RequestOptions, FetchOptions, RequestData } from '../types';
+import { OktaAuthInterface, RequestOptions, FetchOptions, RequestData } from '../types';
 
-export function httpRequest(sdk: OktaAuth, options: RequestOptions): Promise<any> {
+export function httpRequest(sdk: OktaAuthInterface, options: RequestOptions): Promise<any> {
   options = options || {};
   var url = options.url,
       method = options.method,
@@ -117,7 +117,7 @@ export function httpRequest(sdk: OktaAuth, options: RequestOptions): Promise<any
     });
 }
 
-export function get(sdk: OktaAuth, url: string, options?: RequestOptions) {
+export function get(sdk: OktaAuthInterface, url: string, options?: RequestOptions) {
   url = isAbsoluteUrl(url) ? url : sdk.getIssuerOrigin() + url;
   var getOptions = {
     url: url,
@@ -127,7 +127,7 @@ export function get(sdk: OktaAuth, url: string, options?: RequestOptions) {
   return httpRequest(sdk, getOptions);
 }
 
-export function post(sdk: OktaAuth, url: string, args?: RequestData, options?: RequestOptions) {
+export function post(sdk: OktaAuthInterface, url: string, args?: RequestData, options?: RequestOptions) {
   url = isAbsoluteUrl(url) ? url : sdk.getIssuerOrigin() + url;
   var postOptions = {
     url: url,

--- a/lib/idx/authenticate.ts
+++ b/lib/idx/authenticate.ts
@@ -12,7 +12,7 @@
 
 
 import { 
-  OktaAuth,
+  OktaAuthInterface,
   IdxOptions,
   IdxTransaction,
   AuthenticatorKey
@@ -38,7 +38,7 @@ export type AuthenticationOptions = IdxOptions
   & EnrollAuthenticatorValues;
 
 export async function authenticate(
-  authClient: OktaAuth, options: AuthenticationOptions = {}
+  authClient: OktaAuthInterface, options: AuthenticationOptions = {}
 ): Promise<IdxTransaction> {
   if (options.password && !options.authenticator) {
     options.authenticator = AuthenticatorKey.OKTA_PASSWORD;

--- a/lib/idx/cancel.ts
+++ b/lib/idx/cancel.ts
@@ -10,13 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { OktaAuth, IdxOptions, IdxTransactionMeta } from '../types';
+import { OktaAuthInterface, IdxOptions, IdxTransactionMeta } from '../types';
 import { run } from './run';
 import { getFlowSpecification } from './flow';
 
 export type CancelOptions = IdxOptions;
 
-export async function cancel (authClient: OktaAuth, options?: CancelOptions) {
+export async function cancel (authClient: OktaAuthInterface, options?: CancelOptions) {
   const meta = authClient.transactionManager.load() as IdxTransactionMeta;
   const flowSpec = getFlowSpecification(authClient, meta.flow);
   return run(authClient, {

--- a/lib/idx/emailVerify.ts
+++ b/lib/idx/emailVerify.ts
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { OktaAuth } from '../types';
+import { OktaAuthInterface } from '../types';
 
 import CustomError from '../errors/CustomError';
 import { urlParamsToObject  } from '../oidc/util/urlParams';
@@ -47,7 +47,7 @@ export function parseEmailVerifyCallback(urlPath: string): EmailVerifyCallbackRe
   return urlParamsToObject(urlPath) as EmailVerifyCallbackResponse;
 }
 
-export async function handleEmailVerifyCallback(authClient: OktaAuth, search: string) {
+export async function handleEmailVerifyCallback(authClient: OktaAuthInterface, search: string) {
   if (isEmailVerifyCallback(search)) {
     const { state, otp } = parseEmailVerifyCallback(search);
     if (authClient.idx.canProceed({ state })) {

--- a/lib/idx/flow/FlowSpecification.ts
+++ b/lib/idx/flow/FlowSpecification.ts
@@ -1,4 +1,4 @@
-import { OktaAuth, FlowIdentifier } from '../../types';
+import { OktaAuthInterface, FlowIdentifier } from '../../types';
 import { AuthenticationFlow } from './AuthenticationFlow';
 import { PasswordRecoveryFlow } from './PasswordRecoveryFlow';
 import { RegistrationFlow } from './RegistrationFlow';
@@ -13,7 +13,7 @@ export interface FlowSpecification {
 }
 
 // eslint-disable-next-line complexity
-export function getFlowSpecification(oktaAuth: OktaAuth, flow: FlowIdentifier = 'default'): FlowSpecification {
+export function getFlowSpecification(oktaAuth: OktaAuthInterface, flow: FlowIdentifier = 'default'): FlowSpecification {
   let remediators, actions, withCredentials = true;
   switch (flow) {
     case 'register':

--- a/lib/idx/headers.ts
+++ b/lib/idx/headers.ts
@@ -15,9 +15,8 @@
 // Currently we must modify request headers using the single instance of `idx.client.interceptors` exported from IDX-JS
 // This means that multiple instances of OktaAuth will see the same header modifications
 // TODO: use AuthJS http agent for IDX API requests. OKTA-417473
-import { OktaAuth } from '../types';
+import { OktaAuthInterface } from '../types';
 import idx from './idx-js';
-
 export function setGlobalRequestInterceptor(fn) {
   idx.client.interceptors.request.use(fn);
 }
@@ -27,7 +26,7 @@ export function clearGlobalRequestInterceptor() {
 }
 
 // A factory which returns a function that can be passed to `setGlobalRequestInterceptor`
-export function createGlobalRequestInterceptor(sdk: OktaAuth) {
+export function createGlobalRequestInterceptor(sdk: OktaAuthInterface) {
   return function (requestConfig) {
     // Set user-agent and any other custom headers set in the options
     var oktaUserAgentHeader = sdk._oktaUserAgent.getHttpHeader();

--- a/lib/idx/index.ts
+++ b/lib/idx/index.ts
@@ -11,16 +11,21 @@
  */
 
 
-export * from './authenticate';
-export * from './cancel';
-export * from './emailVerify';
-export * from './interact';
-export * from './introspect';
-export * from './poll';
-export * from './proceed';
-export * from './register';
-export * from './recoverPassword';
-export * from './handleInteractionCodeRedirect';
-export * from './startTransaction';
+export { authenticate } from './authenticate';
+export { cancel } from './cancel';
+export { 
+  handleEmailVerifyCallback, 
+  isEmailVerifyCallback, 
+  parseEmailVerifyCallback, 
+  isEmailVerifyCallbackError, 
+} from './emailVerify';
+export { interact } from './interact';
+export { introspect } from './introspect';
+export { poll } from './poll';
+export { proceed, canProceed } from './proceed';
+export { register } from './register';
+export { recoverPassword } from './recoverPassword';
+export { handleInteractionCodeRedirect } from './handleInteractionCodeRedirect';
+export { startTransaction } from './startTransaction';
 export * from './transactionMeta';
 export * from './unlockAccount';

--- a/lib/idx/index.ts
+++ b/lib/idx/index.ts
@@ -27,5 +27,5 @@ export { register } from './register';
 export { recoverPassword } from './recoverPassword';
 export { handleInteractionCodeRedirect } from './handleInteractionCodeRedirect';
 export { startTransaction } from './startTransaction';
+export { unlockAccount } from './unlockAccount';
 export * from './transactionMeta';
-export * from './unlockAccount';

--- a/lib/idx/interact.ts
+++ b/lib/idx/interact.ts
@@ -12,7 +12,7 @@
  */
 /* eslint complexity:[0,8] */
 import idx from './idx-js';
-import { OktaAuth, IdxTransactionMeta } from '../types';
+import { OktaAuthInterface, IdxTransactionMeta } from '../types';
 import { getSavedTransactionMeta, saveTransactionMeta } from './transactionMeta';
 import { getOAuthBaseUrl } from '../oidc';
 import { createTransactionMeta } from '.';
@@ -44,7 +44,10 @@ function getResponse(meta: IdxTransactionMeta): InteractResponse {
 }
 
 // Begin or resume a transaction. Returns an interaction handle
-export async function interact (authClient: OktaAuth, options: InteractOptions = {}): Promise<InteractResponse> {
+export async function interact (
+  authClient: OktaAuthInterface, 
+  options: InteractOptions = {}
+): Promise<InteractResponse> {
   options = removeNils(options);
 
   let meta = getSavedTransactionMeta(authClient, options);

--- a/lib/idx/introspect.ts
+++ b/lib/idx/introspect.ts
@@ -11,7 +11,7 @@
  */
 
 import idx from './idx-js';
-import { OktaAuth } from '../types';
+import { OktaAuthInterface } from '../types';
 import { IdxResponse, isRawIdxResponse } from './types/idx-js';
 import { getOAuthDomain } from '../oidc';
 import { IDX_API_VERSION } from '../constants';
@@ -23,7 +23,10 @@ export interface IntrospectOptions {
   version?: string;
 }
 
-export async function introspect (authClient: OktaAuth, options: IntrospectOptions = {}): Promise<IdxResponse> {
+export async function introspect (
+  authClient: OktaAuthInterface, 
+  options: IntrospectOptions = {}
+): Promise<IdxResponse> {
   // try load from storage first
   let rawIdxResponse = authClient.transactionManager.loadIdxResponse();
   

--- a/lib/idx/poll.ts
+++ b/lib/idx/poll.ts
@@ -15,12 +15,12 @@ import { proceed } from './proceed';
 import { 
   IdxPollOptions,
   IdxTransaction,
-  OktaAuth,
+  OktaAuthInterface,
 } from '../types';
 import { getSavedTransactionMeta } from './transactionMeta';
 import { warn } from '../util';
 
-export async function poll(authClient: OktaAuth, options: IdxPollOptions = {}): Promise<IdxTransaction> {
+export async function poll(authClient: OktaAuthInterface, options: IdxPollOptions = {}): Promise<IdxTransaction> {
   let transaction = await proceed(authClient, {
     startPolling: true
   });

--- a/lib/idx/proceed.ts
+++ b/lib/idx/proceed.ts
@@ -12,7 +12,7 @@
 
 
 import { 
-  OktaAuth,
+  OktaAuthInterface,
   IdxTransaction,
 } from '../types';
 import { run } from './run';
@@ -35,13 +35,13 @@ export type ProceedOptions = AuthenticationOptions
   & SelectEnrollmentChannelOptions
   & { step?: string };
 
-export function canProceed(authClient: OktaAuth, options?: { state?: string }) {
+export function canProceed(authClient: OktaAuthInterface, options?: { state?: string }) {
   const meta = getSavedTransactionMeta(authClient, options);
   return !!meta;
 }
 
 export async function proceed(
-  authClient: OktaAuth,
+  authClient: OktaAuthInterface,
   options: ProceedOptions = {}
 ): Promise<IdxTransaction> {
   const { state } = options;

--- a/lib/idx/recoverPassword.ts
+++ b/lib/idx/recoverPassword.ts
@@ -22,7 +22,7 @@ import {
 } from './remediators';
 import { getFlowSpecification } from './flow';
 import { 
-  OktaAuth, 
+  OktaAuthInterface, 
   IdxOptions, 
   IdxTransaction,
 } from '../types';
@@ -36,7 +36,7 @@ export type PasswordRecoveryOptions = IdxOptions
   & ReEnrollAuthenticatorValues;
 
 export async function recoverPassword(
-  authClient: OktaAuth, options: PasswordRecoveryOptions = {}
+  authClient: OktaAuthInterface, options: PasswordRecoveryOptions = {}
 ): Promise<IdxTransaction> {
   const flowSpec = getFlowSpecification(authClient, 'recoverPassword');
   return run(

--- a/lib/idx/register.ts
+++ b/lib/idx/register.ts
@@ -25,7 +25,7 @@ import { AuthSdkError } from '../errors';
 import { 
   IdxOptions, 
   IdxTransaction, 
-  OktaAuth, 
+  OktaAuthInterface, 
   IdxFeature,
 } from '../types';
 
@@ -37,7 +37,7 @@ export type RegistrationOptions = IdxOptions
   & SkipValues;
 
 export async function register(
-  authClient: OktaAuth, options: RegistrationOptions = {}
+  authClient: OktaAuthInterface, options: RegistrationOptions = {}
 ): Promise<IdxTransaction> {
 
   // Only check at the beginning of the transaction

--- a/lib/idx/run.ts
+++ b/lib/idx/run.ts
@@ -18,7 +18,7 @@ import { remediate, RemediateOptions } from './remediate';
 import { getFlowSpecification, RemediationFlow } from './flow';
 import * as remediators from './remediators';
 import { 
-  OktaAuth,
+  OktaAuthInterface,
   IdxStatus,
   IdxTransaction,
   IdxFeature,
@@ -82,7 +82,7 @@ function getAvailableSteps(idxResponse: IdxResponse): NextStep[] {
 }
 
 export async function run(
-  authClient: OktaAuth, 
+  authClient: OktaAuthInterface, 
   options: RunOptions = {},
 ): Promise<IdxTransaction> {
   let tokens;

--- a/lib/idx/startTransaction.ts
+++ b/lib/idx/startTransaction.ts
@@ -12,10 +12,10 @@
 
 
 import { run, RunOptions } from './run';
-import { OktaAuth, IdxTransaction } from '../types';
+import { OktaAuthInterface, IdxTransaction } from '../types';
 
 export async function startTransaction(
-  authClient: OktaAuth, 
+  authClient: OktaAuthInterface, 
   options: RunOptions = {}
 ): Promise<IdxTransaction> {
   // Clear IDX response cache and saved transaction meta (if any)

--- a/lib/idx/transactionMeta.ts
+++ b/lib/idx/transactionMeta.ts
@@ -11,13 +11,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { OktaAuth, IdxTransactionMeta, TransactionMetaOptions, PKCETransactionMeta } from '../types';
+import { OktaAuthInterface, IdxTransactionMeta, TransactionMetaOptions, PKCETransactionMeta } from '../types';
 import { removeNils, warn } from '../util';
 import { createOAuthMeta } from '../oidc';
 
 // Calculate new values
 export async function createTransactionMeta(
-  authClient: OktaAuth,
+  authClient: OktaAuthInterface,
   options: TransactionMetaOptions = {}
 ): Promise<IdxTransactionMeta> {
   const tokenParams = await authClient.token.prepareTokenParams(options);
@@ -39,7 +39,7 @@ export async function createTransactionMeta(
   return meta;
 }
 
-export function hasSavedInteractionHandle(authClient: OktaAuth, options?: TransactionMetaOptions): boolean {
+export function hasSavedInteractionHandle(authClient: OktaAuthInterface, options?: TransactionMetaOptions): boolean {
   const savedMeta = getSavedTransactionMeta(authClient, options);
   if (savedMeta?.interactionHandle) {
     return true;
@@ -49,7 +49,7 @@ export function hasSavedInteractionHandle(authClient: OktaAuth, options?: Transa
 
 // Returns the saved transaction meta, if it exists and is valid
 export function getSavedTransactionMeta(
-  authClient: OktaAuth,
+  authClient: OktaAuthInterface,
   options?: TransactionMetaOptions
 ): IdxTransactionMeta | undefined {
   options = removeNils(options);
@@ -78,7 +78,7 @@ export function getSavedTransactionMeta(
 }
 
 export async function getTransactionMeta(
-  authClient: OktaAuth,
+  authClient: OktaAuthInterface,
   options?: TransactionMetaOptions
 ): Promise<IdxTransactionMeta> {
   options = removeNils(options);
@@ -92,11 +92,11 @@ export async function getTransactionMeta(
   return createTransactionMeta(authClient, options);
 }
 
-export function saveTransactionMeta (authClient: OktaAuth, meta): void {
+export function saveTransactionMeta (authClient: OktaAuthInterface, meta): void {
   authClient.transactionManager.save(meta, { muteWarning: true });
 }
 
-export function clearTransactionMeta (authClient: OktaAuth): void {
+export function clearTransactionMeta (authClient: OktaAuthInterface): void {
   authClient.transactionManager.clear();
 }
 

--- a/lib/idx/types/index.ts
+++ b/lib/idx/types/index.ts
@@ -14,7 +14,7 @@
 import { InteractOptions } from '../interact';
 import { IntrospectOptions } from '../introspect';
 import { APIError, Tokens } from '../../types';
-import { IdxTransactionMeta } from '../../types/Transaction';
+import { PKCETransactionMeta } from '../../types/Transaction';
 import { 
   IdxActions, 
   IdxAuthenticator, 
@@ -36,7 +36,6 @@ export { AccountUnlockOptions } from '../unlockAccount';
 export { ProceedOptions } from '../proceed';
 export { CancelOptions } from '../cancel';
 export { FlowIdentifier };
-export { IdxTransactionMeta };
 export { IdxAuthenticator };
 export { EmailVerifyCallbackResponse } from '../emailVerify';
 export { WebauthnEnrollValues } from '../authenticator/WebauthnEnrollment';
@@ -87,6 +86,15 @@ export enum IdxFeature {
   REGISTRATION = 'enroll-profile',
   SOCIAL_IDP = 'redirect-idp',
   ACCOUNT_UNLOCK = 'unlock-account',
+}
+
+export interface IdxTransactionMeta extends PKCETransactionMeta {
+  interactionHandle?: string;
+  remediations?: string[];
+  flow?: FlowIdentifier;
+  withCredentials?: boolean;
+  activationToken?: string;
+  recoveryToken?: string;
 }
 
 export interface IdxTransaction {

--- a/lib/idx/unlockAccount.ts
+++ b/lib/idx/unlockAccount.ts
@@ -23,7 +23,7 @@ import {
 } from './remediators';
 import { AuthSdkError } from '../errors';
 import { 
-  OktaAuth, 
+  OktaAuthInterface, 
   IdxOptions, 
   IdxTransaction,
   IdxFeature,
@@ -37,7 +37,7 @@ export type AccountUnlockOptions = IdxOptions
   & AuthenticatorVerificationDataValues;
 
 export async function unlockAccount(
-  authClient: OktaAuth, options: AccountUnlockOptions = {}
+  authClient: OktaAuthInterface, options: AccountUnlockOptions = {}
 ): Promise<IdxTransaction> {
   options.flow = 'unlockAccount';
 

--- a/lib/oidc/endpoints/well-known.ts
+++ b/lib/oidc/endpoints/well-known.ts
@@ -12,17 +12,17 @@
  */
 import { get } from '../../http';
 import { find } from '../../util';
-import { OktaAuth, WellKnownResponse } from '../../types';
+import { OktaAuthInterface, WellKnownResponse } from '../../types';
 import AuthSdkError from '../../errors/AuthSdkError';
 
-export function getWellKnown(sdk: OktaAuth, issuer?: string): Promise<WellKnownResponse> {
+export function getWellKnown(sdk: OktaAuthInterface, issuer?: string): Promise<WellKnownResponse> {
   var authServerUri = (issuer || sdk.options.issuer);
   return get(sdk, authServerUri + '/.well-known/openid-configuration', {
     cacheResponse: true
   });
 }
 
-export function getKey(sdk: OktaAuth, issuer: string, kid: string): Promise<string> {
+export function getKey(sdk: OktaAuthInterface, issuer: string, kid: string): Promise<string> {
   var httpCache = sdk.storageManager.getHttpCache(sdk.options.cookies);
 
   return getWellKnown(sdk, issuer)

--- a/lib/oidc/exchangeCodeForTokens.ts
+++ b/lib/oidc/exchangeCodeForTokens.ts
@@ -12,14 +12,14 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-import { CustomUrls, OAuthResponse, OktaAuth, TokenParams, TokenResponse } from '../types';
+import { CustomUrls, OAuthResponse, OktaAuthInterface, TokenParams, TokenResponse } from '../types';
 import { getOAuthUrls, getDefaultTokenParams } from './util';
 import { clone } from '../util';
 import { postToTokenEndpoint } from './endpoints/token';
 import { handleOAuthResponse } from './handleOAuthResponse';
 
 // codeVerifier is required. May pass either an authorizationCode or interactionCode
-export function exchangeCodeForTokens(sdk: OktaAuth, tokenParams: TokenParams, urls?: CustomUrls): Promise<TokenResponse> {
+export function exchangeCodeForTokens(sdk: OktaAuthInterface, tokenParams: TokenParams, urls?: CustomUrls): Promise<TokenResponse> {
   urls = urls || getOAuthUrls(sdk, tokenParams);
   // build params using defaults + options
   tokenParams = Object.assign({}, getDefaultTokenParams(sdk), clone(tokenParams));

--- a/lib/oidc/getToken.ts
+++ b/lib/oidc/getToken.ts
@@ -16,12 +16,13 @@
 import {
   getOAuthUrls,
   loadFrame,
+  addPostMessageListener
 } from './util';
 
 import AuthSdkError from '../errors/AuthSdkError';
 
 import {
-  OktaAuth,
+  OktaAuthInterface,
   TokenParams,
   PopupParams,
   OAuthResponse,
@@ -29,7 +30,6 @@ import {
 
 import { prepareTokenParams } from './util/prepareTokenParams';
 import { buildAuthorizeParams } from './endpoints/authorize';
-import { addPostMessageListener } from './util';
 import { handleOAuthResponse } from './handleOAuthResponse';
 /*
  * Retrieve an idToken from an Okta or a third party idp
@@ -81,7 +81,7 @@ import { handleOAuthResponse } from './handleOAuthResponse';
  * @param {String} [options.popupTitle] Title dispayed in the popup.
  *                                      Defaults to 'External Identity Provider User Authentication'
  */
-export function getToken(sdk: OktaAuth, options: TokenParams & PopupParams) {
+export function getToken(sdk: OktaAuthInterface, options: TokenParams & PopupParams) {
   if (arguments.length > 2) {
     return Promise.reject(new AuthSdkError('As of version 3.0, "getToken" takes only a single set of options'));
   }

--- a/lib/oidc/getWithPopup.ts
+++ b/lib/oidc/getWithPopup.ts
@@ -11,12 +11,12 @@
  *
  */
 import { AuthSdkError } from '../errors';
-import { OktaAuth, TokenParams, TokenResponse } from '../types';
+import { OktaAuthInterface, TokenParams, TokenResponse } from '../types';
 import { clone } from '../util';
 import { getToken } from './getToken';
 import { loadPopup } from './util';
 
-export function getWithPopup(sdk: OktaAuth, options: TokenParams): Promise<TokenResponse> {
+export function getWithPopup(sdk: OktaAuthInterface, options: TokenParams): Promise<TokenResponse> {
   if (arguments.length > 2) {
     return Promise.reject(new AuthSdkError('As of version 3.0, "getWithPopup" takes only a single set of options'));
   }

--- a/lib/oidc/getWithRedirect.ts
+++ b/lib/oidc/getWithRedirect.ts
@@ -12,12 +12,12 @@
  *
  */
 import { AuthSdkError } from '../errors';
-import { OktaAuth, TokenParams } from '../types';
+import { OktaAuthInterface, TokenParams } from '../types';
 import { clone } from '../util';
 import { prepareTokenParams, createOAuthMeta } from './util';
 import { buildAuthorizeParams } from './endpoints/authorize';
 
-export async function getWithRedirect(sdk: OktaAuth, options?: TokenParams): Promise<void> {
+export async function getWithRedirect(sdk: OktaAuthInterface, options?: TokenParams): Promise<void> {
   if (arguments.length > 2) {
     return Promise.reject(new AuthSdkError('As of version 3.0, "getWithRedirect" takes only a single set of options'));
   }

--- a/lib/oidc/getWithoutPrompt.ts
+++ b/lib/oidc/getWithoutPrompt.ts
@@ -11,11 +11,11 @@
  *
  */
 import { AuthSdkError } from '../errors';
-import { OktaAuth, TokenParams, TokenResponse } from '../types';
+import { OktaAuthInterface, TokenParams, TokenResponse } from '../types';
 import { clone } from '../util';
 import { getToken } from './getToken';
 
-export function getWithoutPrompt(sdk: OktaAuth, options: TokenParams): Promise<TokenResponse> {
+export function getWithoutPrompt(sdk: OktaAuthInterface, options: TokenParams): Promise<TokenResponse> {
   if (arguments.length > 2) {
     return Promise.reject(new AuthSdkError('As of version 3.0, "getWithoutPrompt" takes only a single set of options'));
   }

--- a/lib/oidc/handleOAuthResponse.ts
+++ b/lib/oidc/handleOAuthResponse.ts
@@ -19,7 +19,7 @@ import {
 } from './util/oauth';
 import { AuthSdkError, OAuthError } from '../errors';
 import {
-  OktaAuth,
+  OktaAuthInterface,
   TokenVerifyParams,
   IDToken,
   OAuthResponse,
@@ -43,7 +43,7 @@ function validateResponse(res: OAuthResponse, oauthParams: TokenParams) {
 }
 
 export async function handleOAuthResponse(
-  sdk: OktaAuth,
+  sdk: OktaAuthInterface,
   tokenParams: TokenParams,
   res: OAuthResponse,
   urls?: CustomUrls

--- a/lib/oidc/renewToken.ts
+++ b/lib/oidc/renewToken.ts
@@ -11,7 +11,7 @@
  *
  */
 import { AuthSdkError } from '../errors';
-import { OktaAuth, Token, Tokens, isAccessToken, AccessToken, IDToken, isIDToken } from '../types';
+import { OktaAuthInterface, Token, Tokens, isAccessToken, AccessToken, IDToken, isIDToken } from '../types';
 import { getWithoutPrompt } from './getWithoutPrompt';
 import { renewTokensWithRefresh } from './renewTokensWithRefresh';
 
@@ -33,7 +33,7 @@ function getSingleToken(originalToken: Token, tokens: Tokens) {
 }
 
 // If we have a refresh token, renew using that, otherwise getWithoutPrompt
-export async function renewToken(sdk: OktaAuth, token: Token): Promise<Token | undefined> {
+export async function renewToken(sdk: OktaAuthInterface, token: Token): Promise<Token | undefined> {
   if (!isIDToken(token) && !isAccessToken(token)) {
     throwInvalidTokenError();
   }

--- a/lib/oidc/renewTokensWithRefresh.ts
+++ b/lib/oidc/renewTokensWithRefresh.ts
@@ -13,12 +13,12 @@
 import { AuthSdkError } from '../errors';
 import { getOAuthUrls } from './util/oauth';
 import { isSameRefreshToken } from './util/refreshToken';
-import { OktaAuth, TokenParams, RefreshToken, Tokens } from '../types';
+import { OktaAuthInterface, TokenParams, RefreshToken, Tokens } from '../types';
 import { handleOAuthResponse } from './handleOAuthResponse';
 import { postRefreshToken } from './endpoints/token';
 
 export async function renewTokensWithRefresh(
-  sdk: OktaAuth,
+  sdk: OktaAuthInterface,
   tokenParams: TokenParams,
   refreshTokenObject: RefreshToken
 ): Promise<Tokens> {

--- a/lib/oidc/revokeToken.ts
+++ b/lib/oidc/revokeToken.ts
@@ -20,14 +20,14 @@ import {
 import { btoa } from '../crypto';
 import AuthSdkError from '../errors/AuthSdkError';
 import {
-  OktaAuth,
+  OktaAuthInterface,
   RevocableToken,
   AccessToken,
   RefreshToken
 } from '../types';
 
 // refresh tokens have precedence to be revoked if no token is specified
-export async function revokeToken(sdk: OktaAuth, token: RevocableToken): Promise<any> {
+export async function revokeToken(sdk: OktaAuthInterface, token: RevocableToken): Promise<any> {
   let accessToken = '';
   let refreshToken = '';
   if (token) { 

--- a/lib/oidc/util/browser.ts
+++ b/lib/oidc/util/browser.ts
@@ -13,7 +13,7 @@
 /* global window, document */
 /* eslint-disable complexity, max-statements */
 import { AuthSdkError } from '../../errors';
-import { OktaAuth } from '../../types';
+import { OktaAuthInterface } from '../../types';
 
 export function addListener(eventTarget, name, fn) {
   if (eventTarget.addEventListener) {
@@ -46,7 +46,7 @@ export function loadPopup(src, options) {
   return window.open(src, title, appearance);
 }
 
-export function addPostMessageListener(sdk: OktaAuth, timeout, state) {
+export function addPostMessageListener(sdk: OktaAuthInterface, timeout, state) {
   var responseHandler;
   var timeoutId;
   var msgReceivedOrTimeout = new Promise(function (resolve, reject) {

--- a/lib/oidc/util/defaultTokenParams.ts
+++ b/lib/oidc/util/defaultTokenParams.ts
@@ -13,11 +13,11 @@
  *
  */
 import { generateNonce, generateState } from './oauth';
-import { OktaAuth, TokenParams } from '../../types';
+import { OktaAuthInterface, TokenParams } from '../../types';
 import { isBrowser } from '../../features';
 import { removeNils } from '../../util';
 
-export function getDefaultTokenParams(sdk: OktaAuth): TokenParams {
+export function getDefaultTokenParams(sdk: OktaAuthInterface): TokenParams {
   const {
     pkce,
     clientId,

--- a/lib/oidc/util/errors.ts
+++ b/lib/oidc/util/errors.ts
@@ -11,7 +11,7 @@
  */
 
 
-import { OktaAuth } from '../../types';
+import { OktaAuthInterface } from '../../types';
 import { OAuthError, AuthApiError } from '../../errors';
 
 export function isInteractionRequiredError(error: Error) {
@@ -22,7 +22,7 @@ export function isInteractionRequiredError(error: Error) {
   return (oauthError.errorCode === 'interaction_required');
 }
 
-export function isAuthorizationCodeError(sdk: OktaAuth, error: Error) {
+export function isAuthorizationCodeError(sdk: OktaAuthInterface, error: Error) {
   if (error.name !== 'AuthApiError') {
     return false;
   }

--- a/lib/oidc/util/loginRedirect.ts
+++ b/lib/oidc/util/loginRedirect.ts
@@ -12,7 +12,7 @@
  */
 /* global window */
 /* eslint-disable complexity, max-statements */
-import { OktaAuth, OktaAuthOptions } from '../../types';
+import { OktaAuthInterface, OktaAuthOptions } from '../../types';
 
 export function hasTokensInHash(hash: string): boolean {
   return /((id|access)_token=)/i.test(hash);
@@ -32,7 +32,7 @@ export function hasErrorInUrl(hashOrSearch: string): boolean {
   return /(error=)/i.test(hashOrSearch) || /(error_description)/i.test(hashOrSearch);
 }
 
-export function isRedirectUri(uri: string, sdk: OktaAuth): boolean {
+export function isRedirectUri(uri: string, sdk: OktaAuthInterface): boolean {
   var authParams = sdk.options;
   if (!uri || !authParams.redirectUri) {
     return false;
@@ -54,7 +54,7 @@ export function getHashOrSearch(options: OktaAuthOptions) {
  * Check if tokens or a code have been passed back into the url, which happens in
  * the OIDC (including social auth IDP) redirect flow.
  */
-export function isLoginRedirect (sdk: OktaAuth) {
+export function isLoginRedirect (sdk: OktaAuthInterface) {
   // First check, is this a redirect URI?
   if (!isRedirectUri(window.location.href, sdk)){
     return false;
@@ -81,7 +81,7 @@ export function isLoginRedirect (sdk: OktaAuth) {
  * Check if error=interaction_required has been passed back in the url, which happens in
  * the social auth IDP redirect flow.
  */
-export function isInteractionRequired (sdk: OktaAuth, hashOrSearch?: string) {
+export function isInteractionRequired (sdk: OktaAuthInterface, hashOrSearch?: string) {
   if (!hashOrSearch) { // web only
     // First check, is this a redirect URI?
     if (!isLoginRedirect(sdk)){

--- a/lib/oidc/util/oauth.ts
+++ b/lib/oidc/util/oauth.ts
@@ -13,7 +13,7 @@
 /* eslint-disable complexity, max-statements */
 import { genRandomString, removeTrailingSlash } from '../../util';
 import AuthSdkError from '../../errors/AuthSdkError';
-import { OktaAuth, CustomUrls } from '../../types';
+import { OktaAuthInterface, CustomUrls } from '../../types';
 
 export function generateState() {
   return genRandomString(64);
@@ -23,24 +23,24 @@ export function generateNonce() {
   return genRandomString(64);
 }
 
-function getIssuer(sdk: OktaAuth, options: CustomUrls = {}) {
+function getIssuer(sdk: OktaAuthInterface, options: CustomUrls = {}) {
   const issuer = removeTrailingSlash(options.issuer) || sdk.options.issuer;
   return issuer;
 }
 
-export function getOAuthBaseUrl(sdk: OktaAuth, options: CustomUrls = {}) {
+export function getOAuthBaseUrl(sdk: OktaAuthInterface, options: CustomUrls = {}) {
   const issuer = getIssuer(sdk, options);
   const baseUrl = issuer.indexOf('/oauth2') > 0 ? issuer : issuer + '/oauth2';
   return baseUrl;
 }
 
-export function getOAuthDomain(sdk: OktaAuth, options: CustomUrls = {}) {
+export function getOAuthDomain(sdk: OktaAuthInterface, options: CustomUrls = {}) {
   const issuer = getIssuer(sdk, options);
   const domain = issuer.split('/oauth2')[0];
   return domain;
 }
 
-export function getOAuthUrls(sdk: OktaAuth, options?: CustomUrls): CustomUrls {
+export function getOAuthUrls(sdk: OktaAuthInterface, options?: CustomUrls): CustomUrls {
   if (arguments.length > 2) {
     throw new AuthSdkError('As of version 3.0, "getOAuthUrls" takes only a single set of options');
   }

--- a/lib/oidc/util/oauthMeta.ts
+++ b/lib/oidc/util/oauthMeta.ts
@@ -1,8 +1,11 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { OAuthTransactionMeta, OktaAuth, PKCETransactionMeta, TokenParams } from '../../types';
+import { OAuthTransactionMeta, OktaAuthInterface, PKCETransactionMeta, TokenParams } from '../../types';
 import { getOAuthUrls } from './oauth';
 
-export function createOAuthMeta(sdk: OktaAuth, tokenParams: TokenParams): OAuthTransactionMeta | PKCETransactionMeta {
+export function createOAuthMeta(
+  sdk: OktaAuthInterface, 
+  tokenParams: TokenParams
+): OAuthTransactionMeta | PKCETransactionMeta {
   const issuer = sdk.options.issuer!;
   const urls = getOAuthUrls(sdk, tokenParams);
   const oauthMeta: OAuthTransactionMeta = {

--- a/lib/oidc/util/pkce.ts
+++ b/lib/oidc/util/pkce.ts
@@ -12,9 +12,8 @@
  */
 
  /* eslint-disable complexity, max-statements */
-import { stringToBase64Url } from '../../crypto';
+import { stringToBase64Url, webcrypto } from '../../crypto';
 import { MIN_VERIFIER_LENGTH, MAX_VERIFIER_LENGTH, DEFAULT_CODE_CHALLENGE_METHOD } from '../../constants';
-import { webcrypto } from '../../crypto';
 
 function dec2hex (dec) {
   return ('0' + dec.toString(16)).substr(-2);

--- a/lib/oidc/util/prepareTokenParams.ts
+++ b/lib/oidc/util/prepareTokenParams.ts
@@ -13,12 +13,12 @@
  */
 import { getWellKnown } from '../endpoints/well-known';
 import { AuthSdkError } from '../../errors';
-import { OktaAuth, TokenParams } from '../../types';
+import { OktaAuthInterface, TokenParams } from '../../types';
 import { getDefaultTokenParams } from './defaultTokenParams';
 import { DEFAULT_CODE_CHALLENGE_METHOD } from '../../constants';
 import PKCE from './pkce';
 
-export function assertPKCESupport(sdk: OktaAuth) {
+export function assertPKCESupport(sdk: OktaAuthInterface) {
   if (!sdk.features.isPKCESupported()) {
     var errorMessage = 'PKCE requires a modern browser with encryption support running in a secure context.';
     if (!sdk.features.isHTTPS()) {
@@ -33,7 +33,7 @@ export function assertPKCESupport(sdk: OktaAuth) {
   }
 }
 
-export async function validateCodeChallengeMethod(sdk: OktaAuth, codeChallengeMethod?: string) {
+export async function validateCodeChallengeMethod(sdk: OktaAuthInterface, codeChallengeMethod?: string) {
   // set default code challenge method, if none provided
   codeChallengeMethod = codeChallengeMethod || sdk.options.codeChallengeMethod || DEFAULT_CODE_CHALLENGE_METHOD;
 
@@ -47,7 +47,7 @@ export async function validateCodeChallengeMethod(sdk: OktaAuth, codeChallengeMe
 }
 
 export async function preparePKCE(
-  sdk: OktaAuth, 
+  sdk: OktaAuthInterface, 
   tokenParams: TokenParams
 ): Promise<TokenParams> {
   let {
@@ -79,7 +79,7 @@ export async function preparePKCE(
 
 // Prepares params for a call to /authorize or /token
 export async function prepareTokenParams(
-  sdk: OktaAuth,
+  sdk: OktaAuthInterface,
   tokenParams: TokenParams = {}
 ): Promise<TokenParams> {
   // build params using defaults + options

--- a/lib/oidc/util/validateClaims.ts
+++ b/lib/oidc/util/validateClaims.ts
@@ -14,9 +14,9 @@
 /* eslint-disable complexity, max-statements */
 
 import AuthSdkError from '../../errors/AuthSdkError';
-import { OktaAuth, TokenVerifyParams, UserClaims } from '../../types';
+import { OktaAuthInterface, TokenVerifyParams, UserClaims } from '../../types';
 
-export function validateClaims(sdk: OktaAuth, claims: UserClaims, validationParams: TokenVerifyParams) {
+export function validateClaims(sdk: OktaAuthInterface, claims: UserClaims, validationParams: TokenVerifyParams) {
   var aud = validationParams.clientId;
   var iss = validationParams.issuer;
   var nonce = validationParams.nonce;

--- a/lib/oidc/verifyToken.ts
+++ b/lib/oidc/verifyToken.ts
@@ -15,12 +15,12 @@
 import { getWellKnown, getKey } from './endpoints/well-known';
 import { validateClaims } from './util';
 import { AuthSdkError } from '../errors';
-import { IDToken, OktaAuth, TokenVerifyParams } from '../types';
+import { IDToken, OktaAuthInterface, TokenVerifyParams } from '../types';
 import { decodeToken } from './decodeToken';
 import * as sdkCrypto from '../crypto';
 
 // Verify the id token
-export async function verifyToken(sdk: OktaAuth, token: IDToken, validationParams: TokenVerifyParams): Promise<IDToken> {
+export async function verifyToken(sdk: OktaAuthInterface, token: IDToken, validationParams: TokenVerifyParams): Promise<IDToken> {
   if (!token || !token.idToken) {
     throw new AuthSdkError('Only idTokens may be verified');
   }

--- a/lib/server/serverStorage.ts
+++ b/lib/server/serverStorage.ts
@@ -13,6 +13,7 @@
 
 import { SimpleStorage, StorageType, StorageUtil, Cookies } from '../types';
 import { AuthSdkError } from '../errors';
+// eslint-disable-next-line import/no-commonjs
 const NodeCache = require('node-cache'); // commonJS module cannot be imported without esModuleInterop
 
 // this is a SHARED memory storage to support a stateless http server

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -10,12 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { StorageManagerOptions, StorageUtil } from './Storage';
+import { StorageManagerOptions, StorageUtil, SimpleStorage } from './Storage';
 import { CookieOptions } from './Cookies';
 import { HttpRequestClient } from './http';
 import { AuthState } from './AuthState';
 import { TransactionManagerOptions } from './Transaction';
-import { SimpleStorage } from './Storage';
 import { FlowIdentifier } from '../idx/types';
 import OktaAuth from '../OktaAuth';
 export interface TokenManagerOptions {

--- a/lib/types/Transaction.ts
+++ b/lib/types/Transaction.ts
@@ -11,9 +11,10 @@
  */
 
 
-import StorageManager from '../StorageManager';
+import { StorageManager } from '../StorageManager';
 import { CustomUrls } from './OktaAuthOptions';
-import { FlowIdentifier } from '../idx/types';
+import { FlowIdentifier, IdxTransactionMeta } from '../idx/types';
+
 export interface TransactionManagerOptions {
   storageManager?: StorageManager;
   enableSharedStorage?: boolean; // default true
@@ -56,15 +57,6 @@ export interface PKCETransactionMeta extends OAuthTransactionMeta {
   codeVerifier: string;
   codeChallengeMethod: string;
   codeChallenge: string;
-}
-
-export interface IdxTransactionMeta extends PKCETransactionMeta {
-  interactionHandle?: string;
-  remediations?: string[];
-  flow?: FlowIdentifier;
-  withCredentials?: boolean;
-  activationToken?: string;
-  recoveryToken?: string;
 }
 
 export type CustomAuthTransactionMeta = Record<string, string | undefined>;

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -15,12 +15,10 @@ import { Token, Tokens, RevocableToken, AccessToken, IDToken, RefreshToken } fro
 import { JWTObject } from './JWT';
 import { UserClaims } from './UserClaims';
 import { CustomUrls, OktaAuthOptions } from './OktaAuthOptions';
-import StorageManager from '../StorageManager';
+import { StorageManager } from '../StorageManager';
 import TransactionManager from '../TransactionManager';
 import { TokenManagerInterface } from './TokenManager';
 import { OktaUserAgent } from '../OktaUserAgent';
-import { FlowIdentifier, IdxPollOptions } from '../idx/types';
-
 import { 
   AuthenticationOptions, 
   RegistrationOptions as IdxRegistrationOptions,
@@ -36,13 +34,15 @@ import {
   ChallengeData,
   ActivationData,
   WebauthnEnrollValues,
-  WebauthnVerificationValues
+  WebauthnVerificationValues,
+  FlowIdentifier, 
+  IdxPollOptions
 } from '../idx/types';
 import { InteractOptions, InteractResponse } from '../idx/interact';
 import { IntrospectOptions } from '../idx/introspect';
 import { IdxResponse } from '../idx/types/idx-js';
 import { TransactionMetaOptions } from './Transaction';
-export interface OktaAuth {
+export interface OktaAuthInterface {
   options: OktaAuthOptions;
   getIssuerOrigin(): string;
   getOriginalUri(): string | undefined;

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -24,4 +24,3 @@ export * from './Storage';
 export * from './Token';
 export * from './TokenManager';
 export * from './UserClaims';
-export * from './AuthState';

--- a/lib/util/sharedStorage.ts
+++ b/lib/util/sharedStorage.ts
@@ -1,5 +1,5 @@
 import { isTransactionMeta, TransactionMeta } from '../types';
-import StorageManager from '../StorageManager';
+import { StorageManager } from '../StorageManager';
 
 const MAX_ENTRY_LIFETIME = 30 * 60 * 1000; // 30 minutes
 

--- a/test/spec/StorageManager.ts
+++ b/test/spec/StorageManager.ts
@@ -12,7 +12,7 @@
 
 
 import SavedObject from '../../lib/SavedObject';
-import StorageManager from '../../lib/StorageManager';
+import { StorageManager } from '../../lib/StorageManager';
 import { 
   CookieOptions, 
   StorageManagerOptions, 

--- a/test/spec/TransactionManager.ts
+++ b/test/spec/TransactionManager.ts
@@ -12,7 +12,7 @@
 
 
 import TransactionManager from '../../lib/TransactionManager';
-import StorageManager from '../../lib/StorageManager';
+import { StorageManager } from '../../lib/StorageManager';
 import { RawIdxResponseFactory } from '@okta/test.support/idx';
 
 jest.mock('../../lib/util/sharedStorage', () => {

--- a/test/spec/oidc/exchangeCodeForTokens.ts
+++ b/test/spec/oidc/exchangeCodeForTokens.ts
@@ -17,9 +17,9 @@ const handleOAuthResponse = jest.fn();
 jest.mock('../../../lib/oidc/handleOAuthResponse', () => { return { handleOAuthResponse }; });
 
 import { exchangeCodeForTokens, getOAuthUrls } from '../../../lib/oidc';
-import { OktaAuth } from '../../../lib/types';
+import { OktaAuthInterface } from '../../../lib/types';
 
-function mockOktaAuth(): OktaAuth {
+function mockOktaAuth(): OktaAuthInterface {
   return {
     options: {
       issuer: 'http://fake'
@@ -27,7 +27,7 @@ function mockOktaAuth(): OktaAuth {
     transactionManager: {
       clear: jest.fn()
     }
-  } as unknown as OktaAuth;
+  } as unknown as OktaAuthInterface;
 }
 
 describe('exchangeCodeForTokens', () => {

--- a/test/spec/oidc/util/defaultTokenParams.ts
+++ b/test/spec/oidc/util/defaultTokenParams.ts
@@ -22,7 +22,7 @@ jest.mock('lib/features',() => {
   return mocked.features;
 });
 import { getDefaultTokenParams } from '../../../../lib/oidc/util/defaultTokenParams';
-import { OktaAuth } from '../../../../lib/types';
+import { OktaAuthInterface } from '../../../../lib/types';
 
 describe('getDefaultTokenParams', () => {
   beforeEach(() => {
@@ -41,12 +41,12 @@ describe('getDefaultTokenParams', () => {
     }
   });
   it('`pkce`: uses value from sdk.options', () => {
-    const sdk = { options: { pkce: true } } as OktaAuth;
+    const sdk = { options: { pkce: true } } as OktaAuthInterface;
     expect(getDefaultTokenParams(sdk).pkce).toBe(true);
   });
   
   it('`clientId`: uses value from sdk.options', () => {
-    const sdk = { options: { clientId: 'abc' } } as OktaAuth;
+    const sdk = { options: { clientId: 'abc' } } as OktaAuthInterface;
     expect(getDefaultTokenParams(sdk).clientId).toBe('abc');
   });
   
@@ -54,40 +54,40 @@ describe('getDefaultTokenParams', () => {
     it('isBrowser: defaults to window.location.href', () => {
       jest.spyOn(mocked.features, 'isBrowser').mockReturnValue(true);
       expect(window.location.href).toBeTruthy();
-      expect(getDefaultTokenParams({ options: {} } as OktaAuth).redirectUri).toBe(window.location.href);
+      expect(getDefaultTokenParams({ options: {} } as OktaAuthInterface).redirectUri).toBe(window.location.href);
     });
     it('uses values from sdk.options', () => {
-      const sdk = { options: { redirectUri: 'abc' } } as OktaAuth;
+      const sdk = { options: { redirectUri: 'abc' } } as OktaAuthInterface;
       expect(getDefaultTokenParams(sdk).redirectUri).toBe('abc');
     });
   });
   
   describe('`responseType`: ', () => {
     it('defaults to ["token", "id_token"]', () => {
-      expect(getDefaultTokenParams({ options: {} } as OktaAuth).responseType).toEqual(['token', 'id_token']);
+      expect(getDefaultTokenParams({ options: {} } as OktaAuthInterface).responseType).toEqual(['token', 'id_token']);
     });
     it('uses values from sdk.options', () => {
-      const sdk = { options: { responseType: 'abc' } } as OktaAuth;
+      const sdk = { options: { responseType: 'abc' } } as OktaAuthInterface;
       expect(getDefaultTokenParams(sdk).responseType).toBe('abc');
     });
   });
 
   it('`responseMode`: uses value from sdk.options', () => {
-    const sdk = { options: { responseMode: 'abc' } } as OktaAuth;
+    const sdk = { options: { responseMode: 'abc' } } as OktaAuthInterface;
     expect(getDefaultTokenParams(sdk).responseMode).toBe('abc');
   });
 
   describe('`state`: ', () => {
     it('generates a default value', () => {
-      expect(getDefaultTokenParams({ options: {} } as OktaAuth).state).toBeTruthy();
+      expect(getDefaultTokenParams({ options: {} } as OktaAuthInterface).state).toBeTruthy();
     });
     it('uses values from sdk.options', () => {
-      const sdk = { options: { state: 'abc' } } as OktaAuth;
+      const sdk = { options: { state: 'abc' } } as OktaAuthInterface;
       expect(getDefaultTokenParams(sdk).state).toBe('abc');
     });
   });
 
   it('`nonce`: generates a default value', () => {
-    expect(getDefaultTokenParams({ options: {} } as OktaAuth).nonce).toBeTruthy();
+    expect(getDefaultTokenParams({ options: {} } as OktaAuthInterface).nonce).toBeTruthy();
   });
 });


### PR DESCRIPTION
eslint-plugin-import is able to help better support es6+ syntax and module exports in the codebase. 

errors/warnings before fix:
```
/Users/shuowu/devex/okta-auth-js/lib/TokenManager.ts
  17:36  warning  '/Users/shuowu/devex/okta-auth-js/lib/constants.ts' imported multiple times  import/no-duplicates
  37:43  warning  '/Users/shuowu/devex/okta-auth-js/lib/constants.ts' imported multiple times  import/no-duplicates

/Users/shuowu/devex/okta-auth-js/lib/browser/fingerprint.ts
  14:26  warning  '/Users/shuowu/devex/okta-auth-js/lib/types/index.ts' imported multiple times  import/no-duplicates
  21:36  warning  '/Users/shuowu/devex/okta-auth-js/lib/types/index.ts' imported multiple times  import/no-duplicates

/Users/shuowu/devex/okta-auth-js/lib/index.ts
  16:21  error  Multiple exports of name 'OktaAuth'                     import/export
  18:1   error  Multiple exports of name 'AuthenticationOptions'        import/export
  18:1   error  Multiple exports of name 'CancelOptions'                import/export
  18:1   error  Multiple exports of name 'EmailVerifyCallbackResponse'  import/export
  18:1   error  Multiple exports of name 'ProceedOptions'               import/export
  18:1   error  Multiple exports of name 'RegistrationOptions'          import/export
  18:1   error  Multiple exports of name 'PasswordRecoveryOptions'      import/export
  19:1   error  Multiple exports of name 'OktaAuth'                     import/export
  19:1   error  Multiple exports of name 'AuthenticationOptions'        import/export
  19:1   error  Multiple exports of name 'CancelOptions'                import/export
  19:1   error  Multiple exports of name 'EmailVerifyCallbackResponse'  import/export
  19:1   error  Multiple exports of name 'ProceedOptions'               import/export
  19:1   error  Multiple exports of name 'RegistrationOptions'          import/export
  19:1   error  Multiple exports of name 'PasswordRecoveryOptions'      import/export
  23:15  error  No named exports found in module './StorageManager'     import/export

/Users/shuowu/devex/okta-auth-js/lib/oidc/getToken.ts
  19:8   warning  '/Users/shuowu/devex/okta-auth-js/lib/oidc/util/index.ts' imported multiple times  import/no-duplicates
  32:40  warning  '/Users/shuowu/devex/okta-auth-js/lib/oidc/util/index.ts' imported multiple times  import/no-duplicates

/Users/shuowu/devex/okta-auth-js/lib/oidc/util/pkce.ts
  15:35  warning  '/Users/shuowu/devex/okta-auth-js/lib/crypto/index.ts' imported multiple times  import/no-duplicates
  17:27  warning  '/Users/shuowu/devex/okta-auth-js/lib/crypto/index.ts' imported multiple times  import/no-duplicates

/Users/shuowu/devex/okta-auth-js/lib/types/OktaAuthOptions.ts
  13:52  warning  '/Users/shuowu/devex/okta-auth-js/lib/types/Storage.ts' imported multiple times  import/no-duplicates
  18:31  warning  '/Users/shuowu/devex/okta-auth-js/lib/types/Storage.ts' imported multiple times  import/no-duplicates

/Users/shuowu/devex/okta-auth-js/lib/types/api.ts
  22:48  warning  '/Users/shuowu/devex/okta-auth-js/lib/idx/types/index.ts' imported multiple times  import/no-duplicates
  39:8   warning  '/Users/shuowu/devex/okta-auth-js/lib/idx/types/index.ts' imported multiple times  import/no-duplicates

/Users/shuowu/devex/okta-auth-js/lib/types/index.ts
  14:1  error  Multiple exports of name 'AuthState'            import/export
  14:1  error  Multiple exports of name 'AuthStateLogOptions'  import/export
  16:1  error  Multiple exports of name 'IdxTransactionMeta'   import/export
  19:1  error  Multiple exports of name 'IdxTransactionMeta'   import/export
  27:1  error  Multiple exports of name 'AuthState'            import/export
  27:1  error  Multiple exports of name 'AuthStateLogOptions'  import/export

✖ 33 problems (21 errors, 12 warnings)
  0 errors and 4 warnings potentially fixable with the `--fix` option.
```