### PR TITLE
docs: Updates typescript usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ const authClient: OktaAuth = new OktaAuth(config)
 const tokenManager: TokenManager = authClient.tokenManager;
 const accessToken: AccessToken = await tokenManager.get('accessToken') as AccessToken;
 const idToken: IDToken = await tokenManager.get('idToken') as IDToken;
-const userInfo: UserClaims = await authClient.getUserInfo(accessToken, idToken);
+const userInfo: UserClaims = await authClient.token.getUserInfo(accessToken, idToken);
 
 if (!userInfo) {
   const tokenParams: TokenParams = {


### PR DESCRIPTION
Updates typescript example for `getUserInfo` to accurately show that it's a `token` method

Should either be `await authClient.getUser(accessToken, idToken);` OR OktaAuth alias `await authClient.token.getUserInfo(accessToken, idToken);`