### PR TITLE
fix: cjs dynamic import transpiling issue - OKTA-488924

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.4.2
+
+### Fixes
+
+- [#1180](https://github.com/okta/okta-auth-js/pull/1180) Fixes commonjs bundle `dynamic import` transpiling issue
+
 ## 6.4.1
 
 ### Fixes

--- a/babel.cjs.js
+++ b/babel.cjs.js
@@ -8,7 +8,7 @@ module.exports = {
       'targets': {
         'node': 11
       },
-      'modules': false
+      'modules': 'commonjs'
     }
   ]],
   'plugins': [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "build/cjs/index.js",


### PR DESCRIPTION
Fixes babel commonjs config, now it transpiles dynamic import to deferred require for cjs bundle.
```
return await _promise.default.resolve().then(() => _interopRequireWildcard(require('crypto')));
```

Resolves: #1176