### PR TITLE
Add fix for TS < 3.6 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,13 +277,11 @@ if (!userInfo) {
 }
 ```
 
-#### Usage with Typescript < 3.6 and Angular < 9
+#### Usage with Typescript < 3.6
 
-Typescript versions prior to 3.6 (used in Angular prior to v9) has no types for WebAuthn. 
+Typescript versions prior to 3.6 have no type definitions for WebAuthn. 
 Support for WebAuthn in IDX API was introduced in `OktaAuth 6.1.0`. 
 To solve this issue please install package `@types/webappsec-credential-management` version `^0.5.1`. 
-For Angular 8 and below please also add `webappsec-credential-management` into `types` of `compilerOptions` in `tsconfig.json`. 
-See [okta-angular sample app for Angular 7](https://github.com/okta/okta-angular/tree/master/test/apps/angular-v7). 
 
 ### Strategies for Obtaining Tokens
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,14 @@ if (!userInfo) {
 }
 ```
 
+#### Usage with Typescript < 3.6 and Angular < 9
+
+Typescript versions prior to 3.6 (used in Angular prior to v9) has no types for WebAuthn. 
+Support for WebAuthn in IDX API was introduced in `OktaAuth 6.1.0`. 
+To solve this issue please install package `@types/webappsec-credential-management` version `^0.5.1`. 
+For Angular 8 and below please also add `webappsec-credential-management` into `types` of `compilerOptions` in `tsconfig.json`. 
+See [okta-angular sample app for Angular 7](https://github.com/okta/okta-angular/tree/master/test/apps/angular-v7). 
+
 ### Strategies for Obtaining Tokens
 
 #### Authorization Code flow for web and native client types


### PR DESCRIPTION
TypeScript< 3.6 has no types for WebAuthn (which is used in `okta-auth-js 6.1.0+`)
Solution is to use `@types/webappsec-credential-management` (but version `0.5.1` , because version 0.6 has no declaration for `AttestationConveyancePreference `) 

Internal ref: [OKTA-473798](https://oktainc.atlassian.net/browse/OKTA-473798)
Partially resolves https://github.com/okta/okta-auth-js/issues/1116
(also see https://github.com/okta/okta-angular/pull/89)