### PR TITLE
Test app: handle !isAuthenticated if document is visible

### DIFF
--- a/lib/ServiceManager.ts
+++ b/lib/ServiceManager.ts
@@ -126,7 +126,6 @@ export class ServiceManager implements ServiceManagerInterface {
     for (const srv of this.services.values()) {
       srv.stop();
     }
-    this.services = new Map();
   }
 
   private startElector() {
@@ -148,6 +147,8 @@ export class ServiceManager implements ServiceManagerInterface {
     if (this.elector) {
       this.elector?.die();
       this.elector = undefined;
+      this.channel?.close();
+      this.channel = undefined;
     }
   }
 

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -347,7 +347,7 @@ class TestApp {
         this.checkAuthRequired();
       }
     });
-    document.addEventListener("visibilitychange", () => {
+    document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'visible') {
         this.checkAuthRequired();
       }
@@ -357,7 +357,7 @@ class TestApp {
     this._afterRender('protected');
   }
 
-  checkAuthRequired() {
+  checkAuthRequired(): void {
     if (document.visibilityState === 'visible' && this.oktaAuth.authStateManager.getAuthState()?.isAuthenticated == false) {
       this.oktaAuth.signInWithRedirect();
     }

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -343,6 +343,7 @@ class TestApp {
     // simulate SecureRoute behaviour
     this.oktaAuth.authStateManager.subscribe((authState: AuthState) => {
       if (!authState.isAuthenticated) {
+        document.title = 'Auth required';
         this.checkAuthRequired();
       }
     });

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -343,12 +343,23 @@ class TestApp {
     // simulate SecureRoute behaviour
     this.oktaAuth.authStateManager.subscribe((authState: AuthState) => {
       if (!authState.isAuthenticated) {
-        this.oktaAuth.signInWithRedirect();
+        this.checkAuthRequired();
+      }
+    });
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === 'visible') {
+        this.checkAuthRequired();
       }
     });
 
     this._setContent(content);
     this._afterRender('protected');
+  }
+
+  checkAuthRequired() {
+    if (document.visibilityState === 'visible' && this.oktaAuth.authStateManager.getAuthState()?.isAuthenticated == false) {
+      this.oktaAuth.signInWithRedirect();
+    }
   }
 
   async bootstrapRenew(): Promise<void> {

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -365,7 +365,6 @@ class TestApp {
     document.addEventListener('visibilitychange', () => {
       this.checkAuthRequired();
     });
-    this.oktaAuth.start();
 
     this.render();
     this._afterRender('protected');
@@ -393,7 +392,7 @@ class TestApp {
       // App initialization stage
       // Sign in with redirect automatically
       setTimeout(() => {
-        this.loginRedirect({});
+        this.oktaAuth.signInWithRedirect();
       }, 500);
     }
   }
@@ -880,7 +879,7 @@ class TestApp {
         setTimeout(resolve, timeout);
       });
     };
-
+    
     // Test
     let w1, w2;
     try {

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -871,7 +871,7 @@ class TestApp {
             name: 'logout_answer',
             value: authStatusText
           }, window.location.origin);
-        }, 10);
+        }, 100);
       } else if (e.data?.name === 'authStatusText') {
         const authStatusText = document.getElementById('auth-status-text')?.innerText;
         window.postMessage({
@@ -896,7 +896,7 @@ class TestApp {
     w1.addEventListener('message', async (e) => {
       if (e.data?.name === 'logout_answer') {
         const authStatusTextTab1 = e.data.value;
-        // Current tab is hidden for now.
+        // Current tab is not in focus for now.
         // Expected text in current tab: "You are authenticated"
         // Close tab #1 and return visibility for current tab.
         // Then expected text in current tab: "You are NOT authenticated. Sign-in again using one of these methods:"
@@ -917,24 +917,26 @@ class TestApp {
             if (e.data?.name === 'authStatusText_answer') {
               const authStatusTextTab2 = e.data.value;
               // Close tab #2 and complete test
-              w2.close();
-              window.focus();
-
-              const isOk = authStatusTextTab1.includes('Sign-in again') 
-                && authStatusTextHidden.includes('You are authenticated') 
-                && authStatusTextVisible.includes('Sign-in again') 
-                && authStatusTextTab2.includes('You are being redirected to sign-in page automatically');
-              if (isOk) {
-                document.getElementById('auth-required-test-msg').innerHTML = 'auth required test passed';
-              } else {
-                document.getElementById('auth-required-test-msg').innerHTML = 'auth required test NOT passed';
-                console.warn({
-                  authStatusTextTab1,
-                  authStatusTextHidden,
-                  authStatusTextVisible,
-                  authStatusTextTab2,
-                });
-              }
+              setTimeout(() => {
+                w2.close();
+                window.focus();
+  
+                const isOk = authStatusTextTab1.includes('Sign-in again') 
+                  && authStatusTextHidden.includes('You are authenticated') 
+                  && authStatusTextVisible.includes('Sign-in again') 
+                  && authStatusTextTab2.includes('You are being redirected to sign-in page automatically');
+                if (isOk) {
+                  document.getElementById('auth-required-test-msg').innerHTML = 'auth required test passed';
+                } else {
+                  document.getElementById('auth-required-test-msg').innerHTML = 'auth required test NOT passed';
+                  console.warn({
+                    authStatusTextTab1,
+                    authStatusTextHidden,
+                    authStatusTextVisible,
+                    authStatusTextTab2,
+                  });
+                }
+              }, 500);
             }
           });
         }, 10);

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -395,7 +395,7 @@ class TestApp {
       // Sign in with redirect automatically
       setTimeout(() => {
         this.oktaAuth.signInWithRedirect();
-      }, 100);
+      }, 500);
     }
   }
 
@@ -891,7 +891,7 @@ class TestApp {
         w1.postMessage({
           name: 'logout'
         }, window.location.origin);
-      }, 500);
+      }, 100);
     }, false);
     w1.addEventListener('message', async (e) => {
       if (e.data?.name === 'logout_answer') {
@@ -920,10 +920,10 @@ class TestApp {
               setTimeout(() => {
                 w2.close();
                 window.focus();
-  
+                
                 const isOk = authStatusTextTab1.includes('Sign-in again') 
                   && authStatusTextHidden.includes('You are authenticated') 
-                  && authStatusTextVisible.includes('Sign-in again') 
+                  && (this.oktaAuth.tokenManager.getOptions().syncStorage ? authStatusTextVisible.includes('Sign-in again') : true)
                   && authStatusTextTab2.includes('You are being redirected to sign-in page automatically');
                 if (isOk) {
                   document.getElementById('auth-required-test-msg').innerHTML = 'auth required test passed';

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -339,6 +339,7 @@ class TestApp {
           ${homeLink(this)}
           <hr/>
           <strong id="auth-status-text">You are NOT authenticated.<br />You are being redirected to sign-in page automatically...</strong>
+          ${loginLinks(this, true)}
         `;
       } else {
         content = `
@@ -392,7 +393,7 @@ class TestApp {
       // App initialization stage
       // Sign in with redirect automatically
       setTimeout(() => {
-        this.oktaAuth.signInWithRedirect();
+        this.loginRedirect({});
       }, 500);
     }
   }

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -854,11 +854,12 @@ class TestApp {
       .then(() => {
         document.getElementById('token-msg').innerHTML = 'concurrent test passed';
       });
-  }
+    }
 
+  /* eslint-disable max-statements, complexity */
   async testAuthRequired(): Promise<void> {
     // Helpers
-    const waitForWindowLoad = (w: Window, timeout = 5000) => {
+    const waitForWindowLoad = (w: Window, timeout = 5000): Promise<void> => {
       return new Promise((resolve, reject) => {
         let loaded = false;
         const timer = setTimeout(() => {
@@ -873,7 +874,7 @@ class TestApp {
         });
       });
     };
-    const sleep = (timeout: number) => {
+    const sleep = (timeout: number): Promise<void> => {
       return new Promise((resolve) => {
         setTimeout(resolve, timeout);
       });

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -24,7 +24,6 @@ import {
   isAuthorizationCodeError,
   IdxStatus,
   IdxTransaction,
-  AuthState,
 } from '@okta/okta-auth-js';
 import { saveConfigToStorage, flattenConfig, Config } from './config';
 import { MOUNT_PATH } from './constants';
@@ -896,16 +895,16 @@ class TestApp {
     }, false);
     w1.addEventListener('message', async (e) => {
       if (e.data?.name === 'logout_answer') {
-        const authStatusText_tab1 = e.data.value;
+        const authStatusTextTab1 = e.data.value;
         // Current tab is hidden for now.
         // Expected text in current tab: "You are authenticated"
         // Close tab #1 and return visibility for current tab.
         // Then expected text in current tab: "You are NOT authenticated. Sign-in again using one of these methods:"
-        const authStatusText_hidden = document.getElementById('auth-status-text')?.innerText;
+        const authStatusTextHidden = document.getElementById('auth-status-text')?.innerText;
         w1.close();
         window.focus();
         setTimeout(() => {
-          const authStatusText_visible = document.getElementById('auth-status-text')?.innerText;
+          const authStatusTextVisible = document.getElementById('auth-status-text')?.innerText;
           // Open tab #2
           // Expected text in tab #2: "You are NOT authenticated. You are being redirected to sign-in page automatically..."
           const w2 = window.open(this.protectedUrl);
@@ -916,24 +915,24 @@ class TestApp {
           }, false);
           w2.addEventListener('message', async (e) => {
             if (e.data?.name === 'authStatusText_answer') {
-              const authStatusText_tab2 = e.data.value;
+              const authStatusTextTab2 = e.data.value;
               // Close tab #2 and complete test
               w2.close();
               window.focus();
 
-              const isOk = authStatusText_tab1.includes('Sign-in again') 
-                && authStatusText_hidden.includes('You are authenticated') 
-                && authStatusText_visible.includes('Sign-in again') 
-                && authStatusText_tab2.includes('You are being redirected to sign-in page automatically');
+              const isOk = authStatusTextTab1.includes('Sign-in again') 
+                && authStatusTextHidden.includes('You are authenticated') 
+                && authStatusTextVisible.includes('Sign-in again') 
+                && authStatusTextTab2.includes('You are being redirected to sign-in page automatically');
               if (isOk) {
                 document.getElementById('auth-required-test-msg').innerHTML = 'auth required test passed';
               } else {
                 document.getElementById('auth-required-test-msg').innerHTML = 'auth required test NOT passed';
                 console.warn({
-                  authStatusText_tab1,
-                  authStatusText_hidden,
-                  authStatusText_visible,
-                  authStatusText_tab2,
+                  authStatusTextTab1,
+                  authStatusTextHidden,
+                  authStatusTextVisible,
+                  authStatusTextTab2,
                 });
               }
             }
@@ -974,7 +973,7 @@ class TestApp {
   }
 
   appHTML(props: Tokens): string {
-    if (window.location.pathname.includes("/protected")) {
+    if (window.location.pathname.includes('/protected')) {
       return this.appProtectedHTML();
     }
 

--- a/test/e2e/pageobjects/TestApp.js
+++ b/test/e2e/pageobjects/TestApp.js
@@ -35,9 +35,11 @@ class TestApp {
   get userInfo() { return $('#user-info'); }
   get sessionExpired() { return $('#session-expired'); }
   get testConcurrentGetTokenBtn() { return $('#test-concurrent-get-token'); }
+  get testAuthRequiredBtn() { return $('#test-auth-required'); }
 
   get tokenError() { return $('#token-error'); }
   get tokenMsg() { return $('#token-msg'); }
+  get authRequiredTestMsg() { return $('#auth-required-test-msg'); }
   
   // Unauthenticated landing
   get loginWidgetBtn() { return $('#login-widget'); }
@@ -234,6 +236,10 @@ class TestApp {
     await this.testConcurrentGetTokenBtn.then(el => el.click());
   }
 
+  async testAuthRequired() {
+    await this.testAuthRequiredBtn.then(el => el.click());
+  }
+
   async selectPkceOptionOff(){
     await this.pkceOptionOff.then(el=> el.click());
   }
@@ -338,6 +344,15 @@ class TestApp {
       return txt !== '';
     }, 10000, 'wait for token message');
     const txt = await this.tokenMsg.then(el => el.getText());
+    assert(txt === msg);
+  }
+
+  async assertAuthRequiredTestMessage(msg) {
+    await browser.waitUntil(async () => {
+      const txt = await this.authRequiredTestMsg.then(el => el.getText());
+      return txt !== '';
+    }, 10000, 'wait for auth required test message');
+    const txt = await this.authRequiredTestMsg.then(el => el.getText());
     assert(txt === msg);
   }
 

--- a/test/e2e/pageobjects/TestApp.js
+++ b/test/e2e/pageobjects/TestApp.js
@@ -40,6 +40,7 @@ class TestApp {
   get tokenError() { return $('#token-error'); }
   get tokenMsg() { return $('#token-msg'); }
   get authRequiredTestMsg() { return $('#auth-required-test-msg'); }
+  get authStatusText() { return $('#auth-status-text'); }
   
   // Unauthenticated landing
   get loginWidgetBtn() { return $('#login-widget'); }
@@ -354,6 +355,15 @@ class TestApp {
     }, 10000, 'wait for auth required test message');
     const txt = await this.authRequiredTestMsg.then(el => el.getText());
     assert(txt === msg);
+  }
+
+  async assertAuthStatusText(msg) {
+    await browser.waitUntil(async () => {
+      const txt = await this.authStatusText.then(el => el.getText());
+      return txt !== '';
+    }, 10000, 'wait for auth status text');
+    const txt = await this.authStatusText.then(el => el.getText());
+    assert(txt.includes(msg));
   }
 
   async assertIssuer(issuer) {

--- a/test/e2e/pageobjects/TestApp.js
+++ b/test/e2e/pageobjects/TestApp.js
@@ -35,11 +35,9 @@ class TestApp {
   get userInfo() { return $('#user-info'); }
   get sessionExpired() { return $('#session-expired'); }
   get testConcurrentGetTokenBtn() { return $('#test-concurrent-get-token'); }
-  get testAuthRequiredBtn() { return $('#test-auth-required'); }
 
   get tokenError() { return $('#token-error'); }
   get tokenMsg() { return $('#token-msg'); }
-  get authRequiredTestMsg() { return $('#auth-required-test-msg'); }
   get authStatusText() { return $('#auth-status-text'); }
   
   // Unauthenticated landing
@@ -237,10 +235,6 @@ class TestApp {
     await this.testConcurrentGetTokenBtn.then(el => el.click());
   }
 
-  async testAuthRequired() {
-    await this.testAuthRequiredBtn.then(el => el.click());
-  }
-
   async selectPkceOptionOff(){
     await this.pkceOptionOff.then(el=> el.click());
   }
@@ -345,15 +339,6 @@ class TestApp {
       return txt !== '';
     }, 10000, 'wait for token message');
     const txt = await this.tokenMsg.then(el => el.getText());
-    assert(txt === msg);
-  }
-
-  async assertAuthRequiredTestMessage(msg) {
-    await browser.waitUntil(async () => {
-      const txt = await this.authRequiredTestMsg.then(el => el.getText());
-      return txt !== '';
-    }, 10000, 'wait for auth required test message');
-    const txt = await this.authRequiredTestMsg.then(el => el.getText());
     assert(txt === msg);
   }
 

--- a/test/e2e/specs/authRequired.js
+++ b/test/e2e/specs/authRequired.js
@@ -20,10 +20,9 @@ import {
 } from '../util/browserUtils';
 import OktaLogin from '../pageobjects/OktaLogin';
 
-describe('protected page', () => {
-
-  it('auth required', async () => {
-    // Open protected page for the first time without being authenticated
+describe('auth required', () => {
+  it('can redirect to sign-in page only on initial load and if document is visible, otherwise show UI to sign-in again', async () => {
+    // Open protected page for the first time in unauthenticated state
     // Expected: auto redirect to sign-in page
     await openPKCE({});
     await TestApp.assertLoggedOut();
@@ -38,7 +37,7 @@ describe('protected page', () => {
     await TestApp.navigateToProtectedPage();
     await TestApp.startService();
 
-    // Open protected page in new tab, logout
+    // Logout in another tab
     await openPKCE({}, true);
     await switchToSecondWindow();
     await TestApp.waitForLogoutBtn();
@@ -47,17 +46,17 @@ describe('protected page', () => {
     await browser.closeWindow();
 
     // Go back to original tab
-    // Expected: Show user buttons to sign-in again
+    // Expected: show buttons to sign-in again
     await switchToMainWindow();
     await TestApp.assertAuthStatusText('Sign-in again');
 
     // Sign-in directly
-    // Expected: page is being updated
+    // Expected: page is being updated for authenticated state
     await loginDirect();
+    await TestApp.waitForLogoutBtn();
     await TestApp.assertAuthStatusText('You are authenticated');
     
     // Complete test
-    await TestApp.waitForLogoutBtn();
     await TestApp.logoutRedirect();
   });
 });

--- a/test/e2e/specs/authRequired.js
+++ b/test/e2e/specs/authRequired.js
@@ -21,7 +21,8 @@ import {
 import OktaLogin from '../pageobjects/OktaLogin';
 
 describe('auth required', () => {
-  it('can redirect to sign-in page only on initial load and if document is visible, otherwise show UI to sign-in again', async () => {
+  it('can redirect to sign-in page only for initial load and doc is visible, otherwise show UI to sign-in again', 
+  async () => {
     // Open protected page for the first time in unauthenticated state
     // Expected: auto redirect to sign-in page
     await openPKCE({});

--- a/test/e2e/specs/crossTabs.js
+++ b/test/e2e/specs/crossTabs.js
@@ -12,7 +12,6 @@
 
 
 import assert from 'assert';
-import OktaLogin from '../pageobjects/OktaLogin';
 import TestApp from '../pageobjects/TestApp';
 import { openPKCE } from '../util/appUtils';
 import { loginDirect } from '../util/loginUtils';

--- a/test/e2e/specs/crossTabs.js
+++ b/test/e2e/specs/crossTabs.js
@@ -102,8 +102,8 @@ describe('cross tabs AuthState update', () => {
         // the first tab show sign buttons
         await TestApp.assertLoggedOut();
       } else {
-        // other tabs show okta hosted login page
-        await OktaLogin.waitForLoad();
+        // other tabs ask to sign-in again
+        await TestApp.assertAuthStatusText('Sign-in again');
       }
     }
   });

--- a/test/e2e/specs/protected.js
+++ b/test/e2e/specs/protected.js
@@ -1,0 +1,42 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+import TestApp from '../pageobjects/TestApp';
+import { openPKCE } from '../util/appUtils';
+import { loginDirect } from '../util/loginUtils';
+
+describe('protected page', () => {
+  let testContext;
+
+  beforeEach(async () => {
+    testContext = {};
+    await openPKCE();
+    await loginDirect();
+    await TestApp.assertLoggedIn();
+    testContext.loggedIn = true;
+  });
+
+  afterEach(async () => {
+    if (testContext.loggedIn) {
+      await TestApp.logoutRedirect();
+    }
+  });
+
+  it('auth required', async () => {
+    await TestApp.navigateToProtectedPage();
+    await TestApp.testAuthRequired();
+    await TestApp.assertAuthRequiredTestMessage('auth required test passed');
+    await TestApp.assertLoggedOut();
+    testContext.loggedIn = false;
+  });
+});

--- a/test/spec/ServiceManager.ts
+++ b/test/spec/ServiceManager.ts
@@ -16,7 +16,9 @@ import util from '@okta/test.support/util';
 
 jest.mock('broadcast-channel', () => {
   const actual = jest.requireActual('broadcast-channel');
-  class FakeBroadcastChannel {}
+  class FakeBroadcastChannel {
+    close() {}
+  }
   return {
     createLeaderElection: actual.createLeaderElection,
     BroadcastChannel: FakeBroadcastChannel
@@ -132,6 +134,7 @@ describe('ServiceManager', () => {
     const options = {
       services: { syncStorage: true }
     };
+    util.disableLeaderElection();
     const client = createAuth(options);
     client.serviceManager.start();
     client.serviceManager.stop();

--- a/test/spec/ServiceManager.ts
+++ b/test/spec/ServiceManager.ts
@@ -128,6 +128,18 @@ describe('ServiceManager', () => {
     client.serviceManager.stop();
   });
 
+  it('can restart', async () => {
+    const options = {
+      services: { syncStorage: true }
+    };
+    const client = createAuth(options);
+    client.serviceManager.start();
+    client.serviceManager.stop();
+    client.serviceManager.start();
+    expect(client.serviceManager.getService('syncStorage')?.isStarted()).toBeTruthy();
+    client.serviceManager.stop();
+  });
+
   describe('Backwards Compatibility', () => {
     it('`services` will supersede `tokenManager` configurations', async () => {
       const options = {


### PR DESCRIPTION
New behavior on change of `authState.isAuthenticated` to false for `/protected` page: 
- call `signInWithRedirect` only if document is visible and it's app initialisation stage
- otherwise show message `You are NOT authenticated. Sign-in again using one of these methods: [sign-in buttons]`

Internal ref: [OKTA-456247](https://oktainc.atlassian.net/browse/OKTA-456247)

---

Steps for `Test auth required`:
- Open protected page in new tab 1 and trigger logout
 Expected text in tab 1: `You are NOT authenticated. Sign-in again using one of these methods: [sign-in buttons]`
- Current tab has visibility state hidden for now (not in focus because of opened tab 1).
Expected text in current tab: `You are authenticated`
- Close tab 1 and return visibility for the current tab.
Then expected text in current tab: `You are NOT authenticated. Sign-in again using one of these methods: [sign-in buttons]`
- Open tab 2
Expected text in tab 2: `You are NOT authenticated. You are being redirected to sign-in page automatically...`
- Close tab 2


https://user-images.githubusercontent.com/72614880/157540431-0fe75bfe-d9fd-4150-bfa9-34066d2520eb.mov


