### PR TITLE
Remove token if renew failed with any error

### DIFF
--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -424,11 +424,8 @@ export class TokenManager implements TokenManagerInterface {
         return tokens[tokenType];
       })
       .catch(err => {
-        // If renew fails, remove token and emit error
-        if (isRefreshTokenError(err) || err.name === 'OAuthError' || err.name === 'AuthSdkError') {
-          // remove token from storage
-          this.remove(key);
-        }
+        // If renew fails, remove token from storage and emit error
+        this.remove(key);
         err.tokenKey = key;
         this.emitError(err);
         throw err;

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -12,7 +12,7 @@
  */
 import { removeNils, clone } from './util';
 import { AuthSdkError } from './errors';
-import { isRefreshTokenError, validateToken  } from './oidc/util';
+import { validateToken  } from './oidc/util';
 import { isLocalhost, isIE11OrLess } from './features';
 import { TOKEN_STORAGE_NAME } from './constants';
 import SdkClock from './clock';

--- a/test/spec/TokenManager/core.ts
+++ b/test/spec/TokenManager/core.ts
@@ -383,10 +383,15 @@ describe('TokenManager', function() {
       }).then(function() {
         expect(false).toBe(true);
       }).catch(function(err) {
+        // After token renew fails it is removed from storage, so next call will throw error
         util.expectErrorToEqual(err, {
-          name: 'Error',
-          message: 'expected',
-          tokenKey: 'test-idToken'
+          name: 'AuthSdkError',
+          message: 'The tokenManager has no token for the key: test-idToken',
+          errorCode: 'INTERNAL',
+          errorSummary: 'The tokenManager has no token for the key: test-idToken',
+          errorLink: 'INTERNAL',
+          errorId: 'INTERNAL',
+          errorCauses: []
         });
       });
       return p1;

--- a/test/spec/TokenManager/renew.ts
+++ b/test/spec/TokenManager/renew.ts
@@ -141,7 +141,7 @@ describe('TokenManager renew', () => {
       jest.spyOn(testContext.sdkMock.token, 'renewTokens').mockImplementation(() => Promise.reject(testContext.error));
     });
 
-    it('OAuthError', async () => {
+    it('on OAuthError, should remove token and emit error', async () => {
       testContext.error = new OAuthError('does not matter', 'also not important');
       try {
         await testContext.instance.renew('idToken');
@@ -155,7 +155,7 @@ describe('TokenManager renew', () => {
       expect(testContext.error.tokenKey).toBe('idToken');
     });
 
-    it('AuthSdkError', async () => {
+    it('on AuthSdkError, should remove token and emit error', async () => {
       testContext.error = new AuthSdkError('does not matter');
       try {
         await testContext.instance.renew('idToken');
@@ -169,7 +169,7 @@ describe('TokenManager renew', () => {
       expect(testContext.error.tokenKey).toBe('idToken');
     });
 
-    it('Refresh token error', async () => {
+    it('on refresh token error, should remove token and emit error', async () => {
       testContext.error = new AuthApiError({
         errorSummary: 'does not matter'
       }, {
@@ -192,7 +192,7 @@ describe('TokenManager renew', () => {
       expect(testContext.error.tokenKey).toBe('idToken');
     });
 
-    it('Other AuthApiError', async () => {
+    it('on other error, should remove token and emit error', async () => {
       testContext.error = new AuthApiError({
         errorSummary: 'Not Found'
       }, {
@@ -207,8 +207,9 @@ describe('TokenManager renew', () => {
           name: 'AuthApiError'
         });
       }
-      expect(testContext.instance.remove).not.toHaveBeenCalledWith('idToken');
+      expect(testContext.instance.remove).toHaveBeenCalledWith('idToken');
       expect(testContext.instance.emitError).toHaveBeenCalledWith(testContext.error);
+      expect(testContext.error.tokenKey).toBe('idToken');
     });
 
   });


### PR DESCRIPTION
Fixes issue: https://github.com/okta/okta-auth-js/issues/1047
Internal ref: [OKTA-460081](https://oktainc.atlassian.net/browse/OKTA-460081)

If token renew fails because of network error, it should be removed from storage.
Note: Some kind of error handling with retry of renewal logic is out of scope of this task.
