### PR TITLE
Create downstream build for widget

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -1,7 +1,14 @@
 test_suites:
-    - name: lint
+    - name: publish
       script_path: ../okta-auth-js/scripts
       sort_order: '1'
+      timeout: '60'
+      script_name: publish
+      criteria: MERGE
+      queue_name: small
+    - name: lint
+      script_path: ../okta-auth-js/scripts
+      sort_order: '2'
       timeout: '60'
       script_name: lint
       criteria: MERGE
@@ -81,13 +88,6 @@ test_suites:
       sort_order: '12'
       timeout: '20'
       script_name: e2e-react-oie
-      criteria: MERGE
-      queue_name: small
-    - name: publish
-      script_path: ../okta-auth-js/scripts
-      sort_order: '13'
-      timeout: '60'
-      script_name: publish
       criteria: MERGE
       queue_name: small
     # Sauce labs tests are flaky due to the free account we are currently using

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "dev:samples": "yarn workspace @okta/samples dev",
     "prepare": "yarn build",
     "start": "yarn workspace @okta/test.app start --open",
-    "stop": "kill -s TERM $(lsof -t -i:8080 -sTCP:LISTEN) || true"
+    "stop": "kill -s TERM $(lsof -t -i:8080 -sTCP:LISTEN) || true",
+    "verify:package": "node scripts/verify-package.js"
   },
   "author": "Okta",
   "keywords": [

--- a/samples/test/runner.js
+++ b/samples/test/runner.js
@@ -49,7 +49,12 @@ function runWithConfig(sampleConfig) {
     'workspace',
     name,
     'start'
-  ], { stdio: 'inherit' });
+  ], { 
+    stdio: 'inherit',
+    env: Object.assign({}, process.env, {
+      SELF_HOSTED_WIDGET: '1' // ensure we are testing beta widgets if installed
+    })
+  });
 
   waitOn({
     resources: [

--- a/scripts/downstream/create-downstream-for-widget.sh
+++ b/scripts/downstream/create-downstream-for-widget.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# download okta-signin-widget artifact version if empty and assign to upstream_artifact_version
+if [[ -z "${upstream_artifact_version}" ]]; then
+  pushd ${OKTA_HOME}/okta-signin-widget > /dev/null
+    download_job_data global artifact_version upstream_artifact_version okta-signin-widget ${upstream_artifact_sha}
+  popd > /dev/null
+  echo "okta-signin-widget version that will be tested: ${upstream_artifact_version}"
+fi
+
+pushd ${OKTA_HOME}/okta-auth-js/scripts > /dev/null
+
+# Get the WIDGET_VERSION version to use
+WIDGET_VERSION="$(echo ${upstream_artifact_version} | cut -d'@' -f3)"
+
+# Update setup script
+echo "Update okta-signin-widget version in scripts/setup.sh to ${WIDGET_VERSION}"
+sed -i "s/\(WIDGET_VERSION\=\).*/\1\"${WIDGET_VERSION}\"/g" setup.sh
+
+popd > /dev/null

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -e
 
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 
@@ -13,6 +13,14 @@ fi
 if ! yarn lint:report; then
   echo "lint failed! Exiting..."
   exit ${TEST_FAILURE}
+fi
+
+mkdir -p ${TEST_RESULT_FILE_DIR}
+if ! yarn verify:package 2> ${TEST_RESULT_FILE_DIR}/verify-package-error.log; then
+  echo "verify package failed! Exiting..."
+  value=`cat ${TEST_RESULT_FILE_DIR}/verify-package-error.log`
+  log_custom_message "Verification Failed" "${value}"
+  exit ${PUBLISH_TYPE_AND_RESULT_DIR_BUT_ALWAYS_FAIL}
 fi
 
 echo ${TEST_SUITE_TYPE} > ${TEST_SUITE_TYPE_FILE}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -xe
 
+# Can be used to run a canary build against a beta AuthJS version that has been published to artifactory.
+# This is available from the "downstream artifact" menu on any okta-auth-js build in Bacon.
+# DO NOT MERGE ANY CHANGES TO THIS LINE!!
+export WIDGET_VERSION=""
+
 # Add yarn to the $PATH so npm cli commands do not fail
 export PATH="${PATH}:$(yarn global bin)"
 
@@ -7,32 +12,28 @@ export PATH="${PATH}:$(yarn global bin)"
 export NVM_DIR="/root/.nvm"
 NODE_VERSION="${1:-v12.22.0}"
 setup_service node $NODE_VERSION
+# Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
+setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
 
 cd ${OKTA_HOME}/${REPO}
 
-# Yarn does not utilize the npmrc/yarnrc registry configuration
-# if a lockfile is present. This results in `yarn install` problems
-# for private registries. Until yarn@2.0.0 is released, this is our current
-# workaround.
-#
-# Related issues:
-#  - https://github.com/yarnpkg/yarn/issues/5892
-#  - https://github.com/yarnpkg/yarn/issues/3330
+if [ ! -z "$WIDGET_VERSION" ]; then
+  echo "Installing WIDGET_VERSION: ${WIDGET_VERSION}"
+  npm config set strict-ssl false
 
-YARN_REGISTRY=https://registry.yarnpkg.com
-OKTA_REGISTRY=${ARTIFACTORY_URL}/api/npm/npm-okta-master
-
-# Replace yarn artifactory with Okta's
-sed -i "s#${YARN_REGISTRY}#${OKTA_REGISTRY}#g" yarn.lock
+  if ! yarn add -DW --force https://artifacts.aue1d.saasure.com/artifactory/npm-topic/@okta/okta-signin-widget/-/@okta/okta-signin-widget-${WIDGET_VERSION}.tgz ; then
+    echo "WIDGET_VERSION could not be installed: ${WIDGET_VERSION}"
+    exit ${FAILED_SETUP}
+  fi
+  
+  echo "WIDGET_VERSION installed: ${WIDGET_VERSION}"
+fi
 
 # Install dependences. --ignore-scripts will prevent chromedriver from attempting to install
 if ! yarn install --frozen-lockfile --ignore-scripts; then
   echo "yarn install failed! Exiting..."
   exit ${FAILED_SETUP}
 fi
-
-# Revert the original change
-sed -i "s#${OKTA_REGISTRY}#${YARN_REGISTRY}#" yarn.lock
 
 # Build
 if ! yarn build; then

--- a/scripts/verify-package.js
+++ b/scripts/verify-package.js
@@ -1,0 +1,22 @@
+function verifyWidgetVersion() {
+  if (/^d16t-okta-signin-widget-.*/.test(process.env.BRANCH)) {
+    console.log('Skipping verification of okta-signin-widget version for downstream artifact build');
+    return;
+  }
+
+  const version = require('../node_modules/@okta/okta-signin-widget/package.json').version;
+  const regex = /^(\d)+\.(\d)+\.(\d)+$/;
+  if (regex.test(version) !== true) {
+    throw new Error(`Invalid/beta version for okta-signin-widget: ${version}`);
+  }
+  console.log(`okta-signin-widget version is valid: ${version}`);
+}
+
+try {
+  verifyWidgetVersion();
+  console.log('verify-package finished successfully');
+} catch (e) {
+  console.error(e);
+  // eslint-disable-next-line no-process-exit
+  process.exit(1);
+}

--- a/test/apps/app/src/config.ts
+++ b/test/apps/app/src/config.ts
@@ -11,7 +11,7 @@
  */
 
 
-import { OktaAuthOptions } from '@okta/okta-auth-js';
+import { OAuthResponseMode, OAuthResponseType, OktaAuthOptions } from '@okta/okta-auth-js';
 import { LOGIN_CALLBACK_PATH, STORAGE_KEY } from './constants';
 const HOST = window.location.host;
 const PROTO = window.location.protocol;
@@ -72,8 +72,8 @@ export function getConfigFromUrl(): Config {
   const pkce = url.searchParams.get('pkce') !== 'false'; // On by default
   const defaultScopes = url.searchParams.get('defaultScopes') === 'true';
   const scopes = (url.searchParams.get('scopes') || 'openid,email,offline_access').split(',');
-  const responseType = (url.searchParams.get('responseType') || 'id_token,token').split(',');
-  const responseMode = url.searchParams.get('responseMode') || undefined;
+  const responseType = (url.searchParams.get('responseType') || 'id_token,token').split(',') as OAuthResponseType[];
+  const responseMode = url.searchParams.get('responseMode') as OAuthResponseMode || undefined;
   const storage = url.searchParams.get('storage') || undefined;
   const expireEarlySeconds = +url.searchParams.get('expireEarlySeconds') || undefined;
   const secureCookies = url.searchParams.get('secure') !== 'false'; // On by default


### PR DESCRIPTION
- enables creation of a canary build using a beta widget version. This will run E2E tests against the beta version.