### PR TITLE
feat(samples): catch and show oauth redirect errors

### DIFF
--- a/samples/config.js
+++ b/samples/config.js
@@ -77,7 +77,7 @@ const samples = [
     name: 'express-embedded-auth-with-sdk',
     pkgName: '@okta/samples.express.embedded-auth-with-sdk',
     template: 'express-embedded-auth-with-sdk',
-    specs: [],
+    specs: ['express-embedded-auth-with-sdk'],
     features: [
       'root-page', 
       'basic-auth', 

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/routes/login.js
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/routes/login.js
@@ -13,6 +13,7 @@
 
 const express = require('express');
 const URL = require('url').URL;
+const { hasErrorInUrl } = require('@okta/okta-auth-js');
 const { 
   getAuthClient, 
   handleTransaction,
@@ -89,6 +90,12 @@ router.get('/login/callback', async (req, res, next) => {
   const authClient = getAuthClient(req);
 
   try {
+    if(hasErrorInUrl(search)) {
+      const error = new Error(`${req.query.error}: ${req.query.error_description}`);
+      next(error);
+      return;
+    }
+
     if (authClient.idx.isEmailVerifyCallback(search)) {
       // may throw an EmailVerifyCallbackError if proceed is not possible
       const transaction = await authClient.idx.handleEmailVerifyCallback(search);

--- a/samples/templates/express-embedded-auth-with-sdk/web-server/routes/login.js
+++ b/samples/templates/express-embedded-auth-with-sdk/web-server/routes/login.js
@@ -13,6 +13,7 @@
 
 const express = require('express');
 const URL = require('url').URL;
+const { hasErrorInUrl } = require('@okta/okta-auth-js');
 const { 
   getAuthClient, 
   handleTransaction,
@@ -89,6 +90,12 @@ router.get('/login/callback', async (req, res, next) => {
   const authClient = getAuthClient(req);
 
   try {
+    if(hasErrorInUrl(search)) {
+      const error = new Error(`${req.query.error}: ${req.query.error_description}`);
+      next(error);
+      return;
+    }
+
     if (authClient.idx.isEmailVerifyCallback(search)) {
       // may throw an EmailVerifyCallbackError if proceed is not possible
       const transaction = await authClient.idx.handleEmailVerifyCallback(search);

--- a/samples/test/pageobjects/EmbeddedAuthWithSDKApp.js
+++ b/samples/test/pageobjects/EmbeddedAuthWithSDKApp.js
@@ -1,0 +1,17 @@
+import assert from 'assert';
+
+class EmbeddedAuthWithSDKApp {
+  get formMessages() { return $('#form-messages .list') }
+
+  async open() {
+    await browser.url('');
+  }
+
+  async assertLoginCallbackFailure(errorMessage) {
+    await this.formMessages.then(el => el.getText()).then(txt => {
+      assert(txt.trim() === errorMessage);
+    });
+  }
+}
+
+export default new EmbeddedAuthWithSDKApp();

--- a/samples/test/pageobjects/EmbeddedAuthWithSDKApp.js
+++ b/samples/test/pageobjects/EmbeddedAuthWithSDKApp.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
 class EmbeddedAuthWithSDKApp {
-  get formMessages() { return $('#form-messages .list') }
+  get formMessages() { return $('#form-messages .list'); }
 
   async open() {
     await browser.url('');

--- a/samples/test/specs/express-embedded-auth-with-sdk.js
+++ b/samples/test/specs/express-embedded-auth-with-sdk.js
@@ -1,0 +1,12 @@
+import EmbeddedAuthWithSDKApp from '../pageobjects/EmbeddedAuthWithSDKApp';
+import { startApp } from '../util';
+
+describe('express-embedded-auth-with-sdk', () => {
+
+  it('can handle general login callback error', async () => {
+    await startApp(EmbeddedAuthWithSDKApp);
+    await browser.url('/login/callback?error=X&error_description=Y');
+    await EmbeddedAuthWithSDKApp.assertLoginCallbackFailure('X: Y');
+  });
+
+});

--- a/test/apps/react-oie/src/App.js
+++ b/test/apps/react-oie/src/App.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { OktaAuth, IdxStatus, urlParamsToObject } from '@okta/okta-auth-js';
+import { OktaAuth, IdxStatus, urlParamsToObject, hasErrorInUrl } from '@okta/okta-auth-js';
 import { formTransformer } from './formTransformer';
 import oidcConfig from './config';
 import './App.css';
@@ -38,7 +38,16 @@ export default function App() {
     oktaAuth.authStateManager.subscribe(updateAuthState);
     oktaAuth.start();
 
-    if(oktaAuth.isLoginRedirect()) {
+    if (hasErrorInUrl(window.location.search)) {
+      const url = new URL(window.location.href);
+      const error = new Error(`${url.searchParams.get('error')}: ${url.searchParams.get('error_description')}`);
+      setAuthState({ isAuthenticated: false });
+      setTransaction({
+        status: IdxStatus.FAILURE,
+        error
+      });
+      return;
+    } else if(oktaAuth.isLoginRedirect()) {
       return parseFromUrl();
     }
     


### PR DESCRIPTION
spec passed in bacon:

```
2022-02-10 16:58:05  "spec" Reporter:
2022-02-10 16:58:05 ------------------------------------------------------------------
2022-02-10 16:58:05 [chrome 89.0.4389.72 linux #0-0] Running: chrome (v89.0.4389.72) on linux
2022-02-10 16:58:05 [chrome 89.0.4389.72 linux #0-0] Session ID: ab1f0ecaf3949402304d20a4f1c5a3c6
2022-02-10 16:58:05 [chrome 89.0.4389.72 linux #0-0]
2022-02-10 16:58:05 [chrome 89.0.4389.72 linux #0-0] » /specs/express-embedded-auth-with-sdk.js
2022-02-10 16:58:05 [chrome 89.0.4389.72 linux #0-0] express-embedded-auth-with-sdk
2022-02-10 16:58:05 [chrome 89.0.4389.72 linux #0-0]    ✓ can handle general login callback error
2022-02-10 16:58:05 [chrome 89.0.4389.72 linux #0-0]
2022-02-10 16:58:05 [chrome 89.0.4389.72 linux #0-0] 1 passing (450ms)
2022-02-10 16:58:05 
2022-02-10 16:58:05 
2022-02-10 16:58:05 Spec Files:	 1 passed, 1 total (100% completed) in 00:00:04 
```