### PR TITLE
feat: support optional params on IDX actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 6.4
 
+### Features
+
+- [#1161](https://github.com/okta/okta-auth-js/pull/1161)
+  - IDX actions accept optional/additional parameters
+  - `requestDidSucceed` is returned on `IdxTransaction`
+  - adds IDX option `shouldProceedWithEmailAuthenticator` to disable email authenticator auto-selection
+
 ### Fixes
 
 - [#1145](https://github.com/okta/okta-auth-js/pull/1145)
@@ -9,6 +16,9 @@
   - Type Fixes:
     - IdxContent: `user` property now optional
     - Input: added missing `key` property
+
+- [#1161](https://github.com/okta/okta-auth-js/pull/1161)
+  - fixes for stateToken flow
 
 ### Other
 

--- a/lib/errors/AuthApiError.ts
+++ b/lib/errors/AuthApiError.ts
@@ -12,6 +12,7 @@
 
 import CustomError from './CustomError';
 import { APIError, HttpResponse } from '../types';
+
 export default class AuthApiError extends CustomError implements APIError {
   errorSummary: string;
   errorCode?: string;

--- a/lib/errors/OAuthError.ts
+++ b/lib/errors/OAuthError.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /*!
  * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
@@ -16,12 +17,20 @@ export default class OAuthError extends CustomError {
   errorCode: string;
   errorSummary: string;
 
+  // for widget / idx-js backward compatibility
+  error: string;
+  error_description: string;
+
   constructor(errorCode: string, summary: string) {
     super(summary);
 
     this.name = 'OAuthError';
     this.errorCode = errorCode;
     this.errorSummary = summary;
+
+    // for widget / idx-js backward compatibility
+    this.error = errorCode;
+    this.error_description = summary;
   }
 }
 

--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -14,9 +14,9 @@
 
 /* eslint-disable complexity */
 import { isString, clone, isAbsoluteUrl, removeNils } from '../util';
-import AuthApiError from '../errors/AuthApiError';
 import { STATE_TOKEN_KEY_NAME, DEFAULT_CACHE_DURATION } from '../constants';
 import { OktaAuthInterface, RequestOptions, FetchOptions, RequestData } from '../types';
+import { AuthApiError, OAuthError } from '../errors';
 
 export function httpRequest(sdk: OktaAuthInterface, options: RequestOptions): Promise<any> {
   options = options || {};
@@ -107,7 +107,11 @@ export function httpRequest(sdk: OktaAuthInterface, options: RequestOptions): Pr
         resp = sdk.options.transformErrorXHR(clone(resp));
       }
 
-      err = new AuthApiError(serverErr, resp);
+      if (serverErr.error && serverErr.error_description) {
+        err = new OAuthError(serverErr.error, serverErr.error_description);
+      } else {
+        err = new AuthApiError(serverErr, resp);
+      }
 
       if (err.errorCode === 'E0000011') {
         storage.delete(STATE_TOKEN_KEY_NAME);

--- a/lib/idx/flow/RemediationFlow.ts
+++ b/lib/idx/flow/RemediationFlow.ts
@@ -11,12 +11,6 @@
  */
 
 
-import { RemediateOptions } from '../remediate';
-import { RemediationValues } from '../remediators';
-import { IdxRemediation } from '../types/idx-js';
+import { RemediatorConstructor } from '../remediators';
 
-type RemediationConstructor = {
-  new<T extends RemediationValues>(remediation: IdxRemediation, values?: T, options?: RemediateOptions): any;
-}
-
-export type RemediationFlow = Record<string, RemediationConstructor>;
+export type RemediationFlow = Record<string, RemediatorConstructor>;

--- a/lib/idx/idxState/v1/generateIdxAction.ts
+++ b/lib/idx/idxState/v1/generateIdxAction.ts
@@ -14,6 +14,7 @@
 // @ts-nocheck
 import { httpRequest } from '../../../http';
 import { OktaAuthInterface } from '../../../types';    // auth-js/types
+import { IdxActionParams } from '../../types/idx-js';
 import { divideActionParamsByMutability } from './actionParser';
 import { makeIdxState } from './makeIdxState';
 import AuthApiError from '../../../errors/AuthApiError';
@@ -25,7 +26,7 @@ const generateDirectFetch = function generateDirectFetch(authClient: OktaAuthInt
   toPersist = {}
 }) {
   const target = actionDefinition.href;
-  return async function(params) {
+  return async function(params: IdxActionParams = {}): Promise<IdxResponse> {
     const headers = {
       'Content-Type': 'application/json',
       'Accept': actionDefinition.accepts || 'application/ion+json',

--- a/lib/idx/introspect.ts
+++ b/lib/idx/introspect.ts
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 /*!
  * Copyright (c) 2021, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
@@ -16,6 +17,7 @@ import { IdxResponse, isRawIdxResponse } from './types/idx-js';
 import { getOAuthDomain } from '../oidc';
 import { IDX_API_VERSION } from '../constants';
 import { httpRequest } from '../http';
+import { isAuthApiError } from '../errors';
 
 export interface IntrospectOptions {
   withCredentials?: boolean;
@@ -60,8 +62,8 @@ export async function introspect (
         args: body
       });
     } catch (err) {
-      if (isRawIdxResponse(err)) {
-        rawIdxResponse = err;
+      if (isAuthApiError(err) && err.xhr && isRawIdxResponse(err.xhr.responseJSON)) {
+        rawIdxResponse = err.xhr.responseJSON;
         requestDidSucceed = false;
       } else {
         throw err;

--- a/lib/idx/remediate.ts
+++ b/lib/idx/remediate.ts
@@ -13,126 +13,60 @@
 
 /* eslint-disable max-statements, max-depth, complexity */
 import { AuthSdkError } from '../errors';
-import { Remediator, RemediationValues } from './remediators';
-import { NextStep, IdxMessage, FlowIdentifier } from './types';
+import { RemediationValues } from './remediators';
+import { FlowIdentifier, RemediationResponse } from './types';
 import { RemediationFlow } from './flow';
 import { 
-  IdxResponse,  
-  IdxRemediation,
-  isIdxResponse, 
+  IdxResponse,
+  IdxActionParams, 
 } from './types/idx-js';
 import {
-  canResendFn,
-  canSkipFn,
   getMessagesFromResponse,
   isTerminalResponse,
-  filterValuesForRemediation
+  filterValuesForRemediation,
+  getRemediator,
+  getNextStep,
+  handleIdxError
 } from './util';
-import { warn } from '../util';
 
-interface RemediationResponse {
-  idxResponse: IdxResponse;
-  nextStep?: NextStep;
-  messages?: IdxMessage[];
-  terminal?: boolean;
-  canceled?: boolean;
+export interface RemediateActionWithOptionalParams {
+  name: string;
+  params?: IdxActionParams;
 }
+
+export type RemediateAction = string | RemediateActionWithOptionalParams;
 export interface RemediateOptions {
   remediators?: RemediationFlow;
-  actions?: string[];
+  actions?: RemediateAction[];
   flow?: FlowIdentifier;
   step?: string;
+  shouldProceedWithEmailAuthenticator?: boolean; // will be removed in next major version
 }
 
-// Return first match idxRemediation in allowed remediators
-export function getRemediator(
-  idxRemediations: IdxRemediation[],
-  values: RemediationValues,
-  options: RemediateOptions,
-): Remediator | undefined {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const remediators = options.remediators!;
 
-  let remediator: Remediator;
-  // remediation name specified by caller - fast-track remediator lookup 
-  if (options.step) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const remediation = idxRemediations.find(({ name }) => name === options.step)!;
-    if (remediation) {
-      const T = remediation ? remediators[remediation.name] : undefined;
-      return T ? new T(remediation, values, options) : undefined;
-    } else {
-      // step was specified, but remediation was not found. This is unexpected!
-      warn(`step "${options.step}" did not match any remediations`);
-      return;
-    }
-  }
-
-  const remediatorCandidates: Remediator[] = [];
-  for (let remediation of idxRemediations) {
-    const isRemeditionInFlow = Object.keys(remediators).includes(remediation.name);
-    if (!isRemeditionInFlow) {
-      continue;
-    }
-
-    const T = remediators[remediation.name];
-    remediator = new T(remediation, values, options);
-    if (remediator.canRemediate()) {
-      // found the remediator
-      return remediator;
-    }
-    // remediator cannot handle the current values
-    // maybe return for next step
-    remediatorCandidates.push(remediator);  
-  }
-  
-  return remediatorCandidates[0];
-}
-
-function getNextStep(
-  remediator: Remediator, idxResponse: IdxResponse
-): NextStep {
-  const nextStep = remediator.getNextStep(idxResponse.context);
-  const canSkip = canSkipFn(idxResponse);
-  const canResend = canResendFn(idxResponse);
-  return {
-    ...nextStep,
-    ...(canSkip && {canSkip}),
-    ...(canResend && {canResend}),
-  };
-}
-
-function handleIdxError(e, remediator?: Remediator): RemediationResponse {
-  // Handle idx messages
-  const idxResponse = isIdxResponse(e) ? e : null;
-  if (!idxResponse) {
-    // Thrown error terminates the interaction with idx
-    throw e;
-  }
-  idxResponse.requestDidSucceed = false;
-  const terminal = isTerminalResponse(idxResponse);
-  const messages = getMessagesFromResponse(idxResponse);
-  if (terminal) {
-    return { idxResponse, terminal, messages };
-  } else {
-    const nextStep = remediator && getNextStep(remediator, idxResponse);
-    return { 
-      idxResponse,
-      messages, 
-      ...(nextStep && { nextStep }) 
-    };
-  }
-}
-
-function getActionFromValues(values, idxResponse: IdxResponse): string | undefined {
+function getActionFromValues(values: RemediationValues, idxResponse: IdxResponse): string | undefined {
   // Currently support resend actions only
   return Object.keys(idxResponse.actions).find(action => !!values.resend && action.includes('-resend'));
 }
 
-function removeActionFromValues(values) {
+function removeActionFromValues(values: RemediationValues): RemediationValues {
   // Currently support resend actions only
-  values.resend = undefined;
-  return values;
+  return {
+    ...values,
+    resend: undefined
+  };
+}
+
+function removeActionFromOptions(options: RemediateOptions, actionName: string): RemediateOptions {
+  let actions = options.actions || [];
+  actions = actions.filter(entry => {
+    if (typeof entry === 'string') {
+      return entry !== actionName;
+    }
+    return entry.name !== actionName;
+  });
+
+  return { ...options, actions };
 }
 
 // This function is called recursively until it reaches success or cannot be remediated
@@ -158,6 +92,8 @@ export async function remediate(
 
   const remediator = getRemediator(neededToProceed, values, options);
   
+  const remediator = getRemediator(neededToProceed, values, options);
+
   // Try actions in idxResponse first
   const actionFromValues = getActionFromValues(values, idxResponse);
   const actionFromOptions = options.actions || [];
@@ -167,12 +103,19 @@ export async function remediate(
   ];
   if (actions) {
     for (let action of actions) {
+      // Action can either be specified as a string, or as an object with name and optional params
+      let params: IdxActionParams = {};
+      if (typeof action !== 'string') {
+        params = action.params || {};
+        action = action.name;
+      }
       let valuesWithoutExecutedAction = removeActionFromValues(values);
-      let optionsWithoutExecutedAction = { ...options, actions: actionFromOptions.filter(entry => entry !== action) };
+      let optionsWithoutExecutedAction = removeActionFromOptions(options, action);
+
       if (typeof idxResponse.actions[action] === 'function') {
         try {
-          idxResponse = await idxResponse.actions[action]();
-          idxResponse.requestDidSucceed = true;
+          idxResponse = await idxResponse.actions[action](params);
+          idxResponse = { ...idxResponse, requestDidSucceed: true };
         } catch (e) {
           return handleIdxError(e, remediator);
         }
@@ -186,8 +129,8 @@ export async function remediate(
       const remediationAction = neededToProceed.find(({ name }) => name === action);
       if (remediationAction) {
         try {
-          idxResponse = await idxResponse.proceed(action, {});
-          idxResponse.requestDidSucceed = true;
+          idxResponse = await idxResponse.proceed(action, params);
+          idxResponse = { ...idxResponse, requestDidSucceed: true };
         }
         catch (e) {
           return handleIdxError(e, remediator);
@@ -200,10 +143,10 @@ export async function remediate(
 
   if (!remediator) {
     if (options.step) {
-      values = filterValuesForRemediation(idxResponse, values); // include only requested values
+      values = filterValuesForRemediation(idxResponse, options.step, values); // include only requested values
       try {
         idxResponse = await idxResponse.proceed(options.step, values);
-        idxResponse.requestDidSucceed = true;
+        idxResponse = { ...idxResponse, requestDidSucceed: true };
         return { idxResponse };
       } catch(e) {
         return handleIdxError(e);
@@ -218,26 +161,30 @@ export async function remediate(
     `);
   }
 
-  if (messages.length) {
-    const nextStep = getNextStep(remediator, idxResponse);
-    return { idxResponse, nextStep, messages };
-  }
+  // if (messages.length) {
+  //   const nextStep = getNextStep(remediator, idxResponse);
+  //   return { idxResponse, nextStep, messages };
+  // }
 
   // Return next step to the caller
   if (!remediator.canRemediate()) {
     const nextStep = getNextStep(remediator, idxResponse);
-    return { idxResponse, nextStep };
+    return {
+      idxResponse,
+      nextStep,
+      messages: messages.length ? messages: undefined
+    };
   }
 
   const name = remediator.getName();
   const data = remediator.getData();
   try {
     idxResponse = await idxResponse.proceed(name, data);
-    idxResponse.requestDidSucceed = true;
+    idxResponse = { ...idxResponse, requestDidSucceed: true };
     // We may want to trim the values bag for the next remediation
     // Let the remediator decide what the values should be (default to current values)
     values = remediator.getValuesAfterProceed();
-    delete options.step; // do not re-use the step
+    options = { ...options, step: undefined }; // do not re-use the step
     return remediate(idxResponse, values, options); // recursive call
   } catch (e) {
     return handleIdxError(e, remediator);

--- a/lib/idx/remediate.ts
+++ b/lib/idx/remediate.ts
@@ -91,8 +91,6 @@ export async function remediate(
   }
 
   const remediator = getRemediator(neededToProceed, values, options);
-  
-  const remediator = getRemediator(neededToProceed, values, options);
 
   // Try actions in idxResponse first
   const actionFromValues = getActionFromValues(values, idxResponse);

--- a/lib/idx/remediate.ts
+++ b/lib/idx/remediate.ts
@@ -159,11 +159,6 @@ export async function remediate(
     `);
   }
 
-  // if (messages.length) {
-  //   const nextStep = getNextStep(remediator, idxResponse);
-  //   return { idxResponse, nextStep, messages };
-  // }
-
   // Return next step to the caller
   if (!remediator.canRemediate()) {
     const nextStep = getNextStep(remediator, idxResponse);

--- a/lib/idx/remediators/AuthenticatorEnrollmentData.ts
+++ b/lib/idx/remediators/AuthenticatorEnrollmentData.ts
@@ -19,10 +19,8 @@ export type AuthenticatorEnrollmentDataValues =  AuthenticatorDataValues & {
   phoneNumber?: string;
   resend?: boolean; // resend is not a remediator value - revise when IdxResponse structure is updated
 }
-export class AuthenticatorEnrollmentData extends AuthenticatorData {
+export class AuthenticatorEnrollmentData extends AuthenticatorData<AuthenticatorEnrollmentDataValues> {
   static remediationName = 'authenticator-enrollment-data';
-
-  values!: AuthenticatorEnrollmentDataValues;
 
   mapAuthenticator() {
     const authenticatorData = this.getAuthenticatorData();

--- a/lib/idx/remediators/AuthenticatorVerificationData.ts
+++ b/lib/idx/remediators/AuthenticatorVerificationData.ts
@@ -15,26 +15,27 @@
 import { AuthSdkError } from '../../errors';
 import { AuthenticatorData, AuthenticatorDataValues } from './Base/AuthenticatorData';
 import { IdxRemediation } from '../types/idx-js';
+import { RemediateOptions } from '../remediate';
 
 export type AuthenticatorVerificationDataValues = AuthenticatorDataValues;
 
-export class AuthenticatorVerificationData extends AuthenticatorData {
+export class AuthenticatorVerificationData extends AuthenticatorData<AuthenticatorVerificationDataValues> {
   static remediationName = 'authenticator-verification-data';
 
-  values!: AuthenticatorVerificationDataValues;
-  shouldProceedWithEmailAuthenticator: boolean;
+  shouldProceedWithEmailAuthenticator: boolean; // will be removed in next major version
 
-  constructor(remediation: IdxRemediation, values: AuthenticatorDataValues = {}) {
+  constructor(remediation: IdxRemediation, values: AuthenticatorDataValues = {}, options: RemediateOptions = {}) {
     super(remediation, values);
 
-    // TODO: extend this feature to all authenticators
-    this.shouldProceedWithEmailAuthenticator = this.authenticator.methods.length === 1 
+    // will be removed in next major version
+    this.shouldProceedWithEmailAuthenticator = options.shouldProceedWithEmailAuthenticator !== false
+      && this.authenticator.methods.length === 1 
       && this.authenticator.methods[0].type === 'email';
   }
 
   canRemediate() {
-    // auto proceed if there is only one method
-    if (this.shouldProceedWithEmailAuthenticator) {
+    // auto proceed if there is only one method (will be removed in next major version)
+    if (this.shouldProceedWithEmailAuthenticator !== false) {
       return true;
     }
     return super.canRemediate();
@@ -42,7 +43,7 @@ export class AuthenticatorVerificationData extends AuthenticatorData {
 
   mapAuthenticator() {
     // auto proceed with the only methodType option
-    if (this.shouldProceedWithEmailAuthenticator) {
+    if (this.shouldProceedWithEmailAuthenticator !== false) {
       const authenticatorFromRemediation = this.getAuthenticatorFromRemediation();
       return authenticatorFromRemediation.form?.value.reduce((acc, curr) => {
         if (curr.value) {

--- a/lib/idx/remediators/Base/AuthenticatorData.ts
+++ b/lib/idx/remediators/Base/AuthenticatorData.ts
@@ -22,10 +22,10 @@ export type AuthenticatorDataValues = RemediationValues & {
 };
 
 // Base class - DO NOT expose static remediationName
-export class AuthenticatorData extends Remediator<AuthenticatorDataValues> {
+export class AuthenticatorData<T extends AuthenticatorDataValues = AuthenticatorDataValues> extends Remediator<T> {
   authenticator: IdxAuthenticator;
 
-  constructor(remediation: IdxRemediation, values: AuthenticatorDataValues = {}) {
+  constructor(remediation: IdxRemediation, values: T = {} as T) {
     super(remediation, values);
 
     // set before other data calculation
@@ -99,7 +99,7 @@ export class AuthenticatorData extends Remediator<AuthenticatorDataValues> {
     return authenticator.form!.value.find(({ name }) => name === 'methodType')?.options as IdxOption[];
   }
 
-  getValuesAfterProceed(): RemediationValues {
+  getValuesAfterProceed(): T {
     this.values = super.getValuesAfterProceed();
     // remove used authenticatorData
     const authenticatorsData = this.values.authenticatorsData!

--- a/lib/idx/remediators/Base/SelectAuthenticator.ts
+++ b/lib/idx/remediators/Base/SelectAuthenticator.ts
@@ -23,7 +23,8 @@ export type SelectAuthenticatorValues = RemediationValues & {
 };
 
 // Base class - DO NOT expose static remediationName
-export class SelectAuthenticator extends Remediator<SelectAuthenticatorValues> {
+export class SelectAuthenticator<T extends SelectAuthenticatorValues = SelectAuthenticatorValues>
+  extends Remediator<T> {
   selectedAuthenticator?: Authenticator;
   selectedOption?: any;
 
@@ -99,7 +100,7 @@ export class SelectAuthenticator extends Remediator<SelectAuthenticatorValues> {
     return { name: 'authenticator', key: 'string' };
   }
 
-  getValuesAfterProceed(): RemediationValues {
+  getValuesAfterProceed(): T {
     this.values = super.getValuesAfterProceed();
     // remove used authenticators
     const authenticators = (this.values.authenticators as Authenticator[])

--- a/lib/idx/remediators/Base/VerifyAuthenticator.ts
+++ b/lib/idx/remediators/Base/VerifyAuthenticator.ts
@@ -19,11 +19,12 @@ import { NextStep } from '../../types';
 export type VerifyAuthenticatorValues = AuthenticatorValues & RemediationValues;
 
 // Base class - DO NOT expose static remediationName
-export class VerifyAuthenticator extends Remediator<VerifyAuthenticatorValues> {
+export class VerifyAuthenticator<T extends VerifyAuthenticatorValues = VerifyAuthenticatorValues>
+  extends Remediator<T> {
 
   authenticator: Authenticator<VerifyAuthenticatorValues>;
 
-  constructor(remediation: IdxRemediation, values: VerifyAuthenticatorValues = {}) {
+  constructor(remediation: IdxRemediation, values: T = {} as T) {
     super(remediation, values);
     this.authenticator = getAuthenticator(remediation);
   }
@@ -50,9 +51,9 @@ export class VerifyAuthenticator extends Remediator<VerifyAuthenticatorValues> {
     return this.authenticator.getInputs(input);
   }
 
-  getValuesAfterProceed(): VerifyAuthenticatorValues {
+  getValuesAfterProceed(): T {
     this.values = super.getValuesAfterProceed();
     let trimmedValues = Object.keys(this.values).filter(valueKey => valueKey !== 'credentials');
-    return trimmedValues.reduce((values, valueKey) => ({...values, [valueKey]: this.values[valueKey]}), {});
+    return trimmedValues.reduce((values, valueKey) => ({...values, [valueKey]: this.values[valueKey]}), {} as T);
   }
 }

--- a/lib/idx/remediators/ChallengeAuthenticator.ts
+++ b/lib/idx/remediators/ChallengeAuthenticator.ts
@@ -14,7 +14,6 @@ import { VerifyAuthenticator, VerifyAuthenticatorValues } from './Base/VerifyAut
 
 export type ChallengeAuthenticatorValues = VerifyAuthenticatorValues;
 
-export class ChallengeAuthenticator extends VerifyAuthenticator {
+export class ChallengeAuthenticator extends VerifyAuthenticator<ChallengeAuthenticatorValues> {
   static remediationName = 'challenge-authenticator';
-  values!: ChallengeAuthenticatorValues;
 }

--- a/lib/idx/remediators/EnrollAuthenticator.ts
+++ b/lib/idx/remediators/EnrollAuthenticator.ts
@@ -15,7 +15,6 @@ import { VerifyAuthenticator, VerifyAuthenticatorValues } from './Base/VerifyAut
 
 export type EnrollAuthenticatorValues = VerifyAuthenticatorValues;
 
-export class EnrollAuthenticator extends VerifyAuthenticator {
+export class EnrollAuthenticator extends VerifyAuthenticator<EnrollAuthenticatorValues> {
   static remediationName = 'enroll-authenticator';
-  values!: EnrollAuthenticatorValues;
 }

--- a/lib/idx/remediators/ResetAuthenticator.ts
+++ b/lib/idx/remediators/ResetAuthenticator.ts
@@ -15,7 +15,6 @@ import { VerifyAuthenticator, VerifyAuthenticatorValues } from './Base/VerifyAut
 
 export type ResetAuthenticatorValues = VerifyAuthenticatorValues;
 
-export class ResetAuthenticator extends VerifyAuthenticator {
+export class ResetAuthenticator extends VerifyAuthenticator<ResetAuthenticatorValues> {
   static remediationName = 'reset-authenticator';
-  values!: ResetAuthenticatorValues;
 }

--- a/lib/idx/remediators/SelectAuthenticatorAuthenticate.ts
+++ b/lib/idx/remediators/SelectAuthenticatorAuthenticate.ts
@@ -20,9 +20,8 @@ export type SelectAuthenticatorAuthenticateValues = SelectAuthenticatorValues & 
   password?: string;
 };
 
-export class SelectAuthenticatorAuthenticate extends SelectAuthenticator {
+export class SelectAuthenticatorAuthenticate extends SelectAuthenticator<SelectAuthenticatorAuthenticateValues> {
   static remediationName = 'select-authenticator-authenticate';
-  values!: SelectAuthenticatorAuthenticateValues;
 
   constructor(remediation: IdxRemediation, values: SelectAuthenticatorValues = {}, options: RemediateOptions = {}) {
     super(remediation, values, options);

--- a/lib/idx/remediators/SelectAuthenticatorEnroll.ts
+++ b/lib/idx/remediators/SelectAuthenticatorEnroll.ts
@@ -15,7 +15,6 @@ import { SelectAuthenticator, SelectAuthenticatorValues } from './Base/SelectAut
 
 export type SelectAuthenticatorEnrollValues = SelectAuthenticatorValues;
 
-export class SelectAuthenticatorEnroll extends SelectAuthenticator {
+export class SelectAuthenticatorEnroll extends SelectAuthenticator<SelectAuthenticatorEnrollValues> {
   static remediationName = 'select-authenticator-enroll';
-  values!: SelectAuthenticatorEnrollValues;
 }

--- a/lib/idx/remediators/SelectAuthenticatorUnlockAccount.ts
+++ b/lib/idx/remediators/SelectAuthenticatorUnlockAccount.ts
@@ -21,9 +21,8 @@ export type SelectAuthenticatorUnlockAccountValues = SelectAuthenticatorValues &
   methodType?: string;
 };
 
-export class SelectAuthenticatorUnlockAccount extends SelectAuthenticator {
+export class SelectAuthenticatorUnlockAccount extends SelectAuthenticator<SelectAuthenticatorUnlockAccountValues> {
   static remediationName = 'select-authenticator-unlock-account';
-  values!: SelectAuthenticatorUnlockAccountValues;
   authenticator?: Authenticator;
 
   map = {

--- a/lib/idx/types/idx-js.ts
+++ b/lib/idx/types/idx-js.ts
@@ -201,9 +201,12 @@ export function isRawIdxResponse(obj: any): obj is RawIdxResponse {
   return obj && obj.version;
 }
 
+export interface IdxActionParams {
+  [key: string]: string | boolean | number;
+}
 
 export interface IdxActions {
-  [key: string]: () => Promise<IdxResponse>;
+  [key: string]: (params?: IdxActionParams) => Promise<IdxResponse>;
 }
 
 // Object returned from auth-js

--- a/lib/idx/types/index.ts
+++ b/lib/idx/types/index.ts
@@ -116,6 +116,7 @@ export interface IdxTransaction {
   meta?: IdxTransactionMeta;
   enabledFeatures?: IdxFeature[];
   availableSteps?: NextStep[];
+  requestDidSucceed?: boolean;
 
   // from idx-js, used by signin widget
   proceed: (remediationName: string, params: unknown) => Promise<IdxResponse>;
@@ -147,4 +148,12 @@ export type Authenticator = {
 
 export function isAuthenticator(obj: any): obj is Authenticator {
   return obj && (obj.key || obj.id);
+}
+
+export interface RemediationResponse {
+  idxResponse: IdxResponse;
+  nextStep?: NextStep;
+  messages?: IdxMessage[];
+  terminal?: boolean;
+  canceled?: boolean;
 }

--- a/lib/idx/util.ts
+++ b/lib/idx/util.ts
@@ -1,7 +1,8 @@
+import { warn } from '../util';
 import * as remediators from './remediators';
-import { RemediationValues } from './remediators';
-import { IdxFeature, NextStep } from './types';
-import { IdxMessage, IdxRemediationValue, IdxResponse } from './types/idx-js';
+import { RemediationValues, Remediator, RemediatorConstructor } from './remediators';
+import { IdxFeature, NextStep, RemediateOptions, RemediationResponse } from './types';
+import { IdxMessage, IdxRemediation, IdxRemediationValue, IdxResponse, isIdxResponse } from './types/idx-js';
 
 export function isTerminalResponse(idxResponse: IdxResponse) {
   const { neededToProceed, interactionCode } = idxResponse;
@@ -102,20 +103,21 @@ export function getEnabledFeatures(idxResponse: IdxResponse): IdxFeature[] {
 }
 
 export function getAvailableSteps(idxResponse: IdxResponse): NextStep[] {
-  const res = [];
+  const res: NextStep[] = [];
 
-  const remediatorMap = Object.values(remediators).reduce((map, remediatorClass) => {
-    // Only add concrete subclasses to the map
-    if (remediatorClass.remediationName) {
-      map[remediatorClass.remediationName] = remediatorClass;
-    }
-    return map;
-  }, {});
+  const remediatorMap: Record<string, RemediatorConstructor> = Object.values(remediators)
+    .reduce((map, remediatorClass) => {
+      // Only add concrete subclasses to the map
+      if (remediatorClass.remediationName) {
+        map[remediatorClass.remediationName] = remediatorClass;
+      }
+      return map;
+    }, {});
 
   for (let remediation of idxResponse.neededToProceed) {
     const T = remediatorMap[remediation.name];
     if (T) {
-      const remediator = new T(remediation);
+      const remediator: Remediator = new T(remediation);
       res.push (remediator.getNextStep(idxResponse.context) as never);
     }
   }
@@ -123,12 +125,113 @@ export function getAvailableSteps(idxResponse: IdxResponse): NextStep[] {
   return res;
 }
 
-export function filterValuesForRemediation(idxResponse: IdxResponse, values: RemediationValues): RemediationValues {
+export function filterValuesForRemediation(
+  idxResponse: IdxResponse,
+  remediationName: string,
+  values: RemediationValues
+): RemediationValues {
+  const remediations = idxResponse.neededToProceed || [];
+  const remediation = remediations.find(r => r.name === remediationName);
+  if (!remediation) {
+    // step was specified, but remediation was not found. This is unexpected!
+    warn(`filterValuesForRemediation: "${remediationName}" did not match any remediations`);
+    return values;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const valuesForRemediation = idxResponse.neededToProceed![0]!.value!.reduce((res, entry) => {
-    const { name } = entry;
-    res[name] = values[name];
+  const valuesForRemediation = remediation.value!.reduce((res, entry) => {
+    const { name, value } = entry;
+    if (name === 'stateHandle') {
+      res[name] = value; // use the stateHandle value in the remediation
+    } else {
+      res[name] = values[name]; // use the value provided by the caller
+    }
     return res;
   }, {});
   return valuesForRemediation;
+}
+
+// Return first match idxRemediation in allowed remediators
+// eslint-disable-next-line complexity
+export function getRemediator(
+  idxRemediations: IdxRemediation[],
+  values: RemediationValues,
+  options: RemediateOptions,
+): Remediator | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const remediators = options.remediators!;
+
+  let remediator: Remediator;
+  // remediation name specified by caller - fast-track remediator lookup 
+  if (options.step) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const remediation = idxRemediations.find(({ name }) => name === options.step)!;
+    if (remediation) {
+      const T = remediation ? remediators[remediation.name] : undefined;
+      return T ? new T(remediation, values, options) : undefined;
+    } else {
+      // step was specified, but remediation was not found. This is unexpected!
+      warn(`step "${options.step}" did not match any remediations`);
+      return;
+    }
+  }
+
+  const remediatorCandidates: Remediator[] = [];
+  for (let remediation of idxRemediations) {
+    const isRemeditionInFlow = Object.keys(remediators as object).includes(remediation.name);
+    if (!isRemeditionInFlow) {
+      continue;
+    }
+
+    const T = remediators[remediation.name];
+    remediator = new T(remediation, values, options);
+    if (remediator.canRemediate()) {
+      // found the remediator
+      return remediator;
+    }
+    // remediator cannot handle the current values
+    // maybe return for next step
+    remediatorCandidates.push(remediator);  
+  }
+  
+  return remediatorCandidates[0];
+}
+
+
+export function getNextStep(
+  remediator: Remediator, idxResponse: IdxResponse
+): NextStep {
+  const nextStep = remediator.getNextStep(idxResponse.context);
+  const canSkip = canSkipFn(idxResponse);
+  const canResend = canResendFn(idxResponse);
+  return {
+    ...nextStep,
+    ...(canSkip && {canSkip}),
+    ...(canResend && {canResend}),
+  };
+}
+
+export function handleIdxError(e, remediator?): RemediationResponse {
+  // Handle idx messages
+  let idxResponse = isIdxResponse(e) ? e : null;
+  if (!idxResponse) {
+    // Thrown error terminates the interaction with idx
+    throw e;
+  }
+  idxResponse = {
+    ...idxResponse,
+    requestDidSucceed: false
+  };
+  const terminal = isTerminalResponse(idxResponse);
+  const messages = getMessagesFromResponse(idxResponse);
+  if (terminal) {
+    return { idxResponse, terminal, messages };
+  } else {
+    const nextStep = remediator && getNextStep(remediator, idxResponse);
+    return { 
+      idxResponse,
+      messages, 
+      ...(nextStep && { nextStep }) 
+    };
+  }
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@babel/cli": "^7.8.0",
     "@babel/core": "^7.8.0",
     "@babel/plugin-proposal-class-properties": "^7.10.1",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
     "@babel/plugin-transform-modules-commonjs": "^7.10.1",
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/plugin-transform-typescript": "^7.10.5",

--- a/test/e2e/pageobjects/TestServer.js
+++ b/test/e2e/pageobjects/TestServer.js
@@ -45,6 +45,10 @@ class TestServer {
   }
 
   async assertLoginSuccess() {
+    await browser.waitUntil(async () => {
+      const txt = await this.status.then(el => el.getText());
+      return !!txt;
+    });
     await this.status.then(el => el.getText()).then(txt => {
       assert(txt.trim() === 'SUCCESS');
     });
@@ -57,6 +61,10 @@ class TestServer {
   }
 
   async assertLoginFailure() {
+    await browser.waitUntil(async () => {
+      const txt = await this.error.then(el => el.getText());
+      return !!txt;
+    });
     await this.status.then(el => el.getText()).then(txt => {
       assert(txt.trim() === '');
     });

--- a/test/spec/idx/introspect.ts
+++ b/test/spec/idx/introspect.ts
@@ -12,6 +12,8 @@
 
 
 import { RawIdxResponseFactory } from '@okta/test.support/idx';
+import { AuthApiError } from '../../../lib/errors';
+import { APIError, HttpResponse } from '../../../lib/types';
 import { introspect } from '../../../lib/idx/introspect';
 
 jest.mock('../../../lib/http', () => {
@@ -99,7 +101,7 @@ describe('idx/introspect', () => {
   it('on IDX error, calls makeIdxState to return a wrapped idxResponse', async () => {
     const { authClient, introspectOptions } = testContext;
     const rawIdxResponse = RawIdxResponseFactory.build();
-    jest.spyOn(mocked.http, 'httpRequest').mockRejectedValueOnce(rawIdxResponse);
+    jest.spyOn(mocked.http, 'httpRequest').mockRejectedValueOnce(new AuthApiError({} as APIError, { responseJSON: rawIdxResponse } as unknown as HttpResponse));
     jest.spyOn(mocked.idxState, 'makeIdxState');
     authClient.transactionManager.loadIdxResponse = jest.fn().mockReturnValue(null);
     const res = await introspect(authClient, introspectOptions);

--- a/test/spec/idx/remediate.ts
+++ b/test/spec/idx/remediate.ts
@@ -1,0 +1,553 @@
+import { remediate } from '../../../lib/idx/remediate';
+import { IdxResponse } from '../../../lib/idx/types';
+
+const util = require('../../../lib/idx/util');
+
+jest.mock('../../../lib/idx/util', () => {
+  const actual = jest.requireActual('../../../lib/idx/util');
+  return { ...actual };
+});
+
+describe('idx/remediate', () => {
+  let testContext;
+  beforeEach(() => {
+    const idxResponse = {
+      proceed: jest.fn(),
+      neededToProceed: [],
+      actions: {},
+      rawIdxState: {}
+    } as unknown as IdxResponse;
+    const errorResponse = { fakeErrorResponse: true };
+    jest.spyOn(util, 'handleIdxError').mockReturnValue(errorResponse);
+    const remediator = {
+      canRemediate: jest.fn(),
+      getNextStep: jest.fn(),
+      getName: jest.fn(),
+      getData: jest.fn(),
+      getValuesAfterProceed: jest.fn()
+    };
+    jest.spyOn(util, 'getRemediator').mockReturnValue(remediator);
+    testContext = {
+      idxResponse,
+      errorResponse,
+      remediator
+    };
+  });
+
+  it('returns idxResponse immediately if idxResponse has an interaction code', async () => {
+    const idxResponse = {
+      interactionCode: 'fake'
+    } as unknown as IdxResponse;
+    const res = await remediate(idxResponse, {}, {});
+    expect(res).toEqual({ idxResponse });
+  });
+
+  it('returns idxResponse, messages, terminal if the idxResponse is terminal', async () => {
+    const messages = ['fake'];
+    jest.spyOn(util, 'isTerminalResponse').mockReturnValue(true);
+    jest.spyOn(util, 'getMessagesFromResponse').mockReturnValue(messages);
+    const idxResponse = { fake: true } as unknown as IdxResponse;
+    const res = await remediate(idxResponse, {}, {});
+    expect(res).toEqual({
+      idxResponse,
+      terminal: true,
+      messages
+    });
+    expect(util.isTerminalResponse).toHaveBeenCalledWith(idxResponse);
+    expect(util.getMessagesFromResponse).toHaveBeenCalledWith(idxResponse);
+  });
+
+  describe('actions', () => {
+
+    describe('values.resend = true', () => {
+
+      describe('action exists in idx response with -resend suffix', () => {
+
+        it('executes the resend action, and calls remediate recursively, removing resend from values', async () => {
+          let { idxResponse } = testContext;
+          const responseFromAction = {
+            ...idxResponse,
+            neededToProceed: [{
+              name: 'another-remediation'
+            }],
+          };
+          idxResponse = {
+            ...idxResponse,
+            neededToProceed: [{
+              name: 'some-remediation'
+            }],
+            actions: {
+              'something-resend': jest.fn().mockReturnValue(responseFromAction)
+            },
+          } as unknown as IdxResponse;
+          const res = await remediate(idxResponse, { resend: true }, {});
+          expect(res).toEqual({
+            idxResponse: {
+              ...responseFromAction,
+              requestDidSucceed: true
+            },
+            nextStep: {}
+          });
+          expect(util.getRemediator).toHaveBeenCalledTimes(2);
+          expect(util.getRemediator).toHaveBeenNthCalledWith(1, idxResponse.neededToProceed, { resend: true }, {});
+          expect(util.getRemediator).toHaveBeenNthCalledWith(2, responseFromAction.neededToProceed, {}, { actions: []});
+        });
+
+        it('will handle exceptions', async () => {
+          const { remediator, errorResponse } = testContext;
+          const error = new Error('my test error');
+          const idxResponse = {
+            neededToProceed: [{
+              name: 'some-remediation'
+            }],
+            actions: {
+              'something-resend': jest.fn().mockRejectedValue(error)
+            },
+            rawIdxState: {}
+          } as unknown as IdxResponse;
+          const res = await remediate(idxResponse, { resend: true }, {});
+          expect(res).toBe(errorResponse);
+          expect(util.handleIdxError).toHaveBeenCalledWith(error, remediator);
+        });
+      });
+
+    });
+
+    describe('action passed as string', () => {
+
+      describe('action exists matching name', () => {
+        it('executes the action specified by name, and calls remediate recursively', async () => {
+          let { idxResponse } = testContext;
+          const responseFromAction = {
+            ...idxResponse,
+            neededToProceed: [{
+              name: 'another-remediation'
+            }],
+          };
+          idxResponse = {
+            ...idxResponse,
+            neededToProceed: [{
+              name: 'some-remediation'
+            }],
+            actions: {
+              'some-action': jest.fn().mockReturnValue(responseFromAction)
+            },
+          } as unknown as IdxResponse;
+          const res = await remediate(idxResponse, {}, { actions: ['some-action'] });
+          expect(res).toEqual({
+            idxResponse: {
+              ...responseFromAction,
+              requestDidSucceed: true
+            },
+            nextStep: {}
+          });
+          expect(util.getRemediator).toHaveBeenCalledTimes(2);
+          expect(util.getRemediator).toHaveBeenNthCalledWith(1, idxResponse.neededToProceed, {}, { actions: ['some-action'] });
+          expect(util.getRemediator).toHaveBeenNthCalledWith(2, responseFromAction.neededToProceed, {}, { actions: [] });
+        });
+        it('will handle exceptions', async () => {
+          const { remediator, errorResponse } = testContext;
+          const error = new Error('my test error');
+          const idxResponse = {
+            neededToProceed: [{
+              name: 'some-remediation'
+            }],
+            actions: {
+              'some-action': jest.fn().mockRejectedValue(error)
+            },
+            rawIdxState: {}
+          } as unknown as IdxResponse;
+          const res = await remediate(idxResponse, { resend: true }, { actions: ['some-action']});
+          expect(res).toEqual(errorResponse);
+          expect(util.handleIdxError).toHaveBeenCalledWith(error, remediator);
+        });
+      });
+
+      describe('no action matches the name', () => {
+        it('proceeds with a remediation with a matching name', async () => {
+          let { idxResponse } = testContext;
+          const responseFromRemediation = {
+            ...idxResponse,
+            neededToProceed: [{
+              name: 'another-remediation'
+            }],
+          };
+          idxResponse = {
+            ...idxResponse,
+            proceed: jest.fn().mockResolvedValue(responseFromRemediation),
+            neededToProceed: [{
+              name: 'some-remediation'
+            }],
+          } as unknown as IdxResponse;
+          const res = await remediate(idxResponse, {}, { actions: ['some-remediation'] });
+          expect(res).toEqual({
+            idxResponse: {
+              ...responseFromRemediation,
+              requestDidSucceed: true
+            },
+            nextStep: {}
+          });
+          expect(util.getRemediator).toHaveBeenCalledTimes(2);
+          expect(util.getRemediator).toHaveBeenNthCalledWith(1, idxResponse.neededToProceed, { }, { actions: ['some-remediation'] });
+          expect(util.getRemediator).toHaveBeenNthCalledWith(2, responseFromRemediation.neededToProceed, {}, { actions: [] });
+        });
+        it('will handle exceptions', async () => {
+          let { idxResponse } = testContext;
+          const { remediator, errorResponse } = testContext;
+          const error = new Error('my test error');
+          idxResponse = {
+            ...idxResponse,
+            proceed: jest.fn().mockRejectedValue(error),
+            neededToProceed: [{
+              name: 'some-remediation'
+            }],
+          } as unknown as IdxResponse;
+          const res = await remediate(idxResponse, {}, { actions: ['some-remediation']});
+          expect(res).toBe(errorResponse);
+          expect(util.handleIdxError).toHaveBeenCalledWith(error, remediator);
+        });
+      });
+
+      describe('no action or remedation matches the name provided', () => {
+        beforeEach(() => {
+          jest.spyOn(util, 'getRemediator').mockReturnValue(undefined);
+          jest.spyOn(util, 'isTerminalResponse').mockReturnValue(false);
+        });
+        it('by default, it will throw an error', async () => {
+          const { idxResponse } = testContext;
+          let didThrow = false;
+          try {
+            await remediate(idxResponse, {}, { actions: ['unknown-action'] });
+          } catch (err: any) {
+            didThrow = true;
+            expect(err.name).toEqual('AuthSdkError');
+            expect(err.errorSummary).toContain('No remediation can match current flow, check policy settings in your org');
+          }
+          expect(didThrow).toBe(true);
+        });
+
+        it('if flow is default, it will return the idxResponse', async () => {
+          const { idxResponse } = testContext;
+          const res = await remediate(idxResponse, {}, { flow: 'default', actions: ['unknown-action'] });
+          expect(res).toEqual({ idxResponse });
+        });
+      });
+
+    });
+
+    describe('action passed as object', () => {
+
+      describe('action exists matching name', () => {
+        it('executes the action specified by name, passing the provided params, and calls remediate recursively', async () => {
+          let { idxResponse } = testContext;
+          const responseFromAction = {
+            ...idxResponse,
+            neededToProceed: [{
+              name: 'another-remediation'
+            }],
+          };
+          const actionFn = jest.fn().mockReturnValue(responseFromAction);
+          idxResponse = {
+            ...idxResponse,
+            neededToProceed: [{
+              name: 'some-remediation'
+            }],
+            actions: {
+              'some-action': actionFn
+            },
+          } as unknown as IdxResponse;
+          const action = {
+            name: 'some-action',
+            params: { foo: 'bar' }
+          };
+          const res = await remediate(idxResponse, {}, { actions: [action] });
+          expect(actionFn).toHaveBeenCalledWith({ foo: 'bar' });
+          expect(res).toEqual({
+            idxResponse: {
+              ...responseFromAction,
+              requestDidSucceed: true
+            },
+            nextStep: {}
+          });
+          expect(util.getRemediator).toHaveBeenCalledTimes(2);
+          expect(util.getRemediator).toHaveBeenNthCalledWith(1, idxResponse.neededToProceed, {}, { actions: [action] });
+          expect(util.getRemediator).toHaveBeenNthCalledWith(2, responseFromAction.neededToProceed, {}, { actions: [] });
+        });
+        it('will handle exceptions', async () => {
+          let { idxResponse } = testContext;
+          const { remediator, errorResponse } = testContext;
+          const error = new Error('my test error');
+          const actionFn = jest.fn().mockRejectedValue(error);
+          idxResponse = {
+            ...idxResponse,
+            neededToProceed: [{
+              name: 'some-remediation'
+            }],
+            actions: {
+              'some-action': actionFn
+            },
+          } as unknown as IdxResponse;
+          const action = {
+            name: 'some-action',
+            params: { foo: 'bar' }
+          };
+          const res = await remediate(idxResponse, {}, { actions: [action]});
+          expect(res).toBe(errorResponse);
+          expect(util.handleIdxError).toHaveBeenCalledWith(error, remediator);
+          expect(actionFn).toHaveBeenCalledWith({ foo: 'bar' });
+        });
+      });
+
+      describe('no action matches the name', () => {
+        it('proceeds with a remediation with a matching name, passing the provided params', async () => {
+          let { idxResponse } = testContext;
+          const responseFromRemediation = {
+            ...idxResponse,
+            neededToProceed: [{
+              name: 'another-remediation'
+            }],
+          };
+          idxResponse = {
+            ...idxResponse,
+            proceed: jest.fn().mockResolvedValue(responseFromRemediation),
+            neededToProceed: [{
+              name: 'some-remediation'
+            }],
+          } as unknown as IdxResponse;
+          const action = {
+            name: 'some-remediation'
+          };
+          const res = await remediate(idxResponse, {}, { actions: [action] });
+          expect(res).toEqual({
+            idxResponse: {
+              ...responseFromRemediation,
+              requestDidSucceed: true
+            },
+            nextStep: {}
+          });
+          expect(util.getRemediator).toHaveBeenCalledTimes(2);
+          expect(util.getRemediator).toHaveBeenNthCalledWith(1, idxResponse.neededToProceed, { }, { actions: [action] });
+          expect(util.getRemediator).toHaveBeenNthCalledWith(2, responseFromRemediation.neededToProceed, {}, { actions: [] });
+        });
+        it('will handle exceptions', async () => {
+          let { idxResponse } = testContext;
+          const { remediator, errorResponse } = testContext;
+          const error = new Error('my test error');
+          idxResponse = {
+            ...idxResponse,
+            proceed: jest.fn().mockRejectedValue(error),
+            neededToProceed: [{
+              name: 'some-remediation'
+            }],
+          } as unknown as IdxResponse;
+          const action = {
+            name: 'some-remediation'
+          };
+          const res = await remediate(idxResponse, {}, { actions: [action]});
+          expect(res).toBe(errorResponse);
+          expect(util.handleIdxError).toHaveBeenCalledWith(error, remediator);
+        });
+      });
+
+      describe('no action or remedation matches the action name provided', () => {
+        it('it will throw an error', async () => {
+          const { idxResponse } = testContext;
+          let didThrow = false;
+          jest.spyOn(util, 'getRemediator').mockReturnValue(undefined);
+          jest.spyOn(util, 'isTerminalResponse').mockReturnValue(false);
+          const action = {
+            name: 'unknown-action'
+          };
+          try {
+            await remediate(idxResponse, {}, { actions: [action] });
+          } catch (err: any) {
+            didThrow = true;
+            expect(err.name).toEqual('AuthSdkError');
+            expect(err.errorSummary).toContain('No remediation can match current flow, check policy settings in your org');
+          }
+          expect(didThrow).toBe(true);
+        });
+      });
+    });
+
+  });
+
+  describe('no remediator matches', () => {
+    beforeEach(() => {
+      jest.spyOn(util, 'getRemediator').mockReturnValue(undefined);
+      jest.spyOn(util, 'isTerminalResponse').mockReturnValue(false);
+    });
+    it('by default, it throws an exception', async () => {
+      const { idxResponse } = testContext;
+      let didThrow = false;
+      try {
+        await remediate(idxResponse, {}, { actions: ['unknown-action'] });
+      } catch (err: any) {
+        didThrow = true;
+        expect(err.name).toEqual('AuthSdkError');
+        expect(err.errorSummary).toContain('No remediation can match current flow, check policy settings in your org');
+      }
+      expect(didThrow).toBe(true);
+    });
+    describe('options.step was provided', () => {
+      it('will execute the named remediation provided by options.step', async () => {
+        let { idxResponse } = testContext;
+        const responseFromRemediation = {
+          ...idxResponse,
+          neededToProceed: [{
+            name: 'another-remediation'
+          }],
+        };
+        idxResponse = {
+          ...idxResponse,
+          proceed: jest.fn().mockResolvedValue(responseFromRemediation),
+          neededToProceed: [{
+            name: 'some-remediation',
+            value: [{
+              name: 'foo'
+            }]
+          }],
+        } as unknown as IdxResponse;
+        const res = await remediate(idxResponse, {}, { step: 'some-remediation' });
+        expect(res).toEqual({
+          idxResponse: {
+            ...responseFromRemediation,
+            requestDidSucceed: true
+          },
+        });
+        expect(util.getRemediator).toHaveBeenCalledTimes(1);
+        expect(util.getRemediator).toHaveBeenNthCalledWith(1, idxResponse.neededToProceed, { }, { step: 'some-remediation' });
+        expect(idxResponse.proceed).toHaveBeenCalledWith('some-remediation', {});
+      });
+      it('will handle exceptions', async () => {
+        let { idxResponse } = testContext;
+          const { errorResponse } = testContext;
+          const error = new Error('my test error');
+          idxResponse = {
+            ...idxResponse,
+            proceed: jest.fn().mockRejectedValue(error),
+            neededToProceed: [{
+              name: 'some-remediation',
+              value: [{
+                name: 'foo'
+              }]
+            }],
+          } as unknown as IdxResponse;
+          const res = await remediate(idxResponse, {}, { step: 'some-remediation' });
+          expect(res).toBe(errorResponse);
+          expect(util.handleIdxError).toHaveBeenCalledWith(error);
+          expect(idxResponse.proceed).toHaveBeenCalledWith('some-remediation', {});
+      });
+    });
+    describe('flow is "default"', () => {
+      it('returns the idxResponse', async () => {
+        const { idxResponse } = testContext;
+        const res = await remediate(idxResponse, {}, { flow: 'default' });
+        expect(res).toEqual({ idxResponse });
+      });
+    });
+  });
+
+  describe('with matching remediator', () => {
+    beforeEach(() => {
+      let { idxResponse } = testContext;
+      idxResponse = {
+        ...idxResponse,
+        neededToProceed: [{
+          name: 'some-remediation'
+        }]
+      };
+      testContext = {
+        ...testContext,
+        idxResponse
+      };
+    });
+    // This behavior is being removed
+    // xit('if there are messages on the remediation, it returns early, without evaluation by the Remediator', async () => {
+    //   const { idxResponse, remediator } = testContext;
+    //   const messages = ['fake'];
+    //   jest.spyOn(util, 'getMessagesFromResponse').mockReturnValue(messages);
+    //   const res = await remediate(idxResponse, {}, {});
+    //   expect(res).toEqual({
+    //     idxResponse,
+    //     messages,
+    //     nextStep: {}
+    //   });
+    //   expect(util.getMessagesFromResponse).toHaveBeenCalledWith(idxResponse);
+    //   expect(remediator.canRemediate).not.toHaveBeenCalled();
+    // });
+    it('if the Remediator cannot remediate, it returns early with nextStep information', async () => {
+      const { idxResponse, remediator } = testContext;
+      remediator.canRemediate.mockReturnValue(false);
+      const res = await remediate(idxResponse, {}, {});
+      expect(res).toEqual({
+        idxResponse,
+        nextStep: {}
+      });
+      expect(remediator.canRemediate).toHaveBeenCalled();
+    });
+    describe('canRemediate', () => {
+      beforeEach(() => {
+        let { remediator } = testContext;
+        jest.spyOn(util, 'isTerminalResponse');
+        const name = 'fubar';
+        const data = { foo: 'bar' };
+        const valuesAfterProceed = { zomething: 'zifferent' };
+        remediator.canRemediate.mockReturnValueOnce(true);
+        remediator.getName.mockReturnValue(name);
+        remediator.getData.mockReturnValue(data);
+        remediator.getValuesAfterProceed.mockReturnValue(valuesAfterProceed);
+        testContext = {
+          ...testContext,
+          name,
+          data,
+          valuesAfterProceed
+        };
+      });
+      it('calls proceed with data from the Remediator, then calls remediate recursively using values from the Remediator', async () => {
+        let { idxResponse, name, data, valuesAfterProceed } = testContext;
+        const responseFromProceed = {
+          ...idxResponse,
+          rawIdxState: {
+            messages: {
+              value: ['hello']
+            }
+          }
+        };
+        idxResponse.proceed.mockResolvedValue(responseFromProceed);
+        const res = await remediate(idxResponse, {}, {});
+        expect(res).toEqual({
+          idxResponse: {
+            ...responseFromProceed,
+            requestDidSucceed: true
+          },
+          messages: ['hello'],
+          nextStep: {}
+        });
+        expect(idxResponse.proceed).toHaveBeenCalledWith(name, data);
+        expect(util.getRemediator).toHaveBeenCalledTimes(2);
+        expect(util.getRemediator).toHaveBeenNthCalledWith(1, idxResponse.neededToProceed, {}, {});
+        expect(util.getRemediator).toHaveBeenNthCalledWith(2, responseFromProceed.neededToProceed, valuesAfterProceed, {});
+
+      });
+
+      it('handles thrown exceptions', async () => {
+        let { idxResponse, remediator, errorResponse } = testContext;
+        jest.spyOn(util, 'isTerminalResponse');
+        const name = 'fubar';
+        const data = { foo: 'bar' };
+        const valuesAfterProceed = { zomething: 'zifferent' };
+        remediator.canRemediate.mockReturnValue(true);
+        remediator.getName.mockReturnValue(name);
+        remediator.getData.mockReturnValue(data);
+        remediator.getValuesAfterProceed.mockReturnValue(valuesAfterProceed);
+        const errorFromProceed = new Error('test error');
+        idxResponse.proceed.mockRejectedValue(errorFromProceed);
+        const res = await remediate(idxResponse, {}, {});
+        expect(res).toEqual(errorResponse);
+        expect(idxResponse.proceed).toHaveBeenCalledWith(name, data);
+        expect(util.isTerminalResponse).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/test/spec/idx/remediators/Remediator.ts
+++ b/test/spec/idx/remediators/Remediator.ts
@@ -68,7 +68,7 @@ describe('remediators/Base/Remediator', () => {
     it('adds authenticator (string) to the list of authenticators', () => {
       const remediation = IdentifyRemediationFactory.build();
       const authenticator = 'okta_password';
-      const r = new Remediator(remediation, { authenticator });
+      const r = new Remediator(remediation, { authenticator } as RemediationValues);
       expect(r.values.authenticators).toEqual([{
         key: 'okta_password'
       }]);
@@ -79,7 +79,7 @@ describe('remediators/Base/Remediator', () => {
       const authenticator = {
         key: 'okta_password'
       };
-      const r = new Remediator(remediation, { authenticator });
+      const r = new Remediator(remediation, { authenticator } as RemediationValues);
       expect(r.values.authenticators).toEqual([{
         key: 'okta_password'
       }]);

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -16,7 +16,15 @@ var babelOptions = {
 };
 
 // Keep source files untransformed for local development
-if (process.env.NODE_ENV !== 'development') {
+if (process.env.NODE_ENV === 'development') {
+  // In local development, we would prefer not to include any babel transforms as they make debugging more difficult
+  // However, there is an issue with testcafe which requires the optional chaining transform for SIW compatibility
+  // https://github.com/DevExpress/testcafe-hammerhead/issues/2714
+  babelOptions.plugins = babelOptions.plugins.concat([
+    '@babel/plugin-proposal-optional-chaining',
+    '@babel/plugin-proposal-nullish-coalescing-operator'
+  ]);
+} else {
   babelOptions.presets.unshift('@babel/preset-env'); // must run after preset-typescript
   babelOptions.plugins = babelOptions.plugins.concat([
     '@babel/plugin-proposal-class-properties',


### PR DESCRIPTION
Adds necessary features for SIW compatibility:

- IDX actions may contain optional parameters not specified in the server response (for logging)
- preserve transaction meta (if it exists) when running using a stateToken
- expose `requestDidSucceed` on the IDXTransaction (not just lower level IdxResponse)
- Add `error` and `error_description` to OAuthError and add handling to request.ts to use OAuthError if server error has these two properties