### PR TITLE
Added ServiceManager to elect leader for token auto renew service

### DIFF
--- a/jest.server.js
+++ b/jest.server.js
@@ -25,7 +25,8 @@ const config = Object.assign({}, baseConfig, {
     'oidc/renewToken.ts',
     'oidc/renewTokens.ts',
     'TokenManager/browser',
-    'TokenManager/crossTabs'
+    'SyncStorageService',
+    'ServiceManager'
   ])
 });
 

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -97,6 +97,7 @@ import {
   clone,
 } from './util';
 import { TokenManager } from './TokenManager';
+import { ServiceManager } from './ServiceManager';
 import { get, httpRequest, setRequestHeader } from './http';
 import PromiseQueue from './PromiseQueue';
 import fingerprint from './browser/fingerprint';
@@ -154,6 +155,7 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
   emitter: typeof Emitter;
   tokenManager: TokenManager;
   authStateManager: AuthStateManager;
+  serviceManager: ServiceManager;
   http: HttpAPI;
   fingerprint: FingerprintAPI;
   _oktaUserAgent: OktaUserAgent;
@@ -350,6 +352,9 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
 
     // AuthStateManager
     this.authStateManager = new AuthStateManager(this);
+
+    // ServiceManager
+    this.serviceManager = new ServiceManager(this.tokenManager, this.tokenManager.getOptions());
   }
 
   start() {
@@ -357,10 +362,12 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
     if (!this.token.isLoginRedirect()) {
       this.authStateManager.updateAuthState();
     }
+    this.serviceManager.start();
   }
 
   stop() {
     this.tokenManager.stop();
+    this.serviceManager.stop();
   }
 
   setHeaders(headers) {

--- a/lib/ServiceManager.ts
+++ b/lib/ServiceManager.ts
@@ -11,7 +11,6 @@
  */
 
 
-/* global window */
 import {
   TokenManagerOptions,
   ServiceManagerInterface

--- a/lib/ServiceManager.ts
+++ b/lib/ServiceManager.ts
@@ -106,18 +106,20 @@ export class ServiceManager implements ServiceManagerInterface {
 
   private startElector() {
     if (ServiceManager.canUseLeaderElection()) {
-      this.channel = new BroadcastChannel(this.options.broadcastChannelName as string);
-      this.elector = createLeaderElection(this.channel);
-      this.elector.onduplicate = this.onLeaderDuplicate;
-      this.elector.awaitLeadership().then(this.onLeader);
+      if (!this.channel) {
+        this.channel = new BroadcastChannel(this.options.broadcastChannelName as string);
+      }
+      if (!this.elector) {
+        this.elector = createLeaderElection(this.channel);
+        this.elector.onduplicate = this.onLeaderDuplicate;
+        this.elector.awaitLeadership().then(this.onLeader);
+      }
     }
   }
 
   private stopElector() {
     this.elector?.die();
     this.elector = undefined;
-    this.channel?.close();
-    this.channel = undefined;
   }
 
   private createService(name: string): TokenService | undefined {

--- a/lib/ServiceManager.ts
+++ b/lib/ServiceManager.ts
@@ -1,0 +1,120 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+/* global window */
+import {
+  TokenManagerOptions,
+  ServiceManagerInterface
+} from './types';
+import { TokenManager } from './TokenManager';
+import {
+  BroadcastChannel,
+  createLeaderElection,
+  LeaderElector
+} from 'broadcast-channel';
+import { TokenService, AutoRenewService, SyncStorageService } from './services';
+
+export class ServiceManager implements ServiceManagerInterface {
+  protected tokenManager: TokenManager;
+  protected options: TokenManagerOptions;
+  private services: Map<string, TokenService>;
+  private channel: BroadcastChannel;
+  private elector: LeaderElector;
+  private started: boolean;
+
+  private static knownServices = ['autoRenew', 'syncStorage'];
+
+  constructor(tokenManager: TokenManager, options: TokenManagerOptions = {}) {
+    this.started = false;
+    this.tokenManager = tokenManager;
+    this.options = options;
+    this.services = new Map();
+
+    // Start elector
+    this.channel = new BroadcastChannel(options.broadcastChannelName as string);
+    this.elector = createLeaderElection(this.channel);
+    this.elector.onduplicate = this.onLeaderDuplicate.bind(this);
+    this.elector.awaitLeadership().then(this.onLeader.bind(this));
+  }
+
+  private onLeader() {
+    if (this.started) {
+      // Start services that requires leadership
+      this.startServices();
+    }
+  }
+
+  private onLeaderDuplicate() {
+  }
+
+  isLeader() {
+    return this.elector.isLeader;
+  }
+
+  hasLeader() {
+    return this.elector.hasLeader;
+  }
+
+  start() {
+    if (this.started) {
+      this.stop();
+    }
+    this.startServices();
+    this.started = true;
+  }
+  
+  stop() {
+    this.stopServices();
+    this.started = false;
+  }
+
+  getService(name: string): TokenService | undefined {
+    return this.services.get(name);
+  }
+
+  private stopServices() {
+    for (const srv of this.services.values()) {
+      srv.stop();
+    }
+    this.services = new Map();
+  }
+
+  private startServices() {
+    for (const name of ServiceManager.knownServices) {
+      const srv = this.createService(name);
+      if (srv) {
+        const canStart = srv.canStart() && !srv.isStarted() && (srv.requiresLeadership() ? this.isLeader() : true);
+        if (canStart) {
+          srv.start();
+          this.services.set(name, srv);
+        }
+      }
+    }
+  }
+
+  private createService(name: string): TokenService | undefined {
+    let service: TokenService | undefined;
+    switch (name) {
+      case 'autoRenew':
+        service = new AutoRenewService(this.tokenManager, this.options);
+        break;
+      case 'syncStorage':
+        service = new SyncStorageService(this.tokenManager, this.options);
+        break;
+      default:
+        throw new Error(`Unknown service ${name}`);
+    }
+    return service;
+  }
+
+}

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -72,6 +72,7 @@ export class TokenManager implements TokenManagerInterface {
   on: (event: string, handler: TokenManagerErrorEventHandler | TokenManagerEventHandler, context?: object) => void;
   off: (event: string, handler?: TokenManagerErrorEventHandler | TokenManagerEventHandler) => void;
 
+  // eslint-disable-next-line complexity
   constructor(sdk: OktaAuthInterface, options: TokenManagerOptions = {}) {
     this.sdk = sdk;
     this.emitter = (sdk as any).emitter;
@@ -422,7 +423,6 @@ export class TokenManager implements TokenManagerInterface {
         return tokens[tokenType];
       })
       .catch(err => {
-        console.log(222, err)
         // If renew fails, remove token from storage and emit error
         this.remove(key);
         err.tokenKey = key;

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -34,7 +34,6 @@ import {
   RefreshToken
 } from './types';
 import { REFRESH_TOKEN_STORAGE_KEY, TOKEN_STORAGE_NAME } from './constants';
-import { TokenService } from './services/TokenService';
 
 const DEFAULT_OPTIONS = {
   autoRenew: true,
@@ -69,7 +68,6 @@ export class TokenManager implements TokenManagerInterface {
   private storage: StorageProvider;
   private state: TokenManagerState;
   private options: TokenManagerOptions;
-  private service: TokenService | null;
 
   on: (event: string, handler: TokenManagerErrorEventHandler | TokenManagerEventHandler, context?: object) => void;
   off: (event: string, handler?: TokenManagerErrorEventHandler | TokenManagerEventHandler) => void;
@@ -80,7 +78,6 @@ export class TokenManager implements TokenManagerInterface {
     if (!this.emitter) {
       throw new AuthSdkError('Emitter should be initialized before TokenManager');
     }
-    this.service = null;
     
     options = Object.assign({}, DEFAULT_OPTIONS, removeNils(options));
     if (isIE11OrLess()) {
@@ -88,6 +85,9 @@ export class TokenManager implements TokenManagerInterface {
     }
     if (!isLocalhost()) {
       options.expireEarlySeconds = DEFAULT_OPTIONS.expireEarlySeconds;
+    }
+    if (!options.broadcastChannelName) {
+      options.broadcastChannelName = sdk.options.clientId;
     }
     this.options = options;
 
@@ -111,21 +111,20 @@ export class TokenManager implements TokenManagerInterface {
   }
 
   start() {
-    if (this.service) {
-      this.stop();
-    }
     if (this.options.clearPendingRemoveTokens) {
       this.clearPendingRemoveTokens();
     }
-    this.service = new TokenService(this, this.getOptions());
-    this.service.start();
+    this.setExpireEventTimeoutAll();
+
+    // todo
+    this.sdk.serviceManager.start();
   }
   
   stop() {
-    if (this.service) {
-      this.service.stop();
-      this.service = null;
-    }
+    this.clearExpireEventTimeoutAll();
+
+    // todo
+    this.sdk.serviceManager.stop();
   }
 
   getOptions(): TokenManagerOptions {
@@ -423,6 +422,7 @@ export class TokenManager implements TokenManagerInterface {
         return tokens[tokenType];
       })
       .catch(err => {
+        console.log(222, err)
         // If renew fails, remove token from storage and emit error
         this.remove(key);
         err.tokenKey = key;

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -116,16 +116,10 @@ export class TokenManager implements TokenManagerInterface {
       this.clearPendingRemoveTokens();
     }
     this.setExpireEventTimeoutAll();
-
-    // todo
-    this.sdk.serviceManager.start();
   }
   
   stop() {
     this.clearExpireEventTimeoutAll();
-
-    // todo
-    this.sdk.serviceManager.stop();
   }
 
   getOptions(): TokenManagerOptions {

--- a/lib/services/AutoRenewService.ts
+++ b/lib/services/AutoRenewService.ts
@@ -11,11 +11,11 @@
  */
 
 
-/* global window */
 import { TokenService } from './TokenService';
 import { TokenManager, EVENT_EXPIRED } from '../TokenManager';
 import { AuthSdkError } from '../errors';
-import { TokenManagerOptions, Token } from '../types';
+import { TokenManagerOptions } from '../types';
+import { isBrowser } from '../features';
 
 export class AutoRenewService extends TokenService {
   private renewTimeQueue: Array<number>;
@@ -44,7 +44,7 @@ export class AutoRenewService extends TokenService {
 
   requiresLeadership() {
     // If tokens sync storage is enabled, handle tokens expiration only in 1 leader tab
-    return !!this.options.syncStorage;
+    return !!this.options.syncStorage && isBrowser();
   }
 
   private onTokenExpiredHandler(key: string) {

--- a/lib/services/SyncStorageService.ts
+++ b/lib/services/SyncStorageService.ts
@@ -1,0 +1,69 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+/* global window */
+import { TokenService } from './TokenService';
+import { TokenManager } from '../TokenManager';
+import { isBrowser } from '../features';
+import { TokenManagerOptions, TokenServiceInterface } from '../types';
+
+
+export class SyncStorageService extends TokenService implements TokenServiceInterface {
+  private syncTimeout: unknown;
+
+  constructor(tokenManager: TokenManager, options: TokenManagerOptions = {}) {
+    super(tokenManager, options);
+    this.storageListener = this.storageListener.bind(this);
+  }
+
+  // Sync authState cross multiple tabs when localStorage is used as the storageProvider
+  // A StorageEvent is sent to a window when a storage area it has access to is changed 
+  // within the context of another document.
+  // https://developer.mozilla.org/en-US/docs/Web/API/StorageEvent
+  private storageListener({ key, newValue, oldValue }: StorageEvent) {
+    const handleCrossTabsStorageChange = () => {
+      this.tokenManager.resetExpireEventTimeoutAll();
+      this.tokenManager.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
+    };
+
+    // Skip if:
+    // not from localStorage.clear (event.key is null)
+    // event.key is not the storageKey
+    // oldValue === newValue
+    if (key && (key !== this.options.storageKey || newValue === oldValue)) {
+      return;
+    }
+
+    // LocalStorage cross tabs update is not synced in IE, set a 1s timer by default to read latest value
+    // https://stackoverflow.com/questions/24077117/localstorage-in-win8-1-ie11-does-not-synchronize
+    this.syncTimeout = setTimeout(() => handleCrossTabsStorageChange(), this.options._storageEventDelay);
+  }
+
+  canStart() {
+    return !!this.options.syncStorage && isBrowser();
+  }
+
+  requiresLeadership() {
+    return false;
+  }
+
+  _start() {
+    window.addEventListener('storage', this.storageListener);
+  }
+
+  _stop() {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    window.removeEventListener('storage', this.storageListener!);
+    clearTimeout(this.syncTimeout as any);
+  }
+} 

--- a/lib/services/TokenService.ts
+++ b/lib/services/TokenService.ts
@@ -12,91 +12,47 @@
 
 
 /* global window */
-import { TokenManager, EVENT_EXPIRED } from '../TokenManager';
-import { AuthSdkError } from '../errors';
-import { isBrowser } from '../features';
-import { TokenManagerOptions } from '../types';
+import { TokenManager } from '../TokenManager';
+import { TokenManagerOptions, TokenServiceInterface } from '../types';
 
-function shouldThrottleRenew(renewTimeQueue) {
-  let res = false;
-  renewTimeQueue.push(Date.now());
-  if (renewTimeQueue.length >= 10) {
-    // get and remove first item from queue
-    const firstTime = renewTimeQueue.shift();
-    const lastTime = renewTimeQueue[renewTimeQueue.length - 1];
-    res = lastTime - firstTime < 30 * 1000;
-  }
-  return res;
-}
-
-export class TokenService {
-  private tokenManager: TokenManager;
-  private options: TokenManagerOptions;
-  private storageListener?: (event: StorageEvent) => void;
-  private onTokenExpiredHandler?: (key: string) => void;
-  private syncTimeout: unknown;
+export abstract class TokenService implements TokenServiceInterface {
+  protected tokenManager: TokenManager;
+  protected options: TokenManagerOptions;
+  private started: boolean;
 
   constructor(tokenManager: TokenManager, options: TokenManagerOptions = {}) {
     this.tokenManager = tokenManager;
     this.options = options;
-    this.storageListener = undefined;
-    this.onTokenExpiredHandler = undefined;
+    this.started = false;
   }
 
+  abstract _start(): void;
+  abstract _stop(): void;
+
   start() {
-    const renewTimeQueue = [];
-    this.onTokenExpiredHandler = (key) => {
-      if (this.options.autoRenew) {
-        if (shouldThrottleRenew(renewTimeQueue)) {
-          const error = new AuthSdkError('Too many token renew requests');
-          this.tokenManager.emitError(error);
-        } else {
-          this.tokenManager.renew(key).catch(() => {}); // Renew errors will emit an "error" event 
-        }
-      } else if (this.options.autoRemove) {
-        this.tokenManager.remove(key);
-      }
-    };
-    this.tokenManager.on(EVENT_EXPIRED, this.onTokenExpiredHandler);
-
-    this.tokenManager.setExpireEventTimeoutAll();
-
-    if (this.options.syncStorage && isBrowser()) {
-      // Sync authState cross multiple tabs when localStorage is used as the storageProvider
-      // A StorageEvent is sent to a window when a storage area it has access to is changed 
-      // within the context of another document.
-      // https://developer.mozilla.org/en-US/docs/Web/API/StorageEvent
-
-      this.storageListener = ({ key, newValue, oldValue }: StorageEvent) => {
-        const handleCrossTabsStorageChange = () => {
-          this.tokenManager.resetExpireEventTimeoutAll();
-          this.tokenManager.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
-        };
-
-        // Skip if:
-        // not from localStorage.clear (event.key is null)
-        // event.key is not the storageKey
-        // oldValue === newValue
-        if (key && (key !== this.options.storageKey || newValue === oldValue)) {
-          return;
-        }
-
-        // LocalStorage cross tabs update is not synced in IE, set a 1s timer by default to read latest value
-        // https://stackoverflow.com/questions/24077117/localstorage-in-win8-1-ie11-does-not-synchronize
-        this.syncTimeout = setTimeout(() => handleCrossTabsStorageChange(), this.options._storageEventDelay);
-      };
-
-      window.addEventListener('storage', this.storageListener);
+    this.stop();
+    if (this.canStart()) {
+      this._start();
+      this.started = true;
     }
   }
 
   stop() {
-    this.tokenManager.clearExpireEventTimeoutAll();
-    this.tokenManager.off(EVENT_EXPIRED, this.onTokenExpiredHandler);
-    if (this.options.syncStorage && isBrowser()) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      window.removeEventListener('storage', this.storageListener!);
-      clearTimeout(this.syncTimeout as any);
+    if (this.started) {
+      this._stop();
     }
+    this.started = false;
+  }
+
+  canStart() {
+    return true;
+  }
+
+  requiresLeadership() {
+    return false;
+  }
+
+  isStarted() {
+    return this.started;
   }
 }

--- a/lib/services/TokenService.ts
+++ b/lib/services/TokenService.ts
@@ -11,7 +11,6 @@
  */
 
 
-/* global window */
 import { TokenManager } from '../TokenManager';
 import { TokenManagerOptions, TokenServiceInterface } from '../types';
 

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -6,23 +6,11 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
+ * 
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export * from './api';
-export * from './AuthState';
-export * from './EventEmitter';
-export * from './Transaction';
-export * from './Cookies';
-export * from './http';
-export * from '../idx/types';
-export * from './JWT';
-export * from './OAuth';
-export * from './OktaAuthOptions';
-export * from './Storage';
-export * from './Token';
-export * from './TokenManager';
+
 export * from './TokenService';
-export * from './ServiceManager';
-export * from './UserClaims';
+export * from './AutoRenewService';
+export * from './SyncStorageService';

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -27,6 +27,7 @@ export interface TokenManagerOptions {
   expireEarlySeconds?: number;
   syncStorage?: boolean;
   _storageEventDelay?: number;
+  broadcastChannelName?: string;
 }
 
 export interface CustomUrls {

--- a/lib/types/ServiceManager.ts
+++ b/lib/types/ServiceManager.ts
@@ -5,5 +5,5 @@ export interface ServiceManagerInterface {
   isLeader(): boolean;
   start(): void;
   stop(): void;
-  getService(name: string): TokenServiceInterface | undefined
+  getService(name: string): TokenServiceInterface | undefined;
 }

--- a/lib/types/ServiceManager.ts
+++ b/lib/types/ServiceManager.ts
@@ -1,0 +1,9 @@
+import { TokenServiceInterface } from './TokenService';
+
+// only add methods needed internally
+export interface ServiceManagerInterface {
+  isLeader(): boolean;
+  start(): void;
+  stop(): void;
+  getService(name: string): TokenServiceInterface | undefined
+}

--- a/lib/types/TokenService.ts
+++ b/lib/types/TokenService.ts
@@ -1,0 +1,7 @@
+export interface TokenServiceInterface {
+  start(): void;
+  stop(): void;
+  isStarted(): boolean;
+  canStart(): boolean;
+  requiresLeadership(): boolean;
+}

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -18,6 +18,7 @@ import { CustomUrls, OktaAuthOptions } from './OktaAuthOptions';
 import { StorageManager } from '../StorageManager';
 import TransactionManager from '../TransactionManager';
 import { TokenManagerInterface } from './TokenManager';
+import { ServiceManagerInterface } from './ServiceManager';
 import { OktaUserAgent } from '../OktaUserAgent';
 import { 
   AuthenticationOptions, 
@@ -51,6 +52,7 @@ export interface OktaAuthInterface {
   storageManager: StorageManager;
   transactionManager: TransactionManager;
   tokenManager: TokenManagerInterface;
+  serviceManager: ServiceManagerInterface;
 
   idx: IdxAPI;
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@peculiar/webcrypto": "1.1.6",
     "Base64": "1.1.0",
     "atob": "^2.1.2",
+    "broadcast-channel": "^4.10.0",
     "btoa": "^1.2.1",
     "core-js": "^3.6.5",
     "cross-fetch": "^3.1.5",

--- a/test/apps/app/src/config.ts
+++ b/test/apps/app/src/config.ts
@@ -18,7 +18,7 @@ const PROTO = window.location.protocol;
 const REDIRECT_URI = `${PROTO}//${HOST}${LOGIN_CALLBACK_PATH}`;
 const POST_LOGOUT_REDIRECT_URI = `${PROTO}//${HOST}/`;
 const DEFAULT_SIW_VERSION = ''; // blank for local/npm/bundled version
-const DEFAULT_CROSS_TABS_COUNT = 20;
+export const DEFAULT_CROSS_TABS_COUNT = 20;
 
 export interface Config extends OktaAuthOptions {
   defaultScopes: boolean;

--- a/test/apps/app/src/form.ts
+++ b/test/apps/app/src/form.ts
@@ -17,6 +17,7 @@
 import { flattenConfig, Config, clearStorage } from './config';
 import { FormDataEvent } from './types';
 import { htmlString, makeClickHandler } from './util';
+import { DEFAULT_CROSS_TABS_COUNT } from './config';
 
 const id = 'config-form';
 const Form = `
@@ -147,7 +148,7 @@ export function updateForm(origConfig: Config): void {
   (document.querySelector(`#f_sameSite [value="${config.sameSite || ''}"]`) as HTMLOptionElement).selected = true;
   (document.getElementById('f_siwVersion') as HTMLInputElement).value = config.siwVersion;
   (document.getElementById('f_idps') as HTMLInputElement).value = config.idps;
-  (document.getElementById('f_crossTabsCount') as HTMLInputElement).value = config.crossTabsCount;
+  (document.getElementById('f_crossTabsCount') as HTMLInputElement).value = config.crossTabsCount || DEFAULT_CROSS_TABS_COUNT;
 
   if (config.pkce) {
     (document.getElementById('f_pkce-on') as HTMLInputElement).checked = true;

--- a/test/apps/app/src/window.ts
+++ b/test/apps/app/src/window.ts
@@ -133,7 +133,8 @@ Object.assign(window, {
           expireEarlySeconds,
           autoRenew: true,
           autoRemove: false,
-          syncStorage: config?.tokenManager?.syncStorage
+          syncStorage: config?.tokenManager?.syncStorage,
+          broadcastChannelName: config.clientId + '_crossTabTest'
         };
         config.isTokenRenewPage = true;
     

--- a/test/spec/AuthStateManager.js
+++ b/test/spec/AuthStateManager.js
@@ -18,6 +18,7 @@ import { AuthStateManager, INITIAL_AUTH_STATE } from '../../lib/AuthStateManager
 import { AuthSdkError } from '../../lib/errors';
 import { OktaAuth } from '@okta/okta-auth-js';
 import tokens from '@okta/test.support/tokens';
+import util from '@okta/test.support/util';
 
 function createAuth() {
   return new OktaAuth({
@@ -129,10 +130,12 @@ describe('AuthStateManager', () => {
         return;
       }
       it('should only trigger authStateManager.updateAuthState once when localStorage changed from other dom', () => {
+        util.disableLeaderElection();
         jest.useFakeTimers();
         const auth = createAuth();
         auth.authStateManager.updateAuthState = jest.fn();
         auth.tokenManager.start(); // uses TokenService / crossTabs
+        auth.serviceManager.start();
         // simulate localStorage change from other dom context
         window.dispatchEvent(new StorageEvent('storage', {
           key: 'okta-token-storage', 
@@ -143,6 +146,7 @@ describe('AuthStateManager', () => {
         expect(auth.authStateManager.updateAuthState).toHaveBeenCalledTimes(1);
         jest.useRealTimers();
         auth.tokenManager.stop();
+        auth.serviceManager.stop();
       });
     });
 

--- a/test/spec/AutoRenewService.ts
+++ b/test/spec/AutoRenewService.ts
@@ -1,0 +1,226 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+import { OktaAuth } from '@okta/okta-auth-js';
+import tokens from '@okta/test.support/tokens';
+import util from '@okta/test.support/util';
+import SdkClock from '../../lib/clock';
+import * as features from '../../lib/features';
+
+const Emitter = require('tiny-emitter');
+
+function createAuth(options) {
+  options = options || {};
+  options.tokenManager = options.tokenManager || {};
+  jest.spyOn(SdkClock, 'create').mockReturnValue(new SdkClock(options.localClockOffset));
+  return new OktaAuth({
+    pkce: false,
+    issuer: 'https://auth-js-test.okta.com',
+    clientId: 'NPSfOkH5eZrTy8PMDlvx',
+    redirectUri: 'https://example.com/redirect',
+    storageUtil: options.storageUtil,
+    tokenManager: {
+      expireEarlySeconds: options.tokenManager.expireEarlySeconds || 0,
+      storage: options.tokenManager.storage,
+      storageKey: options.tokenManager.storageKey,
+      autoRenew: options.tokenManager.autoRenew || false,
+      autoRemove: options.tokenManager.autoRemove || false,
+      secure: options.tokenManager.secure, // used by cookie storage,
+      clearPendingRemoveTokens: options.tokenManager.clearPendingRemoveTokens !== false
+    }
+  });
+}
+
+describe('AutoRenewService', function() {
+  let client;
+
+  function setupSync(options = {}, start = false) {
+    client = createAuth(options);
+    // clear downstream listeners
+    client.tokenManager.off('added');
+    client.tokenManager.off('removed');
+
+    if (start) {
+      client.tokenManager.start();
+    }
+    return client;
+  }
+
+  beforeEach(function() {
+    client = null;
+  });
+  afterEach(function() {
+    if (client) {
+      client.tokenManager.stop();
+      client.tokenManager.clear();
+      client.serviceManager.stop();
+    }
+    jest.useRealTimers();
+  });
+
+
+  describe('autoRenew', function() {
+    beforeEach(function() {
+      jest.useFakeTimers();
+      jest.spyOn(features, 'isLocalhost').mockReturnValue(true);
+      util.disableLeaderElection();
+      util.mockLeader();
+    });
+    afterEach(async () => {
+      jest.useRealTimers();
+    });
+
+    it('should register listener for "expired" event', function() {
+      jest.spyOn(Emitter.prototype, 'on');
+      jest.spyOn(Emitter.prototype, 'off');
+      setupSync({ tokenManager: { autoRenew: true } }, true);
+      client.tokenManager.start();
+      client.serviceManager.start();
+      expect(Emitter.prototype.on).toHaveBeenCalledWith('expired', expect.any(Function));
+      client.serviceManager.stop();
+      expect(Emitter.prototype.off).toHaveBeenCalledWith('expired', expect.any(Function));
+    });
+
+    describe('too many renew requests', () => {
+      it('should emit too many renew error when latest 10 expired event happen in 30 seconds', () => {
+        setupSync({
+          tokenManager: { autoRenew: true }
+        }, true);
+        client.serviceManager.start();
+        client.tokenManager.renew = jest.fn().mockImplementation(() => Promise.resolve());
+        const handler = jest.fn().mockImplementation(err => {
+          util.expectErrorToEqual(err, {
+            name: 'AuthSdkError',
+            message: 'Too many token renew requests',
+            errorCode: 'INTERNAL',
+            errorSummary: 'Too many token renew requests',
+            errorLink: 'INTERNAL',
+            errorId: 'INTERNAL',
+            errorCauses: []
+          });
+        });
+        client.tokenManager.on('error', handler);
+        let startTime = Math.round(Date.now() / 1000);
+        // 2 * 10 < 30 => emit error
+        for (let i = 0; i < 10; i++) {
+          util.warpToUnixTime(startTime);
+          client.emitter.emit('expired');
+          startTime = startTime + 2;
+        }
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(client.tokenManager.renew).toHaveBeenCalledTimes(9);
+      });
+
+      it('should keep emitting errors if expired events keep emitting in 30s', () => {
+        setupSync({
+          tokenManager: { autoRenew: true }
+        }, true);
+        client.serviceManager.start();
+        client.tokenManager.renew = jest.fn().mockImplementation(() => Promise.resolve());
+        const handler = jest.fn();
+        client.tokenManager.on('error', handler);
+        let startTime = Math.round(Date.now() / 1000);
+        // 2 * 10 < 30 => emit error
+        for (let i = 0; i < 20; i++) {
+          util.warpToUnixTime(startTime);
+          client.emitter.emit('expired');
+          startTime = startTime + 2;
+        }
+        expect(handler).toHaveBeenCalledTimes(11);
+        expect(client.tokenManager.renew).toHaveBeenCalledTimes(9);
+      });
+  
+      it('should not emit error if time diff for the latest 10 requests are more than 30s', () => {
+        setupSync({
+          tokenManager: { autoRenew: true }
+        }, true);
+        const handler = jest.fn();
+        client.tokenManager.on('error', handler);
+        client.serviceManager.start();
+        client.tokenManager.renew = jest.fn().mockImplementation(() => Promise.resolve());
+        let startTime = Math.round(Date.now() / 1000);
+        // 5 * 10 > 30 => not emit error
+        for (let i = 0; i < 20; i++) {
+          util.warpToUnixTime(startTime);
+          client.emitter.emit('expired');
+          startTime = startTime + 5;
+        }
+        expect(handler).not.toHaveBeenCalled();
+        expect(client.tokenManager.renew).toHaveBeenCalledTimes(20);
+      });
+
+      it('should resume autoRenew if requests become normal again', () => {
+        setupSync({
+          tokenManager: { autoRenew: true }
+        }, true);
+        const handler = jest.fn();
+        client.tokenManager.on('error', handler);
+        client.serviceManager.start();
+        client.tokenManager.renew = jest.fn().mockImplementation(() => Promise.resolve());
+
+        // trigger too many requests error
+        // 10 * 2 < 30 => should emit error
+        let startTime = Math.round(Date.now() / 1000);
+        for (let i = 0; i < 20; i++) {
+          util.warpToUnixTime(startTime);
+          client.emitter.emit('expired');
+          startTime = startTime + 2;
+        }
+        // resume to normal requests
+        // wait 50s, then 10 * 5 > 30 => not emit error
+        startTime = startTime + 50;
+        util.warpToUnixTime(startTime);
+        for (let i = 0; i < 10; i++) {
+          util.warpToUnixTime(startTime);
+          client.emitter.emit('expired');
+          startTime = startTime + 5;
+        }
+
+        expect(handler).toHaveBeenCalledTimes(11);
+        expect(client.tokenManager.renew).toHaveBeenCalledTimes(19);
+      });
+    });
+  });
+
+  describe('autoRemove', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      util.disableLeaderElection();
+      util.mockLeader();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should call tokenManager.remove() when autoRenew === false && autoRemove === true', () => {
+      setupSync({ tokenManager: { autoRenew: false, autoRemove: true } }, true);
+      client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
+      client.serviceManager.start();
+      client.tokenManager.remove = jest.fn();
+      util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
+      util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
+      expect(client.tokenManager.remove).toHaveBeenCalledWith('test-idToken');
+    });
+
+    it('should not call tokenManager.remove() when autoRenew === false && autoRemove === false', () => {
+      setupSync({ tokenManager: { autoRenew: false, autoRemove: false } }, true);
+      client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
+      client.serviceManager.start();
+      client.tokenManager.remove = jest.fn();
+      util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
+      util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
+      expect(client.tokenManager.remove).not.toHaveBeenCalled();
+    });
+  });
+
+});

--- a/test/spec/OktaAuth/api.ts
+++ b/test/spec/OktaAuth/api.ts
@@ -22,6 +22,7 @@ import {
 import tokens from '@okta/test.support/tokens';
 import {postToTransaction} from '../../../lib/tx';
 import { APIError, isAccessToken, isIDToken } from '../../../lib/types';
+import util from '@okta/test.support/util';
 
 describe('OktaAuth (api)', function() {
   let auth;
@@ -39,6 +40,7 @@ describe('OktaAuth (api)', function() {
   describe('service methods', () => {
     beforeEach(() => {
       jest.spyOn(auth.token, 'isLoginRedirect').mockReturnValue(false);
+      util.disableLeaderElection();
     });
     afterEach(() => {
       auth.stop();

--- a/test/spec/ServiceManager.ts
+++ b/test/spec/ServiceManager.ts
@@ -12,12 +12,14 @@
 
 
 import { OktaAuth } from '@okta/okta-auth-js';
+import util from '@okta/test.support/util';
 
 jest.mock('broadcast-channel', () => {
   const actual = jest.requireActual('broadcast-channel');
+  class FakeBroadcastChannel {}
   return {
     createLeaderElection: actual.createLeaderElection,
-    BroadcastChannel: actual.BroadcastChannel
+    BroadcastChannel: FakeBroadcastChannel
   };
 });
 
@@ -52,6 +54,7 @@ describe('ServiceManager', () => {
     const options = { tokenManager: { syncStorage: true, autoRenew: true } };
     let client1 = createAuth(options);
     let client2 = createAuth(options);
+    util.disableLeaderElection();
     jest.spyOn(client1.serviceManager, 'isLeader').mockReturnValue(true);
     jest.spyOn(client2.serviceManager, 'isLeader').mockReturnValue(false);
     client1.serviceManager.start();
@@ -68,6 +71,7 @@ describe('ServiceManager', () => {
     const options = { tokenManager: { syncStorage: false, autoRenew: true } };
     let client1 = createAuth(options);
     let client2 = createAuth(options);
+    util.disableLeaderElection();
     jest.spyOn(client1.serviceManager, 'isLeader').mockReturnValue(true);
     jest.spyOn(client2.serviceManager, 'isLeader').mockReturnValue(false);
     client1.serviceManager.start();
@@ -84,6 +88,7 @@ describe('ServiceManager', () => {
     const options = { tokenManager: { syncStorage: false, autoRenew: false } };
     let client1 = createAuth(options);
     let client2 = createAuth(options);
+    util.disableLeaderElection();
     jest.spyOn(client1.serviceManager, 'isLeader').mockReturnValue(true);
     jest.spyOn(client2.serviceManager, 'isLeader').mockReturnValue(false);
     client1.serviceManager.start();
@@ -111,7 +116,6 @@ describe('ServiceManager', () => {
 
     const options = { tokenManager: { syncStorage: true, autoRenew: true } };
     let client = createAuth(options);
-    //jest.spyOn(client.serviceManager, 'isLeader').mockReturnValue(false);
     jest.spyOn(mocked.broadcastChannel, 'createLeaderElection').mockReturnValue(mockedElector);
     client.serviceManager.start();
     expect(client.serviceManager.getService('autoRenew')?.isStarted()).toBeFalsy();

--- a/test/spec/ServiceManager.ts
+++ b/test/spec/ServiceManager.ts
@@ -1,0 +1,125 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+import { OktaAuth } from '@okta/okta-auth-js';
+
+jest.mock('broadcast-channel', () => {
+  const actual = jest.requireActual('broadcast-channel');
+  return {
+    createLeaderElection: actual.createLeaderElection,
+    BroadcastChannel: actual.BroadcastChannel
+  };
+});
+
+const mocked = {
+  broadcastChannel: require('broadcast-channel'),
+};
+
+function createAuth(options) {
+  options = options || {};
+  options.tokenManager = options.tokenManager || {};
+  return new OktaAuth({
+    issuer: 'https://auth-js-test.okta.com',
+    clientId: 'NPSfOkH5eZrTy8PMDlvx',
+    redirectUri: 'https://example.com/redirect',
+    tokenManager: {
+      syncStorage: options.tokenManager.syncStorage || false,
+      autoRenew: options.tokenManager.autoRenew || false,
+      autoRemove: options.tokenManager.autoRemove || false,
+    }
+  });
+}
+
+describe('ServiceManager', () => {
+  beforeEach(function() {
+    jest.useFakeTimers();
+  });
+  afterEach(function() {
+    jest.useRealTimers();
+  });
+
+  it('starts syncStorage service for every tab, autoRenew service for leader tab (for syncStorage == true)', () => {
+    const options = { tokenManager: { syncStorage: true, autoRenew: true } };
+    let client1 = createAuth(options);
+    let client2 = createAuth(options);
+    jest.spyOn(client1.serviceManager, 'isLeader').mockReturnValue(true);
+    jest.spyOn(client2.serviceManager, 'isLeader').mockReturnValue(false);
+    client1.serviceManager.start();
+    client2.serviceManager.start();
+    expect(client1.serviceManager.getService('autoRenew')?.isStarted()).toBeTruthy();
+    expect(client2.serviceManager.getService('autoRenew')?.isStarted()).toBeFalsy();
+    expect(client1.serviceManager.getService('syncStorage')?.isStarted()).toBeTruthy();
+    expect(client2.serviceManager.getService('syncStorage')?.isStarted()).toBeTruthy();
+    client1.serviceManager.stop();
+    client2.serviceManager.stop();
+  });
+
+  it('starts autoRenew service for every tab (for syncStorage == false)', () => {
+    const options = { tokenManager: { syncStorage: false, autoRenew: true } };
+    let client1 = createAuth(options);
+    let client2 = createAuth(options);
+    jest.spyOn(client1.serviceManager, 'isLeader').mockReturnValue(true);
+    jest.spyOn(client2.serviceManager, 'isLeader').mockReturnValue(false);
+    client1.serviceManager.start();
+    client2.serviceManager.start();
+    expect(client1.serviceManager.getService('autoRenew')?.isStarted()).toBeTruthy();
+    expect(client2.serviceManager.getService('autoRenew')?.isStarted()).toBeTruthy();
+    expect(client1.serviceManager.getService('syncStorage')?.isStarted()).toBeFalsy();
+    expect(client2.serviceManager.getService('syncStorage')?.isStarted()).toBeFalsy();
+    client1.serviceManager.stop();
+    client2.serviceManager.stop();
+  });
+
+  it('starts no services for syncStorage == false and autoRenew == false', () => {
+    const options = { tokenManager: { syncStorage: false, autoRenew: false } };
+    let client1 = createAuth(options);
+    let client2 = createAuth(options);
+    jest.spyOn(client1.serviceManager, 'isLeader').mockReturnValue(true);
+    jest.spyOn(client2.serviceManager, 'isLeader').mockReturnValue(false);
+    client1.serviceManager.start();
+    client2.serviceManager.start();
+    expect(client1.serviceManager.getService('autoRenew')?.isStarted()).toBeFalsy();
+    expect(client2.serviceManager.getService('autoRenew')?.isStarted()).toBeFalsy();
+    expect(client1.serviceManager.getService('syncStorage')?.isStarted()).toBeFalsy();
+    expect(client2.serviceManager.getService('syncStorage')?.isStarted()).toBeFalsy();
+    client1.serviceManager.stop();
+    client2.serviceManager.stop();
+  });
+
+  it('starts autoRenew service after becoming leader (for syncStorage == true)', async () => {
+    // Become leader in 100ms
+    const mockedElector = {
+      isLeader: false,
+      awaitLeadership: () => new Promise(resolve => {
+        setTimeout(() => {
+          mockedElector.isLeader = true;
+          resolve();
+        }, 100);
+      }) as Promise<void>,
+      die: () => {},
+    };
+
+    const options = { tokenManager: { syncStorage: true, autoRenew: true } };
+    let client = createAuth(options);
+    //jest.spyOn(client.serviceManager, 'isLeader').mockReturnValue(false);
+    jest.spyOn(mocked.broadcastChannel, 'createLeaderElection').mockReturnValue(mockedElector);
+    client.serviceManager.start();
+    expect(client.serviceManager.getService('autoRenew')?.isStarted()).toBeFalsy();
+    expect(client.serviceManager.getService('syncStorage')?.isStarted()).toBeTruthy();
+    jest.runAllTimers();
+    await Promise.resolve();
+    expect(client.serviceManager.getService('autoRenew')?.isStarted()).toBeTruthy();
+    client.serviceManager.stop();
+  });
+
+});

--- a/test/spec/SyncStorageService.ts
+++ b/test/spec/SyncStorageService.ts
@@ -14,13 +14,13 @@
 /* eslint-disable max-statements */
 /* global window, localStorage, StorageEvent */
 
-import { TokenManager } from '../../../lib/TokenManager';
-import { SyncStorageService } from '../../../lib/services/SyncStorageService';
-import * as features from '../../../lib/features';
+import { TokenManager } from '../../lib/TokenManager';
+import { SyncStorageService } from '../../lib/services/SyncStorageService';
+import * as features from '../../lib/features';
 
 const Emitter = require('tiny-emitter');
 
-describe('cross tabs communication', () => {
+describe('SyncStorageService', () => {
   let sdkMock;
   let instance;
   let syncInstance;

--- a/test/spec/TokenManager/browser.ts
+++ b/test/spec/TokenManager/browser.ts
@@ -75,7 +75,10 @@ describe('TokenManager (browser)', function() {
     client.tokenManager.off('added');
     client.tokenManager.off('removed');
     if (start) {
+      util.disableLeaderElection();
+      util.mockLeader();
       client.tokenManager.start();
+      client.serviceManager.start();
     }
     return client;
   }

--- a/test/spec/TokenManager/browser.ts
+++ b/test/spec/TokenManager/browser.ts
@@ -90,9 +90,8 @@ describe('TokenManager (browser)', function() {
   });
   
   afterEach(() => {
-    if (client && client.tokenManager) {
-      client.tokenManager.stop();
-    }
+    client?.tokenManager?.stop();
+    client?.serviceManager?.stop();
   });
 
   describe('options', () => {

--- a/test/spec/TokenManager/core.ts
+++ b/test/spec/TokenManager/core.ts
@@ -361,18 +361,9 @@ describe('TokenManager', function() {
     beforeEach(function() {
       jest.useFakeTimers();
       jest.spyOn(features, 'isLocalhost').mockReturnValue(true);
-      util.disableLeaderElection();
-      util.mockLeader();
     });
     afterEach(async () => {
       jest.useRealTimers();
-    });
-    it('should register listener for "expired" event', function() {
-      jest.spyOn(Emitter.prototype, 'on');
-      setupSync({ tokenManager: { syncStorage: true, autoRenew: true } }, true);
-      client.tokenManager.start();
-      client.serviceManager.start();
-      expect(Emitter.prototype.on).toHaveBeenCalledWith('expired', expect.any(Function));
     });
 
     it('emits "expired" on existing tokens even when autoRenew is disabled', function() {
@@ -429,137 +420,8 @@ describe('TokenManager', function() {
       expect(callback).toHaveBeenCalledWith('test-idToken', tokens.standardIdTokenParsed);
     });
 
-    describe('too many renew requests', () => {
-      it('should emit too many renew error when latest 10 expired event happen in 30 seconds', () => {
-        setupSync({
-          tokenManager: { autoRenew: true }
-        }, true);
-        client.serviceManager.start();
-        client.tokenManager.renew = jest.fn().mockImplementation(() => Promise.resolve());
-        const handler = jest.fn().mockImplementation(err => {
-          util.expectErrorToEqual(err, {
-            name: 'AuthSdkError',
-            message: 'Too many token renew requests',
-            errorCode: 'INTERNAL',
-            errorSummary: 'Too many token renew requests',
-            errorLink: 'INTERNAL',
-            errorId: 'INTERNAL',
-            errorCauses: []
-          });
-        });
-        client.tokenManager.on('error', handler);
-        let startTime = Math.round(Date.now() / 1000);
-        // 2 * 10 < 30 => emit error
-        for (let i = 0; i < 10; i++) {
-          util.warpToUnixTime(startTime);
-          client.emitter.emit('expired');
-          startTime = startTime + 2;
-        }
-        expect(handler).toHaveBeenCalledTimes(1);
-        expect(client.tokenManager.renew).toHaveBeenCalledTimes(9);
-      });
-
-      it('should keep emitting errors if expired events keep emitting in 30s', () => {
-        setupSync({
-          tokenManager: { autoRenew: true }
-        }, true);
-        client.serviceManager.start();
-        client.tokenManager.renew = jest.fn().mockImplementation(() => Promise.resolve());
-        const handler = jest.fn();
-        client.tokenManager.on('error', handler);
-        let startTime = Math.round(Date.now() / 1000);
-        // 2 * 10 < 30 => emit error
-        for (let i = 0; i < 20; i++) {
-          util.warpToUnixTime(startTime);
-          client.emitter.emit('expired');
-          startTime = startTime + 2;
-        }
-        expect(handler).toHaveBeenCalledTimes(11);
-        expect(client.tokenManager.renew).toHaveBeenCalledTimes(9);
-      });
-  
-      it('should not emit error if time diff for the latest 10 requests are more than 30s', () => {
-        setupSync({
-          tokenManager: { autoRenew: true }
-        }, true);
-        const handler = jest.fn();
-        client.tokenManager.on('error', handler);
-        client.serviceManager.start();
-        client.tokenManager.renew = jest.fn().mockImplementation(() => Promise.resolve());
-        let startTime = Math.round(Date.now() / 1000);
-        // 5 * 10 > 30 => not emit error
-        for (let i = 0; i < 20; i++) {
-          util.warpToUnixTime(startTime);
-          client.emitter.emit('expired');
-          startTime = startTime + 5;
-        }
-        expect(handler).not.toHaveBeenCalled();
-        expect(client.tokenManager.renew).toHaveBeenCalledTimes(20);
-      });
-
-      it('should resume autoRenew if requests become normal again', () => {
-        setupSync({
-          tokenManager: { autoRenew: true }
-        }, true);
-        const handler = jest.fn();
-        client.tokenManager.on('error', handler);
-        client.serviceManager.start();
-        client.tokenManager.renew = jest.fn().mockImplementation(() => Promise.resolve());
-
-        // trigger too many requests error
-        // 10 * 2 < 30 => should emit error
-        let startTime = Math.round(Date.now() / 1000);
-        for (let i = 0; i < 20; i++) {
-          util.warpToUnixTime(startTime);
-          client.emitter.emit('expired');
-          startTime = startTime + 2;
-        }
-        // resume to normal requests
-        // wait 50s, then 10 * 5 > 30 => not emit error
-        startTime = startTime + 50;
-        util.warpToUnixTime(startTime);
-        for (let i = 0; i < 10; i++) {
-          util.warpToUnixTime(startTime);
-          client.emitter.emit('expired');
-          startTime = startTime + 5;
-        }
-
-        expect(handler).toHaveBeenCalledTimes(11);
-        expect(client.tokenManager.renew).toHaveBeenCalledTimes(19);
-      });
-    });
   });
 
-  describe('autoRemove', () => {
-    beforeEach(() => {
-      jest.useFakeTimers();
-      util.disableLeaderElection();
-      util.mockLeader();
-    });
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-
-    it('should call tokenManager.remove() when autoRenew === false && autoRemove === true', () => {
-      setupSync({ tokenManager: { autoRenew: false, autoRemove: true } }, true);
-      client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
-      client.serviceManager.start();
-      client.tokenManager.remove = jest.fn();
-      util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
-      util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
-      expect(client.tokenManager.remove).toHaveBeenCalledWith('test-idToken');
-    });
-
-    it('should not call tokenManager.remove() when autoRenew === false && autoRemove === false', () => {
-      setupSync({ tokenManager: { autoRenew: false, autoRemove: false } }, true);
-      client.tokenManager.add('test-idToken', tokens.standardIdTokenParsed);
-      client.serviceManager.start();
-      client.tokenManager.remove = jest.fn();
-      util.warpToUnixTime(tokens.standardIdTokenClaims.iat);
-      util.warpByTicksToUnixTime(tokens.standardIdTokenParsed.expiresAt + 1);
-      expect(client.tokenManager.remove).not.toHaveBeenCalled();
-    });
-  });
 
   // describe('get', function() {
   //   it('should throw AuthSdkError if autoRenew is turned on and app is in oauth callback state', async () => {

--- a/test/spec/TokenManager/crossTabs.ts
+++ b/test/spec/TokenManager/crossTabs.ts
@@ -15,6 +15,7 @@
 /* global window, localStorage, StorageEvent */
 
 import { TokenManager } from '../../../lib/TokenManager';
+import { SyncStorageService } from '../../../lib/services/SyncStorageService';
 import * as features from '../../../lib/features';
 
 const Emitter = require('tiny-emitter');
@@ -22,6 +23,7 @@ const Emitter = require('tiny-emitter');
 describe('cross tabs communication', () => {
   let sdkMock;
   let instance;
+  let syncInstance;
   beforeEach(function() {
     jest.useFakeTimers();
     instance = null;
@@ -44,11 +46,16 @@ describe('cross tabs communication', () => {
     if (instance) {
       instance.stop();
     }
+    if (syncInstance) {
+      syncInstance.stop();
+    }
   });
 
   function createInstance(options?) {
     instance = new TokenManager(sdkMock, options);
     instance.start();
+    syncInstance = new SyncStorageService(instance, instance.getOptions());
+    syncInstance.start();
     return instance;
   }
 

--- a/test/support/oauthUtil.js
+++ b/test/support/oauthUtil.js
@@ -298,9 +298,8 @@ oauthUtil.setup = function(opts) {
       if (authClient && authClient._tokenQueue) {
         expect(authClient._tokenQueue.queue.length).toBe(0);
       }
-      if (authClient && authClient.tokenManager) {
-        authClient.tokenManager.stop();
-      }
+      authClient?.tokenManager?.stop();
+      authClient?.serviceManager?.stop();
     });
 };
 

--- a/test/support/oauthUtil.js
+++ b/test/support/oauthUtil.js
@@ -205,7 +205,10 @@ oauthUtil.setup = function(opts) {
   oauthUtil.loadWellKnownAndKeysCache(authClient);
 
   if (opts.autoRenew) {
+    util.disableLeaderElection();
+    util.mockLeader();
     authClient.tokenManager.start();
+    authClient.serviceManager.start();
   }
 
   if (opts.tokenManagerAddKeys) {

--- a/test/support/util.js
+++ b/test/support/util.js
@@ -18,6 +18,7 @@ import _ from 'lodash';
 import { OktaAuth } from '@okta/okta-auth-js';
 
 import browserStorage from '../../lib/browser/browserStorage';
+import { ServiceManager } from '../../lib/ServiceManager';
 const cookies = browserStorage.storage;
 
 var util = {};
@@ -455,6 +456,14 @@ util.assertAuthSdkError = function (err, message) {
   expect(err.errorLink).toEqual('INTERNAL');
   expect(err.errorId).toEqual('INTERNAL');
   expect(err.errorCauses).toEqual([]);
+};
+
+util.disableLeaderElection = function() {
+  jest.spyOn(ServiceManager, 'canUseLeaderElection').mockReturnValue(false);
+};
+
+util.mockLeader = function() {
+  jest.spyOn(ServiceManager.prototype, 'isLeader').mockReturnValue(true);
 };
 
 export default util;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1666,6 +1666,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.16.0", "@babel/runtime@^7.6.2":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
+  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.14.5", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
@@ -5852,6 +5859,11 @@ bfj@^7.0.2:
     hoopy "^0.1.4"
     tryer "^1.0.1"
 
+big-integer@^1.6.16:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -6025,6 +6037,20 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.10.0.tgz#d19fb902df227df40b1b580351713d30c302d198"
+  integrity sha512-hOUh312XyHk6JTVyX9cyXaH1UYs+2gHVtnW16oQAu9FL7ALcXGXc/YoJWqlkV8vUn14URQPMmRi4A9q4UrwVEQ==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    detect-node "^2.1.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    p-queue "6.6.2"
+    rimraf "3.0.2"
+    unload "2.3.1"
 
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
@@ -8090,7 +8116,7 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node@^2.0.4:
+detect-node@2.1.0, detect-node@^2.0.4, detect-node@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -9354,7 +9380,7 @@ event-stream@=3.3.4:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
-eventemitter3@^4.0.0:
+eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -14879,6 +14905,11 @@ micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -15192,6 +15223,13 @@ nan@^2.12.1:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.1.23:
   version "3.1.23"
@@ -15669,6 +15707,11 @@ object.values@^1.1.5:
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
 
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
+
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
@@ -15929,6 +15972,14 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
+p-queue@6.6.2:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
 p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
@@ -15945,6 +15996,13 @@ p-timeout@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-2.0.1.tgz#d8dd1979595d2dc0139e1fe46b8b646cb3cdf038"
   integrity sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==
+  dependencies:
+    p-finally "^1.0.0"
+
+p-timeout@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
   dependencies:
     p-finally "^1.0.0"
 
@@ -18408,17 +18466,17 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -20797,6 +20855,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.3.1.tgz#9d16862d372a5ce5cb630ad1309c2fd6e35dacfe"
+  integrity sha512-MUZEiDqvAN9AIDRbbBnVYVvfcR6DrjCqeU2YQMmliFZl9uaBUjTkhuDQkBiyAy8ad5bx1TXVbqZ3gg7namsWjA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "2.1.0"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Added [broadcast-channel](https://github.com/pubkey/broadcast-channel) package to solve cross-tab token renewal issues with tab leader election method.
Added `ServiceManager` that is responsible for:
- obtaining leadership status using `broadcast-channel`
- starting/stopping `AutoRenewService` (depending on leadership status) and `SyncStorageService`.
(`TokenService` is splitted into `AutoRenewService` and `SyncStorageService`, based on https://github.com/okta/okta-auth-js/pull/1108/files)

Notes:
-  `syncStorage` should be set to true to start auto-renew only on 1 leader tab. Otherwise auto-renew service will run on every tab.
- `tokenManager.start()` does not start token service anymore. `serviceManager.start()` is responsible for starting services and is called in `oktaAuth.start()`



Internal ref: [OKTA-456234](https://oktainc.atlassian.net/browse/OKTA-456234) (and [OKTA-456251](https://oktainc.atlassian.net/browse/OKTA-456251))

Resolves https://github.com/okta/okta-auth-js/issues/1001

[Cross-tab simulation](https://github.com/okta/okta-auth-js/pull/1106)
before:

https://user-images.githubusercontent.com/72614880/154743038-7086b485-4352-4415-8ce5-cbd3caa9a3b9.mov


after:


https://user-images.githubusercontent.com/72614880/154743059-d3798da4-4758-4941-9635-863ef69f73e3.mov


