### PR TITLE
Adds support to pass activationToken to /register endpoint

### DIFF
--- a/samples/config.js
+++ b/samples/config.js
@@ -91,6 +91,7 @@ const samples = [
       'self-service-password-recovery', 
       'self-service-registration',
       'self-service-registration-custom-attribute',
+      'self-service-registration-activation-token',
       'mfa-password-and-email',
       'mfa-password-and-sms',
       'social-login-mfa',

--- a/samples/test/features/self-service-registration-activation-token.feature
+++ b/samples/test/features/self-service-registration-activation-token.feature
@@ -1,0 +1,9 @@
+Feature: Add another Required Attribute to the Profile Enrollment Policy
+
+  Background:
+    Given a Profile Enrollment policy defined assigning new users to the Everyone Group and by collecting "First Name", "Last Name", "Email", and a random property is allowed and assigned to a SPA, WEB APP or MOBILE application
+    And a User named "Mary" is created in staged state
+ 
+  Scenario: Mary signs up for an account using activation token
+    Given Mary opens the Self Service Registration View with activation token
+  #   And she sees the Select Authenticator page with password as the only option

--- a/samples/test/features/self-service-registration-activation-token.feature
+++ b/samples/test/features/self-service-registration-activation-token.feature
@@ -1,9 +1,9 @@
 Feature: Add another Required Attribute to the Profile Enrollment Policy
 
   Background:
-    Given a Profile Enrollment policy defined assigning new users to the Everyone Group and by collecting "First Name", "Last Name", "Email", and a random property is allowed and assigned to a SPA, WEB APP or MOBILE application
+    Given a Profile Enrollment policy defined assigning new users to the Everyone Group and by collecting "First Name", "Last Name", and "Email", is allowed and assigned to a SPA, WEB APP or MOBILE application
     And a User named "Mary" is created in staged state
  
   Scenario: Mary signs up for an account using activation token
     Given Mary opens the Self Service Registration View with activation token
-  #   And she sees the Select Authenticator page with password as the only option
+    And she sees the Select Authenticator page with password as the only option

--- a/samples/test/steps/given.ts
+++ b/samples/test/steps/given.ts
@@ -45,8 +45,8 @@ import ActionContext from '../support/context';
 import attachSSRPolicy from
   '../support/action/context-enabled/org-config/attachProfileEnrollmentPolicyWithCustomProfileAttribute';
 import createContextUser from '../support/action/context-enabled/live-user/createContextUser';
-import activateContextUserActivationToken from '../support/action/context-enabled/live-user/activateContextUserActivationToken';
-
+import activateContextUserActivationToken from 
+  '../support/action/context-enabled/live-user/activateContextUserActivationToken';
 
 Given(
   /^^a Profile Enrollment policy defined .* (?=by .* and a random property *.).*/,
@@ -149,7 +149,7 @@ Given(
 Given(
   /^a User named "([^/s]+)" is created in staged state$/,
   async function(this: ActionContext, firstName: string) {
-    await createContextUserAndCredentials.call(this, firstName, [''], false);
+    await createContextUserAndCredentials.call(this, firstName, ['MFA Required'], false);
   }
 );
 

--- a/samples/test/steps/given.ts
+++ b/samples/test/steps/given.ts
@@ -146,6 +146,13 @@ Given(
 );
 
 Given(
+  /^a User named "([^/s]+)" created and activated returning activation token$/,
+  async function(this: ActionContext, firstName: string) {
+    await createContextUserAndCredentials.call(this, firstName, ['MFA Required']);
+  }
+);
+
+Given(
   /^an Authenticator Enrollment Policy that has PHONE as optional and EMAIL as required for the Everyone Group$/,
   () => ({}) // no-op
 );

--- a/samples/test/steps/given.ts
+++ b/samples/test/steps/given.ts
@@ -45,6 +45,7 @@ import ActionContext from '../support/context';
 import attachSSRPolicy from
   '../support/action/context-enabled/org-config/attachProfileEnrollmentPolicyWithCustomProfileAttribute';
 import createContextUser from '../support/action/context-enabled/live-user/createContextUser';
+import activateContextUserActivationToken from '../support/action/context-enabled/live-user/activateContextUserActivationToken';
 
 
 Given(
@@ -146,10 +147,15 @@ Given(
 );
 
 Given(
-  /^a User named "([^/s]+)" created and activated returning activation token$/,
+  /^a User named "([^/s]+)" is created in staged state$/,
   async function(this: ActionContext, firstName: string) {
-    await createContextUserAndCredentials.call(this, firstName, ['MFA Required']);
+    await createContextUserAndCredentials.call(this, firstName, [''], false);
   }
+);
+
+Given(
+  /^Mary opens the Self Service Registration View with activation token/,
+  activateContextUserActivationToken
 );
 
 Given(

--- a/samples/test/support/action/context-enabled/live-user/activateContextUserActivationToken.ts
+++ b/samples/test/support/action/context-enabled/live-user/activateContextUserActivationToken.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+import openRegisterWithActivationToken from '../../../management-api/openRegisterWithActivationToken';
+import ActionContext from '../../../context';
+
+export default async function (this: ActionContext): Promise<void> {
+  await openRegisterWithActivationToken(this.user);
+}

--- a/samples/test/support/action/context-enabled/live-user/createContextUser.ts
+++ b/samples/test/support/action/context-enabled/live-user/createContextUser.ts
@@ -16,7 +16,8 @@ import createUser from '../../../management-api/createUser';
 import ActionContext, { getReusedContext } from '../../../context';
 import { Scenario } from '../../../scenario';
 
-export default async function (this: ActionContext, firstName: string, assignToGroups?: string[]): Promise<void> {
+export default async function 
+  (this: ActionContext, firstName: string, assignToGroups?: string[], activate = true): Promise<void> {
   // Scenario 10.1.3
   if (this.isCurrentScenario(Scenario.TOTP_SIGN_IN_REUSE_SHARED_SECRET)) {
     // reuse context
@@ -26,7 +27,7 @@ export default async function (this: ActionContext, firstName: string, assignToG
   } else {
     // don't create a18n profile and don't save credentials in context
     const credentials = this.credentials || await createCredentials(firstName, this.featureName, false);
-    const user = await createUser(credentials, assignToGroups);
+    const user = await createUser(credentials, assignToGroups, activate);
     this.user = user;
   }
 } 

--- a/samples/test/support/action/context-enabled/live-user/createContextUserAndCredentials.ts
+++ b/samples/test/support/action/context-enabled/live-user/createContextUserAndCredentials.ts
@@ -16,7 +16,7 @@ import createUser from '../../../management-api/createUser';
 import ActionContext, {getReusedContext } from '../../../context';
 import { Scenario } from '../../../scenario';
 
-export default async function (this: ActionContext, firstName: string, assignToGroups?: string[]): Promise<void> {
+export default async function (this: ActionContext, firstName: string, assignToGroups?: string[], activate: boolean = true): Promise<void> {
   // Scenario 10.1.3
   if (this.isCurrentScenario(Scenario.TOTP_SIGN_IN_REUSE_SHARED_SECRET)) {
     // reuse context
@@ -27,7 +27,7 @@ export default async function (this: ActionContext, firstName: string, assignToG
   } else {
     const credentials = this.credentials || await createCredentials(firstName, this.featureName);
     this.credentials = credentials;
-    const user = await createUser(credentials, assignToGroups);
+    const user = await createUser(credentials, assignToGroups, activate);
     this.user = user;
   }
 } 

--- a/samples/test/support/action/context-enabled/live-user/createContextUserAndCredentials.ts
+++ b/samples/test/support/action/context-enabled/live-user/createContextUserAndCredentials.ts
@@ -16,7 +16,8 @@ import createUser from '../../../management-api/createUser';
 import ActionContext, {getReusedContext } from '../../../context';
 import { Scenario } from '../../../scenario';
 
-export default async function (this: ActionContext, firstName: string, assignToGroups?: string[], activate: boolean = true): Promise<void> {
+export default async function 
+  (this: ActionContext, firstName: string, assignToGroups?: string[], activate = true): Promise<void> {
   // Scenario 10.1.3
   if (this.isCurrentScenario(Scenario.TOTP_SIGN_IN_REUSE_SHARED_SECRET)) {
     // reuse context

--- a/samples/test/support/management-api/addAppToPolicy.ts
+++ b/samples/test/support/management-api/addAppToPolicy.ts
@@ -10,13 +10,10 @@ export default async function(policyId: string, appId: string) {
   });
 
   try {
-    const issuer = config.issuer?.replace('/oauth2/default', '');
+    const orgUrl = config.issuer?.replace('/oauth2/default', '');
     let policy = await oktaClient.getPolicy(policyId);
-    let mappingsUrl = `${issuer}/api/v1/policies/${policyId}/mappings?forceCreate=true`;
-    await oktaClient.http.post(mappingsUrl, { body: JSON.stringify({
-      resourceId: appId,
-      resourceType: 'APP',
-    })});
+    let assignAppToPolicyUrl = `${orgUrl}/api/v1/apps/${appId}/policies/${policyId}`;
+    await oktaClient.http.put(assignAppToPolicyUrl);
     return policy;
   } catch (err) {
     console.warn('Unable to create policy-to-app mapping.', policyId, appId);

--- a/samples/test/support/management-api/createUser.ts
+++ b/samples/test/support/management-api/createUser.ts
@@ -18,7 +18,7 @@ import { UserCredentials } from './createCredentials';
 
 const userGroup = 'Basic Auth Web';
 
-export default async (credentials: UserCredentials, assignToGroups = [userGroup]): Promise<User> => {
+export default async (credentials: UserCredentials, assignToGroups = [userGroup], activate: boolean = true): Promise<User> => {
   const config = getConfig();
   const oktaClient = new Client({
     orgUrl: config.orgUrl,
@@ -54,7 +54,7 @@ export default async (credentials: UserCredentials, assignToGroups = [userGroup]
         password : { value: credentials.password }
       }
     }, {
-      activate: true
+      activate: activate
     });
 
     await oktaClient.assignUserToApplication(config.clientId as string, {

--- a/samples/test/support/management-api/createUser.ts
+++ b/samples/test/support/management-api/createUser.ts
@@ -18,7 +18,8 @@ import { UserCredentials } from './createCredentials';
 
 const userGroup = 'Basic Auth Web';
 
-export default async (credentials: UserCredentials, assignToGroups = [userGroup], activate: boolean = true): Promise<User> => {
+export default async (credentials: UserCredentials, assignToGroups = [userGroup], activate = true): 
+  Promise<User> => {
   const config = getConfig();
   const oktaClient = new Client({
     orgUrl: config.orgUrl,
@@ -43,19 +44,33 @@ export default async (credentials: UserCredentials, assignToGroups = [userGroup]
       testGroup = await oktaClient.createGroup(basicAuthGroup);
     }
 
-    user = await oktaClient.createUser({
-      profile: {
-        firstName: credentials.firstName,
-        lastName: credentials.lastName,
-        email: credentials.emailAddress,
-        login: credentials.emailAddress
-      },
-      credentials: {
-        password : { value: credentials.password }
-      }
-    }, {
-      activate: activate
-    });
+    if (activate === false) {
+      // Create user without password
+      user = await oktaClient.createUser({
+        profile: {
+          firstName: credentials.firstName,
+          lastName: credentials.lastName,
+          email: credentials.emailAddress,
+          login: credentials.emailAddress
+        }
+      }, {
+        activate: activate
+      });
+    } else {
+      user = await oktaClient.createUser({
+        profile: {
+          firstName: credentials.firstName,
+          lastName: credentials.lastName,
+          email: credentials.emailAddress,
+          login: credentials.emailAddress
+        },
+        credentials: {
+          password : { value: credentials.password }
+        }
+      }, {
+        activate: activate
+      });
+    }
 
     await oktaClient.assignUserToApplication(config.clientId as string, {
       id: user.id

--- a/samples/test/support/management-api/openRegisterWithActivationToken.ts
+++ b/samples/test/support/management-api/openRegisterWithActivationToken.ts
@@ -13,15 +13,12 @@
 
 import { User } from '@okta/okta-sdk-nodejs';
 
-export default async function(user: User) : Promise<void> {
+export default async function(user: User): Promise<void> {
   const sendEmail = { sendEmail : false };
   const token = await user.activate(sendEmail);
-  console.log(token);
-  console.log(token);
-  console.log(token);
-  console.log(token);
-  console.log(token);
-  const url = `http://localhost:8080/register?activationToken=${token}`;
-  browser.url(url);
+
+  const baseUrl = browser.options.baseUrl;
+  const registerWithActivationTokenUrl = `${baseUrl}/register?activationToken=${token.activationToken}`;
+  browser.url(registerWithActivationTokenUrl);
 }
 

--- a/samples/test/support/management-api/openRegisterWithActivationToken.ts
+++ b/samples/test/support/management-api/openRegisterWithActivationToken.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+import { User } from '@okta/okta-sdk-nodejs';
+
+export default async function(user: User) : Promise<void> {
+  const sendEmail = { sendEmail : false };
+  const token = await user.activate(sendEmail);
+  console.log(token);
+  console.log(token);
+  console.log(token);
+  console.log(token);
+  console.log(token);
+  const url = `http://localhost:8080/register?activationToken=${token}`;
+  browser.url(url);
+}
+


### PR DESCRIPTION
- Adds activation token support in sample app (Pass activation token to /register endpoint)
- Adds cucumber feature test for activation token flow
- Updates the profile enrollment policy mapping API to use apps API (previous API is being deprecated)