### PR TITLE
Refactor @okta/env - OKTA-476439

### DIFF
--- a/env/index.js
+++ b/env/index.js
@@ -32,8 +32,8 @@ function getPath(filename, currDir = __dirname) {
   // stop when find testenv file or reach to root dir
   while (!fs.existsSync(res) && currDir !== prevDir)  {
     prevDir = currDir;
-    currDir = path.resolve(currDir, '..');
     res = path.resolve(currDir, filename);
+    currDir = path.resolve(currDir, '..');
   }
   return fs.existsSync(res) ? res : null;
 }

--- a/env/package.json
+++ b/env/package.json
@@ -5,8 +5,5 @@
   "private": true,
   "dependencies": {
     "dotenv": "^8.2.0"
-  },
-  "devDependencies": {
-    "js-yaml": "^4.1.0"
   }
 }

--- a/env/package.json
+++ b/env/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "private": true,
   "dependencies": {
-    "dotenv": "^8.2.0"
+    "dotenv": "^8.2.0",
+    "js-yaml": "^4.1.0"
   }
 }

--- a/samples/generated/express-embedded-auth-with-sdk/config.js
+++ b/samples/generated/express-embedded-auth-with-sdk/config.js
@@ -12,7 +12,7 @@
 
 
 const env = require('./env')();
-env.setEnvironmentVarsFromTestEnv(); // Set environment variables from "testenv" file
+env.setEnvironmentVarsFromTestEnv(__dirname);
 
 module.exports = function () {
   const { 

--- a/samples/generated/express-embedded-auth-with-sdk/env/okta-env.js
+++ b/samples/generated/express-embedded-auth-with-sdk/env/okta-env.js
@@ -10,22 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-
 const dotenv = require('dotenv');
 const yaml = require('js-yaml');
 const fs = require('fs');
 const path = require('path');
-const ROOT_DIR = path.resolve(__dirname, '..');
 
-// Read environment variables from "testenv". Override environment vars if they are already set.
-const TESTENV = path.resolve(ROOT_DIR, 'testenv');
-
-// Multiple sets of environment variables can be stored in a file called "testenv.yml"
-const TESTENV_YAML = path.resolve(ROOT_DIR, 'testenv.yml');
-
-if (fs.existsSync(TESTENV)) {
-  setEnvironmentVarsFromTestEnv();
-}
+const TESTENV_FILE = 'testenv';
+const TESTENV_YAML = 'testenv.yml';
 
 function setEnvironmentVars(envConfig) {
   Object.keys(envConfig).forEach((k) => {
@@ -36,32 +27,32 @@ function setEnvironmentVars(envConfig) {
   });  
 }
 
-function setEnvironmentVarsFromTestEnv() {
-  if (!fs.existsSync(TESTENV)) {
+function getPath(filename, currDir = __dirname) {
+  let res, prevDir;
+  // stop when find testenv file or reach to root dir
+  while (!fs.existsSync(res) && currDir !== prevDir)  {
+    prevDir = currDir;
+    currDir = path.resolve(currDir, '..');
+    res = path.resolve(currDir, filename);
+  }
+  return fs.existsSync(res) ? res : null;
+}
+
+function setEnvironmentVarsFromTestEnv(currDir) {
+  const testEnvPath = getPath(TESTENV_FILE, currDir);
+  if (!testEnvPath) {
     return;
   }
-  const envConfig = dotenv.parse(fs.readFileSync(TESTENV));
+  const envConfig = dotenv.parse(fs.readFileSync(testEnvPath));
   setEnvironmentVars(envConfig);
 }
 
-function loadTestEnvYaml() {
-  if (!fs.existsSync(TESTENV_YAML)) {
+function setEnvironmentVarsFromTestEnvYaml(name, currDir) {
+  const testEnvPath = getPath(TESTENV_YAML, currDir);
+  if (!testEnvPath) {
     return;
   }
-
-  return yaml.load(fs.readFileSync(TESTENV_YAML, 'utf8'));
-}
-
-function getTestEnvironmentNames() {
-  const doc = loadTestEnvYaml();
-  if (!doc) {
-    return;
-  }
-  return Object.keys(doc);
-}
-
-function setEnvironmentVarsFromTestEnvYaml(name) {
-  const doc = loadTestEnvYaml();
+  const doc = yaml.load(fs.readFileSync(testEnvPath, 'utf8'));
   if (!doc) {
     console.log(`Can't load testenv.yml`);
     return;
@@ -79,8 +70,6 @@ function setEnvironmentVarsFromTestEnvYaml(name) {
 }
 
 module.exports = {
-  setEnvironmentVars,
   setEnvironmentVarsFromTestEnv,
-  setEnvironmentVarsFromTestEnvYaml,
-  getTestEnvironmentNames
+  setEnvironmentVarsFromTestEnvYaml
 };

--- a/samples/generated/express-embedded-auth-with-sdk/env/okta-env.js
+++ b/samples/generated/express-embedded-auth-with-sdk/env/okta-env.js
@@ -32,8 +32,8 @@ function getPath(filename, currDir = __dirname) {
   // stop when find testenv file or reach to root dir
   while (!fs.existsSync(res) && currDir !== prevDir)  {
     prevDir = currDir;
-    currDir = path.resolve(currDir, '..');
     res = path.resolve(currDir, filename);
+    currDir = path.resolve(currDir, '..');
   }
   return fs.existsSync(res) ? res : null;
 }

--- a/samples/generated/express-embedded-sign-in-widget/config.js
+++ b/samples/generated/express-embedded-sign-in-widget/config.js
@@ -12,7 +12,7 @@
 
 
 const env = require('./env')();
-env.setEnvironmentVarsFromTestEnv(); // Set environment variables from "testenv" file
+env.setEnvironmentVarsFromTestEnv(__dirname);
 
 module.exports = function () {
   const { 

--- a/samples/generated/express-embedded-sign-in-widget/env/okta-env.js
+++ b/samples/generated/express-embedded-sign-in-widget/env/okta-env.js
@@ -10,22 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-
 const dotenv = require('dotenv');
 const yaml = require('js-yaml');
 const fs = require('fs');
 const path = require('path');
-const ROOT_DIR = path.resolve(__dirname, '..');
 
-// Read environment variables from "testenv". Override environment vars if they are already set.
-const TESTENV = path.resolve(ROOT_DIR, 'testenv');
-
-// Multiple sets of environment variables can be stored in a file called "testenv.yml"
-const TESTENV_YAML = path.resolve(ROOT_DIR, 'testenv.yml');
-
-if (fs.existsSync(TESTENV)) {
-  setEnvironmentVarsFromTestEnv();
-}
+const TESTENV_FILE = 'testenv';
+const TESTENV_YAML = 'testenv.yml';
 
 function setEnvironmentVars(envConfig) {
   Object.keys(envConfig).forEach((k) => {
@@ -36,32 +27,32 @@ function setEnvironmentVars(envConfig) {
   });  
 }
 
-function setEnvironmentVarsFromTestEnv() {
-  if (!fs.existsSync(TESTENV)) {
+function getPath(filename, currDir = __dirname) {
+  let res, prevDir;
+  // stop when find testenv file or reach to root dir
+  while (!fs.existsSync(res) && currDir !== prevDir)  {
+    prevDir = currDir;
+    currDir = path.resolve(currDir, '..');
+    res = path.resolve(currDir, filename);
+  }
+  return fs.existsSync(res) ? res : null;
+}
+
+function setEnvironmentVarsFromTestEnv(currDir) {
+  const testEnvPath = getPath(TESTENV_FILE, currDir);
+  if (!testEnvPath) {
     return;
   }
-  const envConfig = dotenv.parse(fs.readFileSync(TESTENV));
+  const envConfig = dotenv.parse(fs.readFileSync(testEnvPath));
   setEnvironmentVars(envConfig);
 }
 
-function loadTestEnvYaml() {
-  if (!fs.existsSync(TESTENV_YAML)) {
+function setEnvironmentVarsFromTestEnvYaml(name, currDir) {
+  const testEnvPath = getPath(TESTENV_YAML, currDir);
+  if (!testEnvPath) {
     return;
   }
-
-  return yaml.load(fs.readFileSync(TESTENV_YAML, 'utf8'));
-}
-
-function getTestEnvironmentNames() {
-  const doc = loadTestEnvYaml();
-  if (!doc) {
-    return;
-  }
-  return Object.keys(doc);
-}
-
-function setEnvironmentVarsFromTestEnvYaml(name) {
-  const doc = loadTestEnvYaml();
+  const doc = yaml.load(fs.readFileSync(testEnvPath, 'utf8'));
   if (!doc) {
     console.log(`Can't load testenv.yml`);
     return;
@@ -79,8 +70,6 @@ function setEnvironmentVarsFromTestEnvYaml(name) {
 }
 
 module.exports = {
-  setEnvironmentVars,
   setEnvironmentVarsFromTestEnv,
-  setEnvironmentVarsFromTestEnvYaml,
-  getTestEnvironmentNames
+  setEnvironmentVarsFromTestEnvYaml
 };

--- a/samples/generated/express-embedded-sign-in-widget/env/okta-env.js
+++ b/samples/generated/express-embedded-sign-in-widget/env/okta-env.js
@@ -32,8 +32,8 @@ function getPath(filename, currDir = __dirname) {
   // stop when find testenv file or reach to root dir
   while (!fs.existsSync(res) && currDir !== prevDir)  {
     prevDir = currDir;
-    currDir = path.resolve(currDir, '..');
     res = path.resolve(currDir, filename);
+    currDir = path.resolve(currDir, '..');
   }
   return fs.existsSync(res) ? res : null;
 }

--- a/samples/generated/express-embedded-sign-in-widget/package.json
+++ b/samples/generated/express-embedded-sign-in-widget/package.json
@@ -7,8 +7,8 @@
     "node": ">=10.0.0"
   },
   "scripts": {
-    "start": "SIW_VERSION=${SIW_VERSION-6.1.0} node ./web-server/server.js",
-    "dev": "SIW_VERSION=${SIW_VERSION-6.1.0} nodemon ./web-server/server.js --watch ../../../build/cjs"
+    "start": "SIW_VERSION=${SIW_VERSION-6.1.1} node ./web-server/server.js",
+    "dev": "SIW_VERSION=${SIW_VERSION-6.1.1} nodemon ./web-server/server.js --watch ../../../build/cjs"
   },
   "dependencies": {
     "express": "^4.17.1",
@@ -24,6 +24,6 @@
     "concurrently": "^6.0.1"
   },
   "peerDependencies": {
-    "@okta/okta-signin-widget": "^6.1.0"
+    "@okta/okta-signin-widget": "^6.1.1"
   }
 }

--- a/samples/generated/static-spa/public/index.html
+++ b/samples/generated/static-spa/public/index.html
@@ -2,14 +2,14 @@
 <html>
   <head>
     <!-- In this sample, okta-auth-js assets are being served locally from node_modules. Assets are also available on CDN -->
-    <!-- https://global.oktacdn.com/okta-auth-js/6.1.0/okta-auth-js.polyfill.js -->
-    <!-- https://global.oktacdn.com/okta-auth-js/6.1.0/okta-auth-js.min.js -->
+    <!-- https://global.oktacdn.com/okta-auth-js/6.2.0/okta-auth-js.polyfill.js -->
+    <!-- https://global.oktacdn.com/okta-auth-js/6.2.0/okta-auth-js.min.js -->
     <script src="/okta-auth-js.polyfill.js" type="text/javascript"></script>
     <script src="/okta-auth-js.min.js" type="text/javascript"></script>
 
     <!-- okta-signin-widget assets are avilable on CDN -->
-    <script src="https://global.oktacdn.com/okta-signin-widget/6.1.0/js/okta-sign-in.min.js" type="text/javascript"></script>
-    <link href="https://global.oktacdn.com/okta-signin-widget/6.1.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+    <script src="https://global.oktacdn.com/okta-signin-widget/6.1.1/js/okta-sign-in.min.js" type="text/javascript"></script>
+    <link href="https://global.oktacdn.com/okta-signin-widget/6.1.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 
     <!-- app styles -->
     <link rel="stylesheet" href="https://unpkg.com/purecss@2.0.6/build/pure-min.css" integrity="sha384-Uu6IeWbM+gzNVXJcM9XV3SohHtmWE+3VGi496jvgX1jyvDTXfdK+rfZc8C1Aehk5" crossorigin="anonymous">

--- a/samples/generated/webpack-spa/package.json
+++ b/samples/generated/webpack-spa/package.json
@@ -26,6 +26,6 @@
     "webpack-dev-server": "^3.2.1"
   },
   "peerDependencies": {
-    "@okta/okta-signin-widget": "^6.1.0"
+    "@okta/okta-signin-widget": "^6.1.1"
   }
 }

--- a/samples/test/cucumber.wdio.conf.ts
+++ b/samples/test/cucumber.wdio.conf.ts
@@ -11,7 +11,7 @@
  */
 
 
-require('@okta/env').setEnvironmentVarsFromTestEnv(); // Set environment variables from "testenv" file
+require('@okta/env').setEnvironmentVarsFromTestEnv(__dirname);
 require('@babel/register'); // Allows use of import module syntax
 require('regenerator-runtime'); // Allows use of async/await
 

--- a/samples/test/runner.js
+++ b/samples/test/runner.js
@@ -13,7 +13,7 @@
 
 /* eslint-disable no-console */
 
-require('@okta/env').setEnvironmentVarsFromTestEnv(); // Set environment variables from "testenv" file
+require('@okta/env').setEnvironmentVarsFromTestEnv(__dirname);
 
 const spawn = require('cross-spawn-with-kill');
 const waitOn = require('wait-on');

--- a/samples/test/sauce.wdio.conf.js
+++ b/samples/test/sauce.wdio.conf.js
@@ -11,7 +11,7 @@
  */
 
 
-require('@okta/env').setEnvironmentVarsFromTestEnv(); // Set environment variables from "testenv" file
+require('@okta/env').setEnvironmentVarsFromTestEnv(__dirname);
 require('@babel/register'); // Allows use of import module syntax
 require('regenerator-runtime'); // Allows use of async/await
 

--- a/samples/test/support/action/setEnvironment.ts
+++ b/samples/test/support/action/setEnvironment.ts
@@ -16,14 +16,14 @@
  * @param  {String}   envName    The name of the test environment
  */
 
-const env = require('@okta/env');
+// const env = require('@okta/env');
 import waitForDisplayed from '../wait/waitForDisplayed';
 import Home from '../selectors/Home';
 import startApp from './startApp';
 
 export default async (envName: string) => {
   // update variables for runner process
-  env.setEnvironmentVarsFromTestEnvYaml(envName);
+  // env.setEnvironmentVarsFromTestEnvYaml(envName);
 
   // update variables for server process
   await startApp('/', { testenv: envName });

--- a/samples/test/support/action/setEnvironment.ts
+++ b/samples/test/support/action/setEnvironment.ts
@@ -16,14 +16,14 @@
  * @param  {String}   envName    The name of the test environment
  */
 
-// const env = require('@okta/env');
+const env = require('@okta/env');
 import waitForDisplayed from '../wait/waitForDisplayed';
 import Home from '../selectors/Home';
 import startApp from './startApp';
 
 export default async (envName: string) => {
   // update variables for runner process
-  // env.setEnvironmentVarsFromTestEnvYaml(envName);
+  env.setEnvironmentVarsFromTestEnvYaml(envName, __dirname);
 
   // update variables for server process
   await startApp('/', { testenv: envName });

--- a/samples/test/wdio.conf.ts
+++ b/samples/test/wdio.conf.ts
@@ -11,7 +11,7 @@
  */
 
 
-require('@okta/env').setEnvironmentVarsFromTestEnv(); // Set environment variables from "testenv" file
+require('@okta/env').setEnvironmentVarsFromTestEnv(__dirname);
 require('@babel/register'); // Allows use of import module syntax
 require('regenerator-runtime'); // Allows use of async/await
 

--- a/test/apps/app/server/index.js
+++ b/test/apps/app/server/index.js
@@ -13,7 +13,7 @@
 
 /* eslint-disable no-console */
 
-require('@okta/env').setEnvironmentVarsFromTestEnv(); // Set environment variables from "testenv" file
+require('@okta/env').setEnvironmentVarsFromTestEnv(__dirname);
 
 const createProxyMiddleware = require('./proxyMiddleware');
 const loginMiddleware = require('./loginMiddleware');

--- a/test/apps/app/webpack.config.js
+++ b/test/apps/app/webpack.config.js
@@ -11,7 +11,7 @@
  */
 
 
-require('@okta/env').setEnvironmentVarsFromTestEnv(); // Set environment variables from "testenv" file
+require('@okta/env').setEnvironmentVarsFromTestEnv(__dirname);
 
 const path = require('path');
 const webpack = require('webpack');

--- a/test/apps/react-mfa-v1/config-overrides.js
+++ b/test/apps/react-mfa-v1/config-overrides.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack');
 
 const envModule = require('@okta/env');
-envModule.setEnvironmentVarsFromTestEnv();
+envModule.setEnvironmentVarsFromTestEnv(__dirname);
 
 const env = {};
 // List of environment variables made available to the app

--- a/test/apps/react-oie/vite.config.js
+++ b/test/apps/react-oie/vite.config.js
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 import { visualizer } from 'rollup-plugin-visualizer';
 import envModule from '@okta/env';
 
-envModule.setEnvironmentVarsFromTestEnv();
+envModule.setEnvironmentVarsFromTestEnv(__dirname);
 
 const env = {};
 // List of environment variables made available to the app

--- a/test/e2e/runner.js
+++ b/test/e2e/runner.js
@@ -17,7 +17,7 @@ const spawn = require('cross-spawn-with-kill');
 const waitOn = require('wait-on');
 const { config, configPredicate } = require('./config');
 
-env.setEnvironmentVarsFromTestEnv();
+env.setEnvironmentVarsFromTestEnv(__dirname);
 
 const getTask = (config) => () => {
   return new Promise(resolve => {

--- a/test/e2e/sauce.wdio.conf.js
+++ b/test/e2e/sauce.wdio.conf.js
@@ -12,7 +12,7 @@
 
 
 // Set environment variables from "testenv" file
-require('@okta/env').setEnvironmentVarsFromTestEnv();
+require('@okta/env').setEnvironmentVarsFromTestEnv(__dirname);
 
 require('@babel/register'); // Allows use of import module syntax
 require('regenerator-runtime'); // Allows use of async/await

--- a/test/e2e/wdio.conf.js
+++ b/test/e2e/wdio.conf.js
@@ -11,7 +11,7 @@
  */
 
 
-require('@okta/env').setEnvironmentVarsFromTestEnv(); // Set environment variables from "testenv" file
+require('@okta/env').setEnvironmentVarsFromTestEnv(__dirname);
 require('@babel/register'); // Allows use of import module syntax
 require('regenerator-runtime'); // Allows use of async/await
 


### PR DESCRIPTION
Refactor @okta/env submodule to be able to read `testenv` inside the sample folder, then it can keep looking up the file within the parent folders until reach to the root.