### PR TITLE
Fix cross-tabs test app config

### DIFF
--- a/test/apps/app/src/window.ts
+++ b/test/apps/app/src/window.ts
@@ -134,6 +134,8 @@ Object.assign(window, {
           autoRenew: true,
           autoRemove: false,
           syncStorage: config?.tokenManager?.syncStorage,
+        };
+        config.services = {
           broadcastChannelName: config.clientId + '_crossTabTest'
         };
         config.isTokenRenewPage = true;


### PR DESCRIPTION
Fix `tsc` error

```js
ERROR in /okta/okta-auth-js/test/apps/app/src/window.ts
./src/window.ts 137:10-65
[tsl] ERROR in /okta/okta-auth-js/test/apps/app/src/window.ts(137,11)
      TS2322: Type '{ expireEarlySeconds: any; autoRenew: true; autoRemove: false; syncStorage: boolean; broadcastChannelName: string; clearPendingRemoveTokens?: boolean; secure?: boolean; storage?: string | SimpleStorage; storageKey?: string; _storageEventDelay?: number; }' is not assignable to type 'TokenManagerOptions'.
  Object literal may only specify known properties, and 'broadcastChannelName' does not exist in type 'TokenManagerOptions'.
```

Without this fix cross-tabs test will not work correctly after clicking 'Start service' and 'Simulate cross-tab token renew'

[OKTA-476581](https://oktainc.atlassian.net/browse/OKTA-476581)