### PR TITLE
fix: signInOptions context type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - [#1071](https://github.com/okta/okta-auth-js/pull/1071) TypeScript: Adds fields for `Input` type in NextStep object
+- [#1094](https://github.com/okta/okta-auth-js/pull/1094) TypeScript: Fixes `SigninOptions.context` type
 
 ## 6.0.0
 

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -235,7 +235,9 @@ export interface SigninOptions extends
   AuthenticationOptions {
     // Only used in Authn V1
     relayState?: string;
-    context?: string;
+    context?: {
+      deviceToken?: string;
+    };
     sendFingerprint?: boolean;
 }
 

--- a/test/types/auth.test-d.ts
+++ b/test/types/auth.test-d.ts
@@ -53,7 +53,10 @@ const authorizeOptions2: TokenParams = {
   expectType<AuthTransaction>(await authClient.signInWithCredentials({
     username: 'some-username',
     password: 'some-password',
-    sendFingerprint: true
+    sendFingerprint: true,
+    context: {
+      deviceToken: 'device-1'
+    }
   }));
   expectType<void>(await authClient.signInWithRedirect());
   expectType<void>(await authClient.signInWithRedirect({


### PR DESCRIPTION
https://developer.okta.com/docs/reference/api/authn/#context-object