### PR TITLE
fix: error handling for IDX actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.3.1
+
+### Fixes
+
+- [#1160](https://github.com/okta/okta-auth-js/pull/1160) Fixes error handling for IDX actions
+
 ## 6.3.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Fixes
 
-- [#1160](https://github.com/okta/okta-auth-js/pull/1160) Fixes error handling for IDX actions
+- [#1160](https://github.com/okta/okta-auth-js/pull/1160)
+  - Fixes error handling for IDX actions
+  - Fixes saved IDX transaction
 
 ## 6.3.0
 

--- a/lib/TransactionManager.ts
+++ b/lib/TransactionManager.ts
@@ -326,11 +326,11 @@ export default class TransactionManager {
     if (!storage) {
       return null;
     }
-    const idxResponse = storage.getStorage();
-    if (!isRawIdxResponse(idxResponse)) {
+    const storedValue = storage.getStorage();
+    if (!storedValue || !isRawIdxResponse(storedValue.rawIdxResponse)) {
       return null;
     }
-    return idxResponse;
+    return storedValue;
   }
 
   clearIdxResponse(): void {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "build/cjs/index.js",

--- a/test/spec/TransactionManager.ts
+++ b/test/spec/TransactionManager.ts
@@ -628,19 +628,23 @@ describe('TransactionManager', () => {
     beforeEach(() => {
       createInstance();
       const setStorage = jest.fn();
-      const meta = {};
+      const rawIdxResponse = RawIdxResponseFactory.build();
+      const savedResponse = {
+        rawIdxResponse,
+        requestDidSucceed: true
+      };
       Object.assign(testContext, {
         setStorage,
-        meta
+        savedResponse
       });
     });
     it('saves to idxResponse storage', () => {
-      const { storageManager, setStorage, meta, transactionManager } = testContext;
+      const { storageManager, setStorage, savedResponse, transactionManager } = testContext;
       jest.spyOn(storageManager, 'getIdxResponseStorage').mockReturnValue({
         setStorage
       });
-      transactionManager.saveIdxResponse(meta);
-      expect(setStorage).toHaveBeenCalledWith(meta);
+      transactionManager.saveIdxResponse(savedResponse);
+      expect(setStorage).toHaveBeenCalledWith(savedResponse);
     });
   });
 
@@ -651,10 +655,16 @@ describe('TransactionManager', () => {
     it('loads from idxResponse storage', () => {
       const { transactionManager, idxResponseStorage } = testContext;
       const rawIdxResponse = RawIdxResponseFactory.build();
-      idxResponseStorage.getStorage.mockReturnValue(rawIdxResponse);
+      idxResponseStorage.getStorage.mockReturnValue({
+        rawIdxResponse,
+        requestDidSucceed: true
+      });
       const res = transactionManager.loadIdxResponse();
       expect(idxResponseStorage.getStorage).toHaveBeenCalled();
-      expect(res).toEqual(rawIdxResponse);
+      expect(res).toEqual({
+        rawIdxResponse,
+        requestDidSucceed: true
+      });
     });
     it('returns null if idxResponse is not valid', () => {
       const { transactionManager, idxResponseStorage } = testContext;


### PR DESCRIPTION
Fixes a bug in error handling for IDX actions. 
"remediators" was being passed to the handler instead of "remediator". 
Tests for remediate.ts are coming in a follow-up PR 