### PR TITLE
fix: security question verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.4.3
+
+### Fixes
+
+- [#1182](https://github.com/okta/okta-auth-js/pull/1182) Fixes security question verification to accept `credentials.answer`
+
 ## 6.4.2
 
 ### Fixes

--- a/lib/idx/authenticator/SecurityQuestionEnrollment.ts
+++ b/lib/idx/authenticator/SecurityQuestionEnrollment.ts
@@ -19,7 +19,7 @@ export class SecurityQuestionEnrollment extends Authenticator<SecurityQuestionEn
 
   mapCredentials(values: SecurityQuestionEnrollValues): Credentials | undefined {
     const { questionKey, question, answer } = values;
-    if (!questionKey && !question && !answer) {
+    if (!answer || (!questionKey && !question)) {
       return;
     }
     return {

--- a/lib/idx/authenticator/SecurityQuestionVerification.ts
+++ b/lib/idx/authenticator/SecurityQuestionVerification.ts
@@ -3,11 +3,17 @@ import { Authenticator, Credentials } from './Authenticator';
 
 export interface SecurityQuestionVerificationValues {
   answer?: string;
+  credentials?: Credentials;
 }
 
 export class SecurityQuestionVerification extends Authenticator<SecurityQuestionVerificationValues> {
   canVerify(values: SecurityQuestionVerificationValues) {
-    return !!values.answer;
+    const { credentials } = values;
+    if (credentials && credentials.answer) {
+      return true;
+    }
+    const { answer } = values;
+    return !!answer;
   }
 
   mapCredentials(values: SecurityQuestionVerificationValues): Credentials | undefined {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "6.4.2",
+  "version": "6.4.3",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "build/cjs/index.js",

--- a/test/spec/idx/authenticator/SecurityQuestionEnrollment.ts
+++ b/test/spec/idx/authenticator/SecurityQuestionEnrollment.ts
@@ -1,0 +1,86 @@
+import { IdxAuthenticator } from '../../../../lib/idx/types';
+import { SecurityQuestionAuthenticatorFactory } from '@okta/test.support/idx';
+import { SecurityQuestionEnrollment } from '../../../../lib/idx/authenticator';
+
+describe('idx/authenticator/SecurityQuestionEnrollment', () => {
+  let testContext;
+  beforeEach(() => {
+    const idxAuthenticator: IdxAuthenticator = SecurityQuestionAuthenticatorFactory.build();
+    const authenticator = new SecurityQuestionEnrollment(idxAuthenticator);
+    testContext = {
+      idxAuthenticator,
+      authenticator
+    };
+  });
+
+  describe('constructor', () => {
+    it('sets the authenticator on the "meta" property', () => {
+      const { idxAuthenticator, authenticator } = testContext;
+      expect(authenticator.meta).toBe(idxAuthenticator);
+    });
+  });
+
+  describe('canVerify', () => {
+    it('by default, returns false', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.canVerify({ unknownValue: 'foo' })).toBe(false);
+    });
+    it('cannot verify using only "answer"', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.canVerify({ answer: 'foo' })).toBe(false);
+    });
+    it('can verify using "answer" and "questionKey"', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.canVerify({ answer: 'foo', questionKey: 'bar' })).toBe(true);
+    });
+    it('canv erify using "answer" and "question"', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.canVerify({ answer: 'foo', question: 'bar' })).toBe(true);
+    });
+    it('cannot verify using only "credentials.answer"', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.canVerify({ credentials: { answer: 'foo' } })).toBe(false);
+    });
+    it('can verify using "credentials.answer" and "credentials.questionKey"', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.canVerify({ credentials: { answer: 'foo', questionKey: 'bar' } })).toBe(true);
+    });
+  });
+
+  describe('mapCredentials', () => {
+    it('returns undefined by default', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.mapCredentials({})).toBe(undefined);
+    });
+    it('returns undefined if only "answer" is set', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.mapCredentials({ answer: 'foo' })).toBe(undefined);
+    });
+    it('returns a credentials object if "answer" and "question" is set', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.mapCredentials({ answer: 'foo', question: 'what do?' })).toEqual({
+        answer: 'foo',
+        questionKey: 'custom',
+        question: 'what do?'
+      });
+    });
+    it('returns a credentials object if "answer" and "questionKey" is set', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.mapCredentials({ answer: 'foo', questionKey: 'bar' })).toEqual({
+        answer: 'foo',
+        questionKey: 'bar',
+      });
+    });
+  });
+
+  describe('getInputs', () => {
+    it('returns three inputs: questionKey, question, answer', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.getInputs()).toEqual([
+        { name: 'questionKey', type: 'string', required: true },
+        { name: 'question', type: 'string', label: 'Create a security question' },
+        { name: 'answer', type: 'string', label: 'Answer', required: true }
+      ]);
+    });
+  });
+});

--- a/test/spec/idx/authenticator/SecurityQuestionEnrollment.ts
+++ b/test/spec/idx/authenticator/SecurityQuestionEnrollment.ts
@@ -33,7 +33,7 @@ describe('idx/authenticator/SecurityQuestionEnrollment', () => {
       const { authenticator } = testContext;
       expect(authenticator.canVerify({ answer: 'foo', questionKey: 'bar' })).toBe(true);
     });
-    it('canv erify using "answer" and "question"', () => {
+    it('can verify using "answer" and "question"', () => {
       const { authenticator } = testContext;
       expect(authenticator.canVerify({ answer: 'foo', question: 'bar' })).toBe(true);
     });

--- a/test/spec/idx/authenticator/SecurityQuestionVerification.ts
+++ b/test/spec/idx/authenticator/SecurityQuestionVerification.ts
@@ -1,0 +1,61 @@
+import { IdxAuthenticator } from '../../../../lib/idx/types';
+import { SecurityQuestionAuthenticatorFactory } from '@okta/test.support/idx';
+import { SecurityQuestionVerification } from '../../../../lib/idx/authenticator';
+
+describe('idx/authenticator/SecurityQuestionVerification', () => {
+  let testContext;
+  beforeEach(() => {
+    const idxAuthenticator: IdxAuthenticator = SecurityQuestionAuthenticatorFactory.build();
+    const authenticator = new SecurityQuestionVerification(idxAuthenticator);
+    testContext = {
+      idxAuthenticator,
+      authenticator
+    };
+  });
+
+  describe('constructor', () => {
+    it('sets the authenticator on the "meta" property', () => {
+      const { idxAuthenticator, authenticator } = testContext;
+      expect(authenticator.meta).toBe(idxAuthenticator);
+    });
+  });
+
+  describe('canVerify', () => {
+    it('by default, returns false', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.canVerify({ unknownValue: 'foo' })).toBe(false);
+    });
+    it('canVerify using "answer"', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.canVerify({ answer: 'foo' })).toBe(true);
+    });
+    it('canVerify using "credentials.answer"', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.canVerify({ credentials: { answer: 'foo' } })).toBe(true);
+    });
+  });
+
+  describe('mapCredentials', () => {
+    it('returns undefined by default', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.mapCredentials({})).toBe(undefined);
+    });
+    it('returns a credentials object if "answer" is set', () => {
+      const { authenticator, idxAuthenticator } = testContext;
+      expect(idxAuthenticator.contextualData.enrolledQuestion.questionKey).toBe('custom');
+      expect(authenticator.mapCredentials({ answer: 'foo' })).toEqual({
+        answer: 'foo',
+        questionKey: 'custom'
+      });
+    });
+  });
+
+  describe('getInputs', () => {
+    it('returns one input: answer', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.getInputs()).toEqual([
+        { name: 'answer', type: 'string', label: 'Answer', required: true }
+      ]);
+    });
+  });
+});

--- a/test/spec/idx/authenticator/SecurityQuestionVerification.ts
+++ b/test/spec/idx/authenticator/SecurityQuestionVerification.ts
@@ -5,7 +5,14 @@ import { SecurityQuestionVerification } from '../../../../lib/idx/authenticator'
 describe('idx/authenticator/SecurityQuestionVerification', () => {
   let testContext;
   beforeEach(() => {
-    const idxAuthenticator: IdxAuthenticator = SecurityQuestionAuthenticatorFactory.build();
+    const idxAuthenticator: IdxAuthenticator = SecurityQuestionAuthenticatorFactory.build({
+      contextualData: {
+        enrolledQuestion: {
+          questionKey: 'custom',
+          question: 'social'
+        }
+      }
+    });
     const authenticator = new SecurityQuestionVerification(idxAuthenticator);
     testContext = {
       idxAuthenticator,

--- a/test/support/idx/factories/authenticators.ts
+++ b/test/support/idx/factories/authenticators.ts
@@ -135,12 +135,13 @@ export const SecurityQuestionAuthenticatorFactory = IdxAuthenticatorFactory.para
   methods: [
     { type: 'security_question' }
   ],
-  contextualData: {
-    enrolledQuestion: {
-      questionKey: 'custom',
-      question: 'social'
-    }
-  }
+  // if already enrolled, contextualData will be set
+  // contextualData: {
+  //   enrolledQuestion: {
+  //     questionKey: 'custom',
+  //     question: 'social'
+  //   }
+  // }
 });
 
 export const WebauthnAuthenticatorFactory = IdxAuthenticatorFactory.params({

--- a/test/support/idx/factories/authenticators.ts
+++ b/test/support/idx/factories/authenticators.ts
@@ -134,7 +134,13 @@ export const SecurityQuestionAuthenticatorFactory = IdxAuthenticatorFactory.para
   type: 'security_question',
   methods: [
     { type: 'security_question' }
-  ]
+  ],
+  contextualData: {
+    enrolledQuestion: {
+      questionKey: 'custom',
+      question: 'social'
+    }
+  }
 });
 
 export const WebauthnAuthenticatorFactory = IdxAuthenticatorFactory.params({


### PR DESCRIPTION
Fixes an issue with lib/idx/authenticator/SecurityQuestionVerification.ts where it was not accepting `credentials.answer` as provided by the Sign-in Widget.

When enrolling in security question there is no "contextualData", but this object is present when verifying.  An omission in the mock used by SIW had it testing security question enrollment, but not verification.  Fixing the mock revealed the issue with AuthJS.

Adding unit tests to cover these cases.