### PR TITLE
 Separate browser and node modules at build time - OKTA-446542

### DIFF
--- a/jest.browser.js
+++ b/jest.browser.js
@@ -9,7 +9,10 @@ const config = Object.assign({}, baseConfig, {
   testPathIgnorePatterns: baseConfig.testPathIgnorePatterns.concat([
     '<rootDir>/test/spec/serverStorage.js',
     '<rootDir>/test/spec/features/server'
-  ])
+  ]),
+  moduleNameMapper: Object.assign({}, baseConfig.moduleNameMapper, {
+    '^./node$': './browser'
+  })
 });
 
 module.exports = config;

--- a/lib/options/browser.ts
+++ b/lib/options/browser.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { StorageManagerOptions } from '../types';
+
+export { default as storage } from '../browser/browserStorage';
+
+export const STORAGE_MANAGER_OPTIONS: StorageManagerOptions = {
+  token: {
+    storageTypes: [
+      'localStorage',
+      'sessionStorage',
+      'cookie'
+    ]
+  },
+  cache: {
+    storageTypes: [
+      'localStorage',
+      'sessionStorage',
+      'cookie'
+    ]
+  },
+  transaction: {
+    storageTypes: [
+      'sessionStorage',
+      'localStorage',
+      'cookie'
+    ]
+  },
+  'shared-transaction': {
+    storageTypes: [
+      'localStorage'
+    ]
+  },
+  'original-uri': {
+    storageTypes: [
+      'localStorage'
+    ]
+  }
+};
+
+export const enableSharedStorage = true;

--- a/lib/options/index.ts
+++ b/lib/options/index.ts
@@ -12,66 +12,13 @@
 
 
 /* eslint-disable complexity */
-import { removeTrailingSlash, warn, removeNils } from './util';
-import { assertValidConfig } from './builderUtil';
-import { OktaAuthOptions, StorageManagerOptions } from './types';
+import { removeTrailingSlash, warn, removeNils } from '../util';
+import { assertValidConfig } from '../builderUtil';
+import { OktaAuthOptions } from '../types';
 
-import fetchRequest from './fetch/fetchRequest';
-import browserStorage from './browser/browserStorage';
-import serverStorage from './server/serverStorage';
-import { isBrowser, isHTTPS } from './features';
-
-const BROWSER_STORAGE: StorageManagerOptions = {
-  token: {
-    storageTypes: [
-      'localStorage',
-      'sessionStorage',
-      'cookie'
-    ]
-  },
-  cache: {
-    storageTypes: [
-      'localStorage',
-      'sessionStorage',
-      'cookie'
-    ]
-  },
-  transaction: {
-    storageTypes: [
-      'sessionStorage',
-      'localStorage',
-      'cookie'
-    ]
-  },
-  'shared-transaction': {
-    storageTypes: [
-      'localStorage'
-    ]
-  },
-  'original-uri': {
-    storageTypes: [
-      'localStorage'
-    ]
-  }
-};
-
-const SERVER_STORAGE: StorageManagerOptions = {
-  token: {
-    storageTypes: [
-      'memory'
-    ]
-  },
-  cache: {
-    storageTypes: [
-      'memory'
-    ]
-  },
-  transaction: {
-    storageTypes: [
-      'memory'
-    ]
-  }
-};
+import fetchRequest from '../fetch/fetchRequest';
+import { storage, STORAGE_MANAGER_OPTIONS, enableSharedStorage } from './node';
+import { isBrowser, isHTTPS } from '../features';
 
 function getCookieSettings(args: OktaAuthOptions = {}, isHTTPS: boolean) {
   // Secure cookies will be automatically used on a HTTPS connection
@@ -107,18 +54,16 @@ function getCookieSettings(args: OktaAuthOptions = {}, isHTTPS: boolean) {
 
 
 export function getDefaultOptions(): OktaAuthOptions {
-  const storageUtil = isBrowser() ? browserStorage : serverStorage;
-  const storageManager = isBrowser() ? BROWSER_STORAGE : SERVER_STORAGE;
-  const enableSharedStorage = isBrowser() ? true : false; // localStorage for multi-tab flows (browser only)
-  return {
+  const options = {
     devMode: false,
     httpRequestClient: fetchRequest,
-    storageUtil,
-    storageManager,
+    storageUtil: storage,
+    storageManager: STORAGE_MANAGER_OPTIONS,
     transactionManager: {
       enableSharedStorage
     }
   };
+  return options;
 }
 
 function mergeOptions(options, args): OktaAuthOptions {
@@ -165,7 +110,7 @@ export function buildOptions(args: OktaAuthOptions = {}): OktaAuthOptions {
     codeChallengeMethod: args.codeChallengeMethod,
     recoveryToken: args.recoveryToken,
     activationToken: args.activationToken,
-    
+
     // Give the developer the ability to disable token signature validation.
     ignoreSignature: !!args.ignoreSignature,
 

--- a/lib/options/index.ts
+++ b/lib/options/index.ts
@@ -10,48 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-
-/* eslint-disable complexity */
-import { removeTrailingSlash, warn, removeNils } from '../util';
+import { removeTrailingSlash, removeNils } from '../util';
 import { assertValidConfig } from '../builderUtil';
 import { OktaAuthOptions } from '../types';
 
 import fetchRequest from '../fetch/fetchRequest';
-import { storage, STORAGE_MANAGER_OPTIONS, enableSharedStorage } from './node';
-import { isBrowser, isHTTPS } from '../features';
-
-function getCookieSettings(args: OktaAuthOptions = {}, isHTTPS: boolean) {
-  // Secure cookies will be automatically used on a HTTPS connection
-  // Non-secure cookies will be automatically used on a HTTP connection
-  // secure option can override the automatic behavior
-  var cookieSettings = args.cookies || {};
-  if (typeof cookieSettings.secure === 'undefined') {
-    cookieSettings.secure = isHTTPS;
-  }
-  if (typeof cookieSettings.sameSite === 'undefined') {
-    cookieSettings.sameSite = cookieSettings.secure ? 'none' : 'lax';
-  }
-
-  // If secure=true, but the connection is not HTTPS, set secure=false.
-  if (cookieSettings.secure && !isHTTPS) {
-    // eslint-disable-next-line no-console
-    warn(
-      'The current page is not being served with the HTTPS protocol.\n' +
-      'For security reasons, we strongly recommend using HTTPS.\n' +
-      'If you cannot use HTTPS, set "cookies.secure" option to false.'
-    );
-    cookieSettings.secure = false;
-  }
-
-  // Chrome >= 80 will block cookies with SameSite=None unless they are also Secure
-  // If sameSite=none, but the connection is not HTTPS, set sameSite=lax.
-  if (cookieSettings.sameSite === 'none' && !cookieSettings.secure) {
-    cookieSettings.sameSite = 'lax';
-  }
-
-  return cookieSettings;
-}
-
+import { storage, STORAGE_MANAGER_OPTIONS, enableSharedStorage, getCookieSettings } from './node';
+import { isHTTPS } from '../features';
 
 export function getDefaultOptions(): OktaAuthOptions {
   const options = {
@@ -104,7 +69,7 @@ export function buildOptions(args: OktaAuthOptions = {}): OktaAuthOptions {
     devMode: !!args.devMode,
     storageManager: args.storageManager,
     transactionManager: args.transactionManager,
-    cookies: isBrowser() ? getCookieSettings(args, isHTTPS()) : args.cookies,
+    cookies: getCookieSettings(args, isHTTPS()),
     flow: args.flow,
     codeChallenge: args.codeChallenge,
     codeChallengeMethod: args.codeChallengeMethod,

--- a/lib/options/node.ts
+++ b/lib/options/node.ts
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { StorageManagerOptions } from '../types';
+
+export { default as storage } from '../server/serverStorage';
+
+export const STORAGE_MANAGER_OPTIONS: StorageManagerOptions = {
+  token: {
+    storageTypes: [
+      'memory'
+    ]
+  },
+  cache: {
+    storageTypes: [
+      'memory'
+    ]
+  },
+  transaction: {
+    storageTypes: [
+      'memory'
+    ]
+  }
+};
+
+export const enableSharedStorage = false;

--- a/lib/options/node.ts
+++ b/lib/options/node.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { StorageManagerOptions } from '../types';
+import { StorageManagerOptions, OktaAuthOptions } from '../types';
 
 export { default as storage } from '../server/serverStorage';
 
@@ -33,3 +33,8 @@ export const STORAGE_MANAGER_OPTIONS: StorageManagerOptions = {
 };
 
 export const enableSharedStorage = false;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+export function getCookieSettings(args: OktaAuthOptions = {}, isHTTPS?: boolean) {
+  return args.cookies;
+}

--- a/test/spec/AuthStateManager.js
+++ b/test/spec/AuthStateManager.js
@@ -15,7 +15,8 @@
 
 import Emitter from 'tiny-emitter';
 import { AuthStateManager, INITIAL_AUTH_STATE } from '../../lib/AuthStateManager';
-import { OktaAuth, AuthSdkError } from '@okta/okta-auth-js';
+import { AuthSdkError } from '../../lib/errors';
+import { OktaAuth } from '@okta/okta-auth-js';
 import tokens from '@okta/test.support/tokens';
 
 function createAuth() {

--- a/test/spec/OktaAuth/constructor.ts
+++ b/test/spec/OktaAuth/constructor.ts
@@ -98,7 +98,13 @@ describe('OktaAuth (constructor)', () => {
             },
             transaction: {
               storageTypes: ['a', 'b']
-            }
+            },
+            'original-uri':  {
+              storageTypes:  ['a'],
+            },
+            'shared-transaction': {
+              storageTypes: ['a'],
+            },
           };
           break;
         case 'cookies':

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -14,7 +14,7 @@ var babelOptions = {
   shouldPrintComment: () => false 
 };
 
-var babelExclude = /node_modules\/(?!p-cancelable|node-cache)/;
+var babelExclude = /node_modules\/(?!p-cancelable)/;
 
 module.exports = {
   module: {
@@ -44,7 +44,6 @@ module.exports = {
     extensions: ['.js', '.ts'],
     alias: {
       './node$': './browser', // use browser built-in objects and functions
-      'node-cache': false // do not webpack node-only modules
     }
   },
   plugins: [


### PR DESCRIPTION
This change excludes `node-cache` package from browser related bundles (esm, umd, cdn) by separating environment specific logic at build time.

Downstream Tests (green):
* okta-signin-widget: https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&sha=81325d06e8851815649feae5c8bab836721af078&page=1&pageSize=6
* monolith: https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&sha=a0acd99fc99252d9f9856c78d19b91b55d0e06b0&page=1&pageSize=6
