### PR TITLE
chore: upgrade okta-sdk-nodejs to latest

### DIFF
--- a/samples/test/package.json
+++ b/samples/test/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@babel/register": "^7.8.2",
-    "@okta/okta-sdk-nodejs": "^5.0.0",
+    "@okta/okta-sdk-nodejs": "^6.4.0",
     "cross-fetch": "^3.1.5",
     "cross-spawn-with-kill": "^1.0.0",
     "regenerator-runtime": "^0.13.3",

--- a/samples/test/specs/spa-app.js
+++ b/samples/test/specs/spa-app.js
@@ -49,8 +49,8 @@ describe('spa-app: ' + sampleConfig.name, () => {
   });
 
   // TODO: fix this flaky test OKTA-464122
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('can use memory token storage', async () => {
+  // [UPDATE 3/8/22] could not get test to fail when attempt to repro. Re-enabling
+  it('can use memory token storage', async () => {
     await startApp('/', { authMethod: 'redirect', requireUserSession: true, storage: 'memory' });
     await loginRedirect();
     await checkProfile();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2862,19 +2862,19 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@okta/okta-sdk-nodejs@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-sdk-nodejs/-/okta-sdk-nodejs-5.0.0.tgz#ce3b034cd02c0a475f3513cb1ef229e9580c1ef1"
-  integrity sha512-hLKDsGWFRu5rdlsapHwYNM+hYpJ9yMbGl/tGIHycL8sJailZiBx+gf5/UJ1vHgqKfhU8yu+R8u5fzC7arqG9sw==
+"@okta/okta-sdk-nodejs@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-sdk-nodejs/-/okta-sdk-nodejs-6.4.0.tgz#ac5620d9eefca908b9c672c425768ce066c3238d"
+  integrity sha512-OtdmDp/M76K/i2NPcUntzAkqjTAJsdjgLfpMoS80mR1yrc+cEZ+g9T9LJdLNx2J8f90ltugRi2vJnv88kUYaZQ==
   dependencies:
-    "@types/node-fetch" "^2.5.8"
-    "@types/rasha" "^1.2.2"
     deep-copy "^1.4.2"
-    isomorphic-fetch "^3.0.0"
+    form-data "^4.0.0"
+    https-proxy-agent "^5.0.0"
     js-yaml "^4.1.0"
     lodash "^4.17.20"
     njwt "^1.0.0"
-    parse-link-header "^1.0.1"
+    node-fetch "^2.6.7"
+    parse-link-header "^2.0.0"
     rasha "^1.2.5"
     safe-flat "^2.0.2"
 
@@ -3614,14 +3614,6 @@
   resolved "https://registry.yarnpkg.com/@types/mockery/-/mockery-1.4.29.tgz#9ba22df37f07e3780fff8531d1a38e633f9457a5"
   integrity sha1-m6It838H43gP/4Ux0aOOYz+UV6U=
 
-"@types/node-fetch@^2.5.8":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz#9b4d4a0425562f9fcea70b12cb3fcdd946ca8132"
-  integrity sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==
-  dependencies:
-    "@types/node" "*"
-    form-data "^3.0.0"
-
 "@types/node@*", "@types/node@>=13.7.0", "@types/node@^15.0.1":
   version "15.12.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.5.tgz#9a78318a45d75c9523d2396131bd3cca54b2d185"
@@ -3675,11 +3667,6 @@
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df"
   integrity sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==
-
-"@types/rasha@^1.2.2":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@types/rasha/-/rasha-1.2.3.tgz#e147f1c688d7064c8d42a6c61bedf5b1347e927a"
-  integrity sha512-59k9jLEufpyKQxuycIYqSU30V4rO1bDlX+W4xGFTj3CFuHRfmcUcVRtxx1mr0T38iwk3d1ZooFqCQR2RX/NUTw==
 
 "@types/recursive-readdir@^2.2.0":
   version "2.2.0"
@@ -10372,6 +10359,15 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -12439,14 +12435,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isomorphic-fetch@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
-  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
-  dependencies:
-    node-fetch "^2.6.1"
-    whatwg-fetch "^3.4.1"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -15577,7 +15565,7 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@2.6.7, node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@2.6.7, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -16401,10 +16389,10 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
-parse-link-header@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parse-link-header/-/parse-link-header-1.0.1.tgz#bedfe0d2118aeb84be75e7b025419ec8a61140a7"
-  integrity sha1-vt/g0hGK64S+deewJUGeyKYRQKc=
+parse-link-header@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-link-header/-/parse-link-header-2.0.0.tgz#949353e284f8aa01f2ac857a98f692b57733f6b7"
+  integrity sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==
   dependencies:
     xtend "~4.0.1"
 


### PR DESCRIPTION
Also re-enables suspected flaky test