### PR TITLE
Added 'Simulate cross-tab token renew' in test app

### DIFF
--- a/test/apps/app/public/renew/index.html
+++ b/test/apps/app/public/renew/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/oidc-app.css"/>
+</head>
+<body class="oidc-app callback">
+  <div id="root"></div>
+  <script src="/oidc-app.js"></script>
+  <script type="text/javascript">
+    bootstrapRenew();
+  </script>
+</body>
+</html>

--- a/test/apps/app/src/config.ts
+++ b/test/apps/app/src/config.ts
@@ -18,6 +18,7 @@ const PROTO = window.location.protocol;
 const REDIRECT_URI = `${PROTO}//${HOST}${LOGIN_CALLBACK_PATH}`;
 const POST_LOGOUT_REDIRECT_URI = `${PROTO}//${HOST}/`;
 const DEFAULT_SIW_VERSION = ''; // blank for local/npm/bundled version
+const DEFAULT_CROSS_TABS_COUNT = 20;
 
 export interface Config extends OktaAuthOptions {
   defaultScopes: boolean;
@@ -29,6 +30,7 @@ export interface Config extends OktaAuthOptions {
   useInteractionCodeFlow: boolean; // widget option
   enableSharedStorage: boolean; // TransactionManager
   isTokenRenewPage?: boolean; // special lite /renew page to test cross-tab token renew
+  crossTabsCount?: number;
 }
 
 export function getDefaultConfig(): Config {
@@ -54,7 +56,8 @@ export function getDefaultConfig(): Config {
     cookies: {
       secure: true
     },
-    enableSharedStorage: true
+    enableSharedStorage: true,
+    crossTabsCount: DEFAULT_CROSS_TABS_COUNT
   };
 }
 
@@ -81,6 +84,11 @@ export function getConfigFromUrl(): Config {
   const useInteractionCodeFlow = url.searchParams.get('useInteractionCodeFlow') === 'true'; // off by default
   const forceRedirect = url.searchParams.get('forceRedirect') === 'true'; // off by default
   const enableSharedStorage = url.searchParams.get('enableSharedStorage') !== 'false'; // on by default
+  const syncStorage = url.searchParams.get('syncStorage') !== 'false'; // on by default
+  let crossTabsCount = parseInt(url.searchParams.get('crossTabsCount'));
+  if (isNaN(crossTabsCount)) {
+    crossTabsCount = DEFAULT_CROSS_TABS_COUNT;
+  }
 
   return {
     issuer,
@@ -105,22 +113,26 @@ export function getConfigFromUrl(): Config {
     },
     tokenManager: {
       storage,
-      expireEarlySeconds
+      expireEarlySeconds,
+      syncStorage
     },
     transactionManager: {
       enableSharedStorage
     },
+    crossTabsCount
   };
 }
 
 export function saveConfigToStorage(config: Config): void {
   const configCopy: any = {};
-  Object.keys(config).forEach(key => {
-    if (typeof (config as any)[key] !== 'function' && !['isTokenRenewPage'].includes(key)) {
-      configCopy[key] = (config as any)[key];
-    }
-  });
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(configCopy));
+  if (!config.isTokenRenewPage) {
+    Object.keys(config).forEach(key => {
+      if (typeof (config as any)[key] !== 'function') {
+        configCopy[key] = (config as any)[key];
+      }
+    });
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(configCopy));
+  }
 }
 
 export function getConfigFromStorage(): Config {

--- a/test/apps/app/src/config.ts
+++ b/test/apps/app/src/config.ts
@@ -28,6 +28,7 @@ export interface Config extends OktaAuthOptions {
   forceRedirect: boolean;
   useInteractionCodeFlow: boolean; // widget option
   enableSharedStorage: boolean; // TransactionManager
+  isTokenRenewPage?: boolean; // special lite /renew page to test cross-tab token renew
 }
 
 export function getDefaultConfig(): Config {
@@ -115,7 +116,7 @@ export function getConfigFromUrl(): Config {
 export function saveConfigToStorage(config: Config): void {
   const configCopy: any = {};
   Object.keys(config).forEach(key => {
-    if (typeof (config as any)[key] !== 'function') {
+    if (typeof (config as any)[key] !== 'function' && !['isTokenRenewPage'].includes(key)) {
       configCopy[key] = (config as any)[key];
     }
   });

--- a/test/apps/app/src/config.ts
+++ b/test/apps/app/src/config.ts
@@ -61,7 +61,7 @@ export function getDefaultConfig(): Config {
   };
 }
 
-// eslint-disable-next-line complexity
+// eslint-disable-next-line complexity,max-statements
 export function getConfigFromUrl(): Config {
   const url = new URL(window.location.href);
   const issuer = url.searchParams.get('issuer');

--- a/test/apps/app/src/form.ts
+++ b/test/apps/app/src/form.ts
@@ -114,6 +114,15 @@ const Form = `
   <label for="idps">IDPs (in format "type:id" space-separated, example: "Facebook:111aaa Google:222bbb")</label>
   <input id="f_idps" name="idps" type="text" />
   </div>
+  <div class="pure-control-group">
+  <label for="syncStorage">Sync storage cross-tab</label>
+  <input id="f_syncStorage-on" name="syncStorage" type="radio" value="true"/>YES
+  <input id="f_syncStorage-off" name="syncStorage" type="radio" value="false"/>NO
+  </div>
+  <div class="pure-control-group">
+  <label for="crossTabsCount">Simulated tabs count</label>
+  <input id="f_crossTabsCount" name="crossTabsCount" type="number" min="1" max="1000" />
+  </div>
   <div class="pure-controls">
   <input id="f_submit" type="submit" value="Update Config" class="pure-button pure-button-primary"/>
   <a href="#clear" onclick="resetConfig(event)" class="pure-button">Reset Config</a>
@@ -138,6 +147,7 @@ export function updateForm(origConfig: Config): void {
   (document.querySelector(`#f_sameSite [value="${config.sameSite || ''}"]`) as HTMLOptionElement).selected = true;
   (document.getElementById('f_siwVersion') as HTMLInputElement).value = config.siwVersion;
   (document.getElementById('f_idps') as HTMLInputElement).value = config.idps;
+  (document.getElementById('f_crossTabsCount') as HTMLInputElement).value = config.crossTabsCount;
 
   if (config.pkce) {
     (document.getElementById('f_pkce-on') as HTMLInputElement).checked = true;
@@ -181,6 +191,12 @@ export function updateForm(origConfig: Config): void {
     (document.getElementById('f_enableSharedStorage-on') as HTMLInputElement).checked = true;
   } else {
     (document.getElementById('f_enableSharedStorage-off') as HTMLInputElement).checked = true;
+  }
+
+  if (config.syncStorage == false) {
+    (document.getElementById('f_syncStorage-off') as HTMLInputElement).checked = true;
+  } else {
+    (document.getElementById('f_syncStorage-on') as HTMLInputElement).checked = true;
   }
 }
 

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -246,8 +246,8 @@ class TestApp {
       const expiresAt = tokenStorage.accessToken.expiresAt;
       const now = Math.ceil(Date.now() / 1000);
       if (expiresAt - now > maxTimeToRenew) {
-        const content = Array.from({length: tabsCount}, () => `
-          <iframe src="${this.renewUrl}" width="250" height="100"></iframe>
+        const content = Array.from({length: tabsCount}, (_, i) => `
+          <iframe src="${this.renewUrl}#${i}" width="250" height="100"></iframe>
         `).join('\n');
         this._setCrossTabsContent(content);
         const iframes = document.getElementsByTagName('iframe');

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -246,7 +246,7 @@ class TestApp {
       const now = Math.ceil(Date.now() / 1000);
       if (expiresAt > now) {
         const expireEarlySeconds = expiresAt - now - waitBeforeRenewSeconds;
-        const content = Array.from({length: tabsCount}, (_, i) => `
+        const content = Array.from({length: tabsCount}, () => `
           <iframe src="${this.renewUrl}#${expireEarlySeconds}" width="250" height="100"></iframe>
         `).join('\n');
         this._setCrossTabsContent(content);
@@ -342,10 +342,11 @@ class TestApp {
     
     this.oktaAuth.authStateManager.subscribe(() => {
       const authState = this.oktaAuth.authStateManager.getAuthState();
-      if (authState.isAuthenticated)
+      if (authState.isAuthenticated) {
         document.getElementById('renew-status').innerHTML = 'Authenticated';
-      else
+      } else {
         document.getElementById('renew-status').innerHTML = 'Not authenticated';
+      }
     });
     this.oktaAuth.tokenManager.on('error', (err: unknown) => {
       this._onTokenError(err);

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -251,7 +251,7 @@ class TestApp {
         `).join('\n');
         this._setCrossTabsContent(content);
         const iframes = document.getElementsByTagName('iframe');
-        let iframesWindows: Window[] = [];
+        const iframesWindows: Window[] = [];
         for (let i = 0 ; i < iframes.length ; i++) {
           iframesWindows.push(iframes[i].contentWindow);
         }

--- a/test/apps/app/src/window.ts
+++ b/test/apps/app/src/window.ts
@@ -134,7 +134,7 @@ Object.assign(window, {
           autoRenew: true,
           autoRemove: false,
           syncStorage: config?.tokenManager?.syncStorage,
-          broadcastChannelName: config.clientId + "_crossTabTest"
+          broadcastChannelName: config.clientId + '_crossTabTest'
         };
         config.isTokenRenewPage = true;
     

--- a/test/apps/app/src/window.ts
+++ b/test/apps/app/src/window.ts
@@ -36,6 +36,7 @@ declare global {
     onFormData: (event: FormDataEvent) => void;
     bootstrapLanding: () => void;
     bootstrapLoginCallback: () => void;
+    bootstrapRenew: () => void;
     getWidgetConfig: () => any;
     getConfig: () => any;
     toQueryString: (obj: any) => string;
@@ -116,6 +117,22 @@ Object.assign(window, {
     config = getConfigFromStorage();
     mount();
     app.bootstrapLoginCallback();
+  },
+
+  bootstrapRenew: function(): void {
+    config = getConfigFromStorage();
+    const expireEarlySeconds = parseInt(window.location.hash.substring(1));
+    config.tokenManager = {
+      ...(config.tokenManager || {}),
+      expireEarlySeconds,
+      autoRenew: true,
+      autoRemove: false,
+      syncStorage: false
+    };
+    config.isTokenRenewPage = true;
+
+    mount();
+    app.bootstrapRenew();
   },
 
   bootstrapProtected: function(): void {

--- a/test/apps/app/src/window.ts
+++ b/test/apps/app/src/window.ts
@@ -133,8 +133,7 @@ Object.assign(window, {
           expireEarlySeconds,
           autoRenew: true,
           autoRemove: false,
-          syncStorage: config?.tokenManager?.syncStorage,
-          broadcastChannelName: config.clientId + '_crossTabTest'
+          syncStorage: config?.tokenManager?.syncStorage
         };
         config.isTokenRenewPage = true;
     

--- a/test/apps/app/src/window.ts
+++ b/test/apps/app/src/window.ts
@@ -120,19 +120,28 @@ Object.assign(window, {
   },
 
   bootstrapRenew: function(): void {
-    config = getConfigFromStorage();
-    const expireEarlySeconds = parseInt(window.location.hash.substring(1));
-    config.tokenManager = {
-      ...(config.tokenManager || {}),
-      expireEarlySeconds,
-      autoRenew: true,
-      autoRemove: false,
-      syncStorage: false
-    };
-    config.isTokenRenewPage = true;
-
-    mount();
-    app.bootstrapRenew();
+    rootElem.innerHTML = 'Loading...';
+    window.postMessage({
+      name:'crossTabTest_ready'
+    }, window.parent.location.origin);
+    window.addEventListener('message', (e) => {
+      if (e.data?.name === 'crossTabTest_bootstrap') {
+        const { expireEarlySeconds } = e.data;
+        config = getConfigFromStorage();
+        config.tokenManager = {
+          ...(config.tokenManager || {}),
+          expireEarlySeconds,
+          autoRenew: true,
+          autoRemove: false,
+          syncStorage: config?.tokenManager?.syncStorage,
+          broadcastChannelName: config.clientId + "_crossTabTest"
+        };
+        config.isTokenRenewPage = true;
+    
+        mount();
+        app.bootstrapRenew();
+      }
+    });
   },
 
   bootstrapProtected: function(): void {


### PR DESCRIPTION
Internal ref: https://oktainc.atlassian.net/browse/OKTA-456240
Added button 'Simulate cross-tab token renew' in test app that opens 20 iframes that tries to autorenew tokens simultaneously.
Practically system allows to run 15 simultaneous renew requests, next ones will result in HTTP 429.
See video

https://user-images.githubusercontent.com/72614880/153445394-9e862d5c-7ec4-453e-afb7-f293f1b4777f.mov

 