### PR TITLE
Call updateAuthState when handleLoginRedirect fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [#1071](https://github.com/okta/okta-auth-js/pull/1071) TypeScript: Adds fields for `Input` type in NextStep object
 - [#1094](https://github.com/okta/okta-auth-js/pull/1094) TypeScript: Fixes `SigninOptions.context` type
+- [#1092](https://github.com/okta/okta-auth-js/pull/1092) Call `updateAuthState` when `handleLoginRedirect` fails
 
 ## 6.0.0
 

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -682,11 +682,17 @@ class OktaAuth implements SDKInterface, SigninAPI, SignoutAPI {
       this.tokenManager.setTokens(tokens);
       originalUri = originalUri || this.getOriginalUri(this.options.state);
     } else if (this.isLoginRedirect()) {
-      // For redirect flow, get state from the URL and use it to retrieve the originalUri
-      const oAuthResponse = await parseOAuthResponseFromUrl(this, {});
-      state = oAuthResponse.state;
-      originalUri = originalUri || this.getOriginalUri(state);
-      await this.storeTokensFromRedirect();
+      try {
+        // For redirect flow, get state from the URL and use it to retrieve the originalUri
+        const oAuthResponse = await parseOAuthResponseFromUrl(this, {});
+        state = oAuthResponse.state;
+        originalUri = originalUri || this.getOriginalUri(state);
+        await this.storeTokensFromRedirect();
+      } catch(e) {
+        // auth state should be updated
+        await this.authStateManager.updateAuthState();
+        throw e;
+      }
     } else {
       return; // nothing to do
     }

--- a/test/spec/OktaAuth/browser.ts
+++ b/test/spec/OktaAuth/browser.ts
@@ -694,6 +694,24 @@ describe('OktaAuth (browser)', function() {
       expect(window.location.replace).not.toHaveBeenCalled();
     });
 
+    it('will call updateAuthState if parseFromUrl throws an error', async () => {
+      const error = new Error('mock error');
+      auth.authStateManager.updateAuthState = jest.fn();
+      auth.token.parseFromUrl.mockImplementation(async () => {
+        throw error;
+      });
+      auth.isLoginRedirect = jest.fn().mockReturnValue(true);
+      let errorThrown = false;
+      try {
+        await auth.handleLoginRedirect();
+      } catch (e) {
+        expect(e).toBe(error);
+        errorThrown = true;
+      }
+      expect(errorThrown).toBe(true);
+      expect(auth.authStateManager.updateAuthState).toHaveBeenCalled();
+    });
+
   });
 
 });


### PR DESCRIPTION
Fixes issue https://github.com/okta/okta-react/issues/173 in auth-js layer
(Previous PR https://github.com/okta/okta-react/pull/205 with same fix was in okta-react layer)

Issue description: if user visits bad login redirect page (like `/login/callback?code=foobar`) but has tokens, `authState ` will still be null


Internal ref: [OKTA-441939](https://oktainc.atlassian.net/browse/OKTA-441939)

