### PR TITLE
use preset-typescript instead of ts-loader

### DIFF
--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -146,10 +146,10 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
   idx: IdxAPI;
   session: SessionAPI;
   pkce: PkceAPI;
-  static features: FeaturesAPI;
-  static crypto: CryptoAPI;
-  static webauthn: WebauthnAPI;
-  features!: FeaturesAPI;
+  static features: FeaturesAPI = features;
+  static crypto: CryptoAPI = crypto;
+  static webauthn: WebauthnAPI = webauthn;
+  features: FeaturesAPI = features;
   token: TokenAPI;
   _tokenQueue: PromiseQueue;
   emitter: any;
@@ -778,14 +778,8 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
   }
 }
 
-// Hoist feature detection functions to static type
+// Hoist feature detection functions to prototype & static type
 OktaAuth.features = OktaAuth.prototype.features = features;
-
-// Hoist crypto utils to static type
-OktaAuth.crypto = crypto;
-
-// Hoist webauthn utils to static type
-OktaAuth.webauthn = webauthn;
 
 // Also hoist constants for CommonJS users
 Object.assign(OktaAuth, {

--- a/lib/idx/flow/RemediationFlow.ts
+++ b/lib/idx/flow/RemediationFlow.ts
@@ -11,6 +11,12 @@
  */
 
 
-import * as remediators from '../remediators';
+import { RemediateOptions } from '../remediate';
+import { RemediationValues } from '../remediators';
+import { IdxRemediation } from '../types/idx-js';
 
-export type RemediationFlow = Record<string, typeof remediators.Remediator>;
+type RemediationConstructor = {
+  new<T extends RemediationValues>(remediation: IdxRemediation, values?: T, options?: RemediateOptions): any;
+}
+
+export type RemediationFlow = Record<string, RemediationConstructor>;

--- a/lib/idx/remediate.ts
+++ b/lib/idx/remediate.ts
@@ -53,7 +53,7 @@ export function getRemediator(
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const remediators = options.remediators!;
 
-  let remediator;
+  let remediator: Remediator;
   // remediation name specified by caller - fast-track remediator lookup 
   if (options.step) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -68,9 +68,9 @@ export function getRemediator(
     }
   }
 
-  const remediatorCandidates = [];
+  const remediatorCandidates: Remediator[] = [];
   for (let remediation of idxRemediations) {
-    const isRemeditionInFlow = Object.keys(remediators as object).includes(remediation.name);
+    const isRemeditionInFlow = Object.keys(remediators).includes(remediation.name);
     if (!isRemeditionInFlow) {
       continue;
     }
@@ -83,7 +83,7 @@ export function getRemediator(
     }
     // remediator cannot handle the current values
     // maybe return for next step
-    remediatorCandidates.push(remediator as never);  
+    remediatorCandidates.push(remediator);  
   }
   
   return remediatorCandidates[0];

--- a/lib/idx/remediators/Base/AuthenticatorData.ts
+++ b/lib/idx/remediators/Base/AuthenticatorData.ts
@@ -22,8 +22,7 @@ export type AuthenticatorDataValues = RemediationValues & {
 };
 
 // Base class - DO NOT expose static remediationName
-export class AuthenticatorData extends Remediator {
-  values!: AuthenticatorDataValues;
+export class AuthenticatorData extends Remediator<AuthenticatorDataValues> {
   authenticator: IdxAuthenticator;
 
   constructor(remediation: IdxRemediation, values: AuthenticatorDataValues = {}) {

--- a/lib/idx/remediators/Base/Remediator.ts
+++ b/lib/idx/remediators/Base/Remediator.ts
@@ -29,17 +29,17 @@ export interface RemediationValues extends IdxOptions {
 }
 
 // Base class - DO NOT expose static remediationName
-export class Remediator {
+export class Remediator<ValuesType extends RemediationValues = RemediationValues> {
   static remediationName: string;
 
   remediation: IdxRemediation;
-  values: RemediationValues;
+  values: ValuesType;
   options: RemediateOptions;
   map?: IdxToRemediationValueMap;
 
   constructor(remediation: IdxRemediation, values: RemediationValues = {}, options: RemediateOptions = {}) {
     // assign fields to the instance
-    this.values = { ...values };
+    this.values = { ...values } as ValuesType;
     this.options = { ...options };
     this.formatAuthenticators();
     this.remediation = remediation;

--- a/lib/idx/remediators/Base/SelectAuthenticator.ts
+++ b/lib/idx/remediators/Base/SelectAuthenticator.ts
@@ -23,8 +23,7 @@ export type SelectAuthenticatorValues = RemediationValues & {
 };
 
 // Base class - DO NOT expose static remediationName
-export class SelectAuthenticator extends Remediator {
-  values!: SelectAuthenticatorValues;
+export class SelectAuthenticator extends Remediator<SelectAuthenticatorValues> {
   selectedAuthenticator?: Authenticator;
   selectedOption?: any;
 

--- a/lib/idx/remediators/Base/VerifyAuthenticator.ts
+++ b/lib/idx/remediators/Base/VerifyAuthenticator.ts
@@ -19,10 +19,9 @@ import { NextStep } from '../../types';
 export type VerifyAuthenticatorValues = AuthenticatorValues & RemediationValues;
 
 // Base class - DO NOT expose static remediationName
-export class VerifyAuthenticator extends Remediator {
+export class VerifyAuthenticator extends Remediator<VerifyAuthenticatorValues> {
 
   authenticator: Authenticator<VerifyAuthenticatorValues>;
-  values!: VerifyAuthenticatorValues;
 
   constructor(remediation: IdxRemediation, values: VerifyAuthenticatorValues = {}) {
     super(remediation, values);

--- a/lib/idx/remediators/EnrollPoll.ts
+++ b/lib/idx/remediators/EnrollPoll.ts
@@ -19,10 +19,8 @@ export interface EnrollPollValues extends RemediationValues {
   startPolling?: boolean;
 }
 
-export class EnrollPoll extends Remediator {
+export class EnrollPoll extends Remediator<EnrollPollValues> {
   static remediationName = 'enroll-poll';
-
-  values!: EnrollPollValues;
 
   canRemediate() {
     return !!this.values.startPolling || this.options.step === 'enroll-poll';

--- a/lib/idx/remediators/EnrollProfile.ts
+++ b/lib/idx/remediators/EnrollProfile.ts
@@ -21,10 +21,8 @@ export interface EnrollProfileValues extends RemediationValues {
   email?: string;
 }
 
-export class EnrollProfile extends Remediator {
+export class EnrollProfile extends Remediator<EnrollProfileValues> {
   static remediationName = 'enroll-profile';
-
-  values!: EnrollProfileValues;
 
   canRemediate() {
     const userProfileFromValues = this.getData().userProfile;

--- a/lib/idx/remediators/EnrollmentChannelData.ts
+++ b/lib/idx/remediators/EnrollmentChannelData.ts
@@ -20,10 +20,8 @@ export type EnrollmentChannelDataValues = RemediationValues & {
   phoneNumber?: string;
 };
 
-export class EnrollmentChannelData extends Remediator {
+export class EnrollmentChannelData extends Remediator<EnrollmentChannelDataValues> {
   static remediationName = 'enrollment-channel-data';
-
-  values!: EnrollmentChannelDataValues;
 
   getInputEmail() {
     return [

--- a/lib/idx/remediators/Identify.ts
+++ b/lib/idx/remediators/Identify.ts
@@ -20,10 +20,8 @@ export interface IdentifyValues extends RemediationValues {
   credentials?: Credentials;
 }
 
-export class Identify extends Remediator {
+export class Identify extends Remediator<IdentifyValues> {
   static remediationName = 'identify';
-
-  values!: IdentifyValues;
 
   map = {
     'identifier': ['username']

--- a/lib/idx/remediators/ReEnrollAuthenticator.ts
+++ b/lib/idx/remediators/ReEnrollAuthenticator.ts
@@ -17,10 +17,8 @@ export interface ReEnrollAuthenticatorValues extends RemediationValues {
   newPassword?: string;
 }
 
-export class ReEnrollAuthenticator extends Remediator {
+export class ReEnrollAuthenticator extends Remediator<ReEnrollAuthenticatorValues> {
   static remediationName = 'reenroll-authenticator';
-
-  values!: ReEnrollAuthenticatorValues;
 
   mapCredentials() {
     const { newPassword } = this.values;

--- a/lib/idx/remediators/SelectEnrollProfile.ts
+++ b/lib/idx/remediators/SelectEnrollProfile.ts
@@ -16,10 +16,8 @@ import { Remediator, RemediationValues } from './Base/Remediator';
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SelectEnrollProfileValues extends RemediationValues {}
 
-export class SelectEnrollProfile extends Remediator {
+export class SelectEnrollProfile extends Remediator<SelectEnrollProfileValues> {
   static remediationName = 'select-enroll-profile';
-
-  values!: SelectEnrollProfileValues;
 
   canRemediate() {
     return true;

--- a/lib/idx/remediators/SelectEnrollmentChannel.ts
+++ b/lib/idx/remediators/SelectEnrollmentChannel.ts
@@ -21,10 +21,8 @@ export type SelectEnrollmentChannelValues = RemediationValues & {
   channel?: string;
 };
 
-export class SelectEnrollmentChannel extends Remediator {
+export class SelectEnrollmentChannel extends Remediator<SelectEnrollmentChannelValues> {
   static remediationName = 'select-enrollment-channel';
-
-  values!: SelectEnrollmentChannelValues;
 
   canRemediate() {
     return Boolean(this.values.channel);

--- a/lib/idx/remediators/Skip.ts
+++ b/lib/idx/remediators/Skip.ts
@@ -17,10 +17,8 @@ export interface SkipValues extends RemediationValues {
   skip?: boolean;
 }
 
-export class Skip extends Remediator {
+export class Skip extends Remediator<SkipValues> {
   static remediationName = 'skip';
-
-  values!: SkipValues;
 
   canRemediate() {
     return !!this.values.skip || this.options.step === 'skip';

--- a/lib/idx/types/index.ts
+++ b/lib/idx/types/index.ts
@@ -28,7 +28,7 @@ import {
 } from './idx-js';
 import { FlowIdentifier } from './FlowIdentifier';
 
-export {
+export type {
   IdxMessage,
   IdxMessages,
   ChallengeData,
@@ -37,18 +37,18 @@ export {
   IdxContext,
   RawIdxResponse
 } from './idx-js';
-export { AuthenticationOptions } from '../authenticate';
-export { RegistrationOptions } from '../register';
-export { PasswordRecoveryOptions } from '../recoverPassword';
-export { AccountUnlockOptions } from '../unlockAccount';
-export { ProceedOptions } from '../proceed';
-export { CancelOptions } from '../cancel';
-export { RemediateOptions } from '../remediate';
-export { FlowIdentifier };
-export { IdxAuthenticator };
-export { EmailVerifyCallbackResponse } from '../emailVerify';
-export { WebauthnEnrollValues } from '../authenticator/WebauthnEnrollment';
-export { WebauthnVerificationValues } from '../authenticator/WebauthnVerification';
+export type { AuthenticationOptions } from '../authenticate';
+export type { RegistrationOptions } from '../register';
+export type { PasswordRecoveryOptions } from '../recoverPassword';
+export type { AccountUnlockOptions } from '../unlockAccount';
+export type { ProceedOptions } from '../proceed';
+export type { CancelOptions } from '../cancel';
+export type { RemediateOptions } from '../remediate';
+export type { FlowIdentifier };
+export type { IdxAuthenticator };
+export type { EmailVerifyCallbackResponse } from '../emailVerify';
+export type { WebauthnEnrollValues } from '../authenticator/WebauthnEnrollment';
+export type { WebauthnVerificationValues } from '../authenticator/WebauthnVerification';
 
 export enum IdxStatus {
   SUCCESS = 'SUCCESS',

--- a/package.json
+++ b/package.json
@@ -144,7 +144,6 @@
     "rollup-plugin-typescript2": "^0.30.0",
     "shelljs": "0.8.4",
     "ts-jest": "^27.1.3",
-    "ts-loader": "^9.2.6",
     "tsd": "^0.17.0",
     "typescript": "^4.2.3",
     "webpack": "^5.60.0",

--- a/test/apps/app/package.json
+++ b/test/apps/app/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@types/js-cookie": "^2.2.6",
-    "ts-loader": "^8.0.0",
     "typescript": "^4.2.3"
   },
   "peerDependencies": {

--- a/test/apps/app/webpack.config.js
+++ b/test/apps/app/webpack.config.js
@@ -18,7 +18,10 @@ const webpack = require('webpack');
 const PORT = process.env.PORT || 8080;
 
 const babelOptions = {
-  presets: ['@babel/env'],
+  presets: [
+    '@babel/env',
+    '@babel/preset-typescript'
+  ],
   plugins: ['@babel/plugin-transform-runtime'],
   sourceType: 'unambiguous'
 };
@@ -52,28 +55,15 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.js$/,
+        test: /\.[jt]s$/,
         use: ['source-map-loader'],
         enforce: 'pre'
       },
       {
-        test: /\.js$/,
+        test: /\.[jt]s$/,
         exclude: /node_modules/,
         loader: 'babel-loader',
         options: babelOptions
-      },
-      {
-        test: /\.ts$/,
-        exclude: /node_modules/,
-        use: [
-          {
-            loader: 'babel-loader',
-            options: babelOptions
-          },
-          {
-            loader: 'ts-loader'
-          }
-        ]
       }
     ]
   }

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -5,7 +5,9 @@ var SDK_VERSION = require('./package.json').version;
 var babelOptions = {
   configFile: false, // do not load from babel.config.js
   babelrc: false, // do not load from .babelrc
-  presets: [],
+  presets: [
+    '@babel/preset-typescript'
+  ],
   plugins: [],
   sourceType: 'unambiguous',
   // the banners should only be added at the end of the build process
@@ -15,7 +17,7 @@ var babelOptions = {
 
 // Keep source files untransformed for local development
 if (process.env.NODE_ENV !== 'development') {
-  babelOptions.presets.push('@babel/preset-env');
+  babelOptions.presets.unshift('@babel/preset-env'); // must run after preset-typescript
   babelOptions.plugins = babelOptions.plugins.concat([
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-runtime'
@@ -27,23 +29,10 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.js$/,
+        test: /\.[jt]s$/,
         exclude: babelExclude,
         loader: 'babel-loader',
         options: babelOptions
-      },
-      {
-        test: /\.ts$/,
-        exclude: babelExclude,
-        use: [
-          {
-            loader: 'babel-loader',
-            options: babelOptions
-          },
-          {
-            loader: 'ts-loader'
-          }
-        ]
       }
     ]
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ var commonConfig = require('./webpack.common.config');
 var license = fs.readFileSync('lib/license-header.txt', 'utf8');
 
 module.exports = _.extend({}, _.cloneDeep(commonConfig), {
-  mode: 'production',
+  mode: (process.env.NODE_ENV === 'development') ? 'development' : 'production',
   entry: './lib/',
   output: {
     path: path.join(__dirname, 'build', 'dist'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -8917,7 +8917,7 @@ enhanced-resolve@^3.4.0:
     object-assign "^4.0.1"
     tapable "^0.2.7"
 
-enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0, enhanced-resolve@^4.5.0:
+enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0, enhanced-resolve@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz#2f3cfd84dbe3b487f18f2db2ef1e064a571ca5ec"
   integrity sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==
@@ -8926,7 +8926,7 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0, enhan
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.0.0, enhanced-resolve@^5.8.3:
+enhanced-resolve@^5.8.3:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
   integrity sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==
@@ -15449,7 +15449,7 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4:
+micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
@@ -21109,27 +21109,6 @@ ts-jest@^27.1.3:
     make-error "1.x"
     semver "7.x"
     yargs-parser "20.x"
-
-ts-loader@^8.0.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.3.0.tgz#83360496d6f8004fab35825279132c93412edf33"
-  integrity sha512-MgGly4I6cStsJy27ViE32UoqxPTN9Xly4anxxVyaIWR+9BGxboV4EyJBGfR3RePV7Ksjj3rHmPZJeIt+7o4Vag==
-  dependencies:
-    chalk "^4.1.0"
-    enhanced-resolve "^4.0.0"
-    loader-utils "^2.0.0"
-    micromatch "^4.0.0"
-    semver "^7.3.4"
-
-ts-loader@^9.2.6:
-  version "9.2.6"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.2.6.tgz#9937c4dd0a1e3dbbb5e433f8102a6601c6615d74"
-  integrity sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==
-  dependencies:
-    chalk "^4.1.0"
-    enhanced-resolve "^5.0.0"
-    micromatch "^4.0.0"
-    semver "^7.3.4"
 
 ts-node@^9.0.0, ts-node@^9.1.1:
   version "9.1.1"


### PR DESCRIPTION
- removes ts-loader and replaces with @babel/preset-typescript
- fixes issues with sourcemaps caused by TS generated code
- removes TS-generated awaiter() code - all transpilation is done by babel
- improves type validation
- use generic type for base Remediator for strong typing of the "values" types for each Remediator
