### PR TITLE
fix: saved idx transaction should be available after terminal response

### DIFF
--- a/lib/TransactionManager.ts
+++ b/lib/TransactionManager.ts
@@ -24,7 +24,8 @@ import {
   TransactionMetaOptions,
   TransactionManagerOptions,
   CookieStorage,
-  SavedIdxResponse
+  SavedIdxResponse,
+  IntrospectOptions
 } from './types';
 import { isRawIdxResponse } from './idx/types/idx-js';
 import { warn } from './util';
@@ -36,7 +37,7 @@ import {
 } from './util/sharedStorage';
 
 export interface ClearTransactionMetaOptions extends TransactionMetaOptions {
-  clearSharedStorage?: boolean;
+  clearSharedStorage?: boolean; // true by default
 }
 export default class TransactionManager {
   options: TransactionManagerOptions;
@@ -68,9 +69,6 @@ export default class TransactionManager {
     // Clear primary storage (by default, sessionStorage on browser)
     transactionStorage.clearStorage();
 
-    // clear IDX response storage
-    this.clearIdxResponse();
-
     // Usually we want to also clear shared storage unless another tab may need it to continue/complete a flow
     if (this.enableSharedStorage && options.clearSharedStorage !== false) {
       const state = options.state || meta?.state;
@@ -78,7 +76,7 @@ export default class TransactionManager {
         clearTransactionFromSharedStorage(this.storageManager, state);
       }
     }
-  
+
     if (!this.legacyWidgetSupport) {
       return;
     }
@@ -307,7 +305,7 @@ export default class TransactionManager {
     // throw new AuthSdkError('Unable to parse the ' + REDIRECT_OAUTH_PARAMS_NAME + ' value from storage');
   }
 
-  saveIdxResponse({ rawIdxResponse, requestDidSucceed }: SavedIdxResponse): void {
+  saveIdxResponse(data: SavedIdxResponse): void {
     if (!this.saveLastResponse) {
       return;
     }
@@ -315,10 +313,11 @@ export default class TransactionManager {
     if (!storage) {
       return;
     }
-    storage.setStorage({ rawIdxResponse, requestDidSucceed });
+    storage.setStorage(data);
   }
 
-  loadIdxResponse(): SavedIdxResponse | null {
+  // eslint-disable-next-line complexity
+  loadIdxResponse(options?: IntrospectOptions): SavedIdxResponse | null {
     if (!this.saveLastResponse) {
       return null;
     }
@@ -330,6 +329,17 @@ export default class TransactionManager {
     if (!storedValue || !isRawIdxResponse(storedValue.rawIdxResponse)) {
       return null;
     }
+
+    if (options) {
+      const { stateHandle, interactionHandle } = options;
+      if (stateHandle && storedValue.stateHandle !== stateHandle) {
+        return null;
+      }
+      if (interactionHandle && storedValue.interactionHandle !== interactionHandle) {
+        return null;
+      }
+    }
+
     return storedValue;
   }
 

--- a/lib/idx/introspect.ts
+++ b/lib/idx/introspect.ts
@@ -27,7 +27,7 @@ export async function introspect (
   let requestDidSucceed;
 
   // try load from storage first
-  const savedIdxResponse = authClient.transactionManager.loadIdxResponse();
+  const savedIdxResponse = authClient.transactionManager.loadIdxResponse(options);
   if (savedIdxResponse) {
     rawIdxResponse = savedIdxResponse.rawIdxResponse;
     requestDidSucceed = savedIdxResponse.requestDidSucceed;

--- a/lib/idx/remediate.ts
+++ b/lib/idx/remediate.ts
@@ -75,13 +75,6 @@ export async function remediate(
     return { idxResponse };
   }
 
-  // Reach to terminal state
-  const terminal = isTerminalResponse(idxResponse);
-  const messages = getMessagesFromResponse(idxResponse);
-  if (terminal) {
-    return { idxResponse, terminal, messages };
-  }
-
   const remediator = getRemediator(neededToProceed, values, options);
 
   // Try actions in idxResponse first
@@ -129,6 +122,13 @@ export async function remediate(
         return remediate(idxResponse, values, optionsWithoutExecutedAction); // recursive call
       }
     }
+  }
+
+  // Do not attempt to remediate if response is in terminal state
+  const terminal = isTerminalResponse(idxResponse);
+  const messages = getMessagesFromResponse(idxResponse);
+  if (terminal) {
+    return { idxResponse, terminal, messages };
   }
 
   if (!remediator) {

--- a/lib/idx/run.ts
+++ b/lib/idx/run.ts
@@ -311,16 +311,17 @@ export async function run(
   else {
     // ensures state is saved to sessionStorage
     saveTransactionMeta(authClient, { ...meta });
+  }
 
-    if (idxResponse) {
-      // Save intermediate idx response in storage to reduce introspect call
-      const { rawIdxState: rawIdxResponse, requestDidSucceed } = idxResponse;
-      authClient.transactionManager.saveIdxResponse({
-        rawIdxResponse,
-        requestDidSucceed
-      });
-    }
-
+  if (idxResponse) {
+    // Save intermediate idx response in storage to reduce introspect call
+    const { rawIdxState: rawIdxResponse, requestDidSucceed } = idxResponse;
+    authClient.transactionManager.saveIdxResponse({
+      rawIdxResponse,
+      requestDidSucceed,
+      stateHandle: idxResponse.context?.stateHandle,
+      interactionHandle: meta?.interactionHandle
+    });
   }
   
   // from idx-js, used by the widget

--- a/lib/idx/startTransaction.ts
+++ b/lib/idx/startTransaction.ts
@@ -19,6 +19,7 @@ export async function startTransaction(
   options: StartOptions = {}
 ): Promise<IdxTransaction> {
   // Clear IDX response cache and saved transaction meta (if any)
+  authClient.transactionManager.clearIdxResponse();
   authClient.transactionManager.clear();
 
   return run(authClient, {

--- a/lib/types/Storage.ts
+++ b/lib/types/Storage.ts
@@ -13,6 +13,7 @@
 import { TransactionMeta } from './Transaction';
 import { Cookies, CookieOptions } from './Cookies';
 import { RawIdxResponse } from '../idx/types/idx-js';
+import { IntrospectOptions } from '.';
 
 // for V1 authn interface: tx.resume()
 export interface TxStorage {
@@ -51,7 +52,12 @@ export interface TransactionStorage extends StorageProvider {
   getStorage(): TransactionMeta;
 }
 
-export interface SavedIdxResponse {
+export interface SavedIdxResponse extends
+  Pick<IntrospectOptions,
+    'stateHandle' |
+    'interactionHandle'
+  >
+{
   rawIdxResponse: RawIdxResponse;
   requestDidSucceed?: boolean;
 }

--- a/test/spec/idx/register.ts
+++ b/test/spec/idx/register.ts
@@ -117,7 +117,8 @@ describe('idx/register', () => {
         clear: () => {},
         save: () => {},
         saveIdxResponse: () => {},
-        loadIdxResponse: () => {}
+        loadIdxResponse: () => {},
+        clearIdxResponse: () => {}
       },
       token: {
         exchangeCodeForTokens: () => Promise.resolve(tokenResponse)

--- a/test/spec/idx/remediate.ts
+++ b/test/spec/idx/remediate.ts
@@ -46,7 +46,7 @@ describe('idx/remediate', () => {
     const messages = ['fake'];
     jest.spyOn(util, 'isTerminalResponse').mockReturnValue(true);
     jest.spyOn(util, 'getMessagesFromResponse').mockReturnValue(messages);
-    const idxResponse = { fake: true } as unknown as IdxResponse;
+    const idxResponse = { fake: true, actions: {} } as unknown as IdxResponse;
     const res = await remediate(idxResponse, {}, {});
     expect(res).toEqual({
       idxResponse,

--- a/test/spec/idx/startTransaction.ts
+++ b/test/spec/idx/startTransaction.ts
@@ -94,6 +94,20 @@ describe('idx/startTransaction', () => {
     };
   });
 
+  it('clears transaction data', async () => {
+    const { authClient } = testContext;
+    jest.spyOn(authClient.transactionManager, 'clear');
+    await startTransaction(authClient);
+    expect(authClient.transactionManager.clear).toHaveBeenCalled();
+  });
+
+  it('clears IDX response', async () => {
+    const { authClient } = testContext;
+    jest.spyOn(authClient.transactionManager, 'clearIdxResponse');
+    await startTransaction(authClient);
+    expect(authClient.transactionManager.clearIdxResponse).toHaveBeenCalled();
+  });
+
   it('calls interact, introspect, and remediate', async () => {
     const { authClient, idxResponse } = testContext;
     await startTransaction(authClient);

--- a/test/spec/idx/unlockAccount.ts
+++ b/test/spec/idx/unlockAccount.ts
@@ -95,7 +95,8 @@ describe('/idx/unlockAccout', () => {
         clear: () => {},
         save: () => {},
         saveIdxResponse: () => {},
-        loadIdxResponse: () => {}
+        loadIdxResponse: () => {},
+        clearIdxResponse: () => {}
       },
       token: {
         exchangeCodeForTokens: () => Promise.resolve(tokenResponse)


### PR DESCRIPTION
- does not clear IDX transaction when reaching a terminal state
- stateHandle and interactionHandle (if available) are stored along with the last transaction
- access to the last IDX transaction can be gated by a matching stateHandle or interactionHandle, if provided by the caller.

This fix maintains compatibility with some stateHandle-based flows which involve executing the "cancel" action after reaching a terminal response.