### PR TITLE
Implement SyncStorageService using broadcast-channel

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 /test/support/xhr
 /test/app/public
+/test/apps/app/public
 node_modules
 /build/dist
 /build/lib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 6.7.0
+
+## Features
+
+- [#1197](https://github.com/okta/okta-auth-js/pull/1197)
+  - Changes implementation of `SyncStorageService` using `broadcast-channel` instead of using `StorageEvent`. Supports `localStorage` and `cookie` storage.
+  - Adds `LeaderElectionService` as separate service
+  - Fixes error `Channel is closed` while stopping leader election
+
 ## 6.6.1
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ When `tokenManager.autoRenew` is `true` both renew strategies are enabled. To di
 By default, the library will attempt to remove expired tokens when `autoRemove` is `true`. If you wish to disable auto removal of tokens, set `autoRemove` to `false`.
 
 #### `syncStorage`
-Automatically syncs tokens across browser tabs when token storage is `localStorage`. To disable this behavior, set `syncStorage` to false.
+Automatically syncs tokens across browser tabs when token storage is `localStorage` or `cookie`. To disable this behavior, set `syncStorage` to false.
 
 This is accomplished by selecting a single tab to handle the network requests to refresh the tokens and broadcasting to the other tabs. This is done to avoid all tabs sending refresh requests simultaneously, which can cause rate limiting/throttling issues.
 

--- a/README.md
+++ b/README.md
@@ -903,11 +903,15 @@ This is accomplished by selecting a single tab to handle the network requests to
 
 ### `start()`
 
+> :hourglass: async
+
 Starts the `OktaAuth` service. See [running as a service](#running-as-a-service) for more details.
 
 ### `stop()`
 
-Starts the `OktaAuth` service. See [running as a service](#running-as-a-service) for more details.
+> :hourglass: async
+
+Stops the `OktaAuth` service. See [running as a service](#running-as-a-service) for more details.
 
 ### `signIn(options)`
 

--- a/README.md
+++ b/README.md
@@ -234,12 +234,12 @@ var authClient = new OktaAuth(config);
 
 ### Running as a service
 
-By default, creating a new instance of `OktaAuth` will not create any asynchronous side-effects. However, certain features such as [token auto renew](#autorenew), [token auto remove](#autoremove) and [cross-tab synchronization](#syncstorage) require `OktaAuth` to be running as a service. This means timeouts are set in the background which will continue working until the service is stopped.  To start the `OktaAuth` service, simply call the `start` method. To terminate all background processes, call `stop`. See [Service Configuration](#services) for more info.
+By default, creating a new instance of `OktaAuth` will not create any asynchronous side-effects. However, certain features such as [token auto renew](#autorenew), [token auto remove](#autoremove) and [cross-tab synchronization](#syncstorage) require `OktaAuth` to be running as a service. This means timeouts are set in the background which will continue working until the service is stopped.  To start the `OktaAuth` service, simply call the `start` method right after creation and before calling other methods like [handleLoginRedirect](#handleloginredirecttokens). To terminate all background processes, call `stop`. See [Service Configuration](#services) for more info.
 
 ```javascript
   var authClient = new OktaAuth(config);
-  authClient.start(); // start the service
-  authClient.stop(); // stop the service
+  await authClient.start(); // start the service
+  await authClient.stop(); // stop the service
 ```
 
 Starting the service will also call [authStateManager.updateAuthState](#authstatemanagerupdateauthstate).

--- a/jest.server.js
+++ b/jest.server.js
@@ -26,6 +26,7 @@ const config = Object.assign({}, baseConfig, {
     'oidc/renewTokens.ts',
     'TokenManager/browser',
     'SyncStorageService',
+    'LeaderElectionService',
     'ServiceManager'
   ])
 });

--- a/lib/AuthStateManager.ts
+++ b/lib/AuthStateManager.ts
@@ -15,10 +15,9 @@
 // Do not use this type in code, so it won't be emitted in the declaration output
 import PCancelable from 'p-cancelable';
 import { AuthSdkError } from './errors';
-import { AuthState, AuthStateLogOptions } from './types';
+import { AuthState, AuthStateLogOptions, EVENT_ADDED, EVENT_REMOVED } from './types';
 import { OktaAuth } from '.';
 import { getConsole } from './util';
-import { EVENT_ADDED, EVENT_REMOVED } from './TokenManager';
 import PromiseQueue from './PromiseQueue';
 
 export const INITIAL_AUTH_STATE = null;

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -175,14 +175,6 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
     }, options.transactionManager));
     this._oktaUserAgent = new OktaUserAgent();
 
-    // Enable `syncStorage` only if token storage type is `localStorage` or `cookie`
-    const syncableStorageTypes = ['localStorage', 'cookie'];
-    const canSyncStorage = typeof args.tokenManager?.storage === 'string' 
-      && syncableStorageTypes.includes(args.tokenManager.storage);
-    if (!canSyncStorage) {
-      args.services = { ...args.services, syncStorage: false };
-    }
-
     this.tx = {
       status: transactionStatus.bind(null, this),
       resume: resumeTransaction.bind(null, this),

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -175,6 +175,14 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
     }, options.transactionManager));
     this._oktaUserAgent = new OktaUserAgent();
 
+    // Enable `syncStorage` only if token storage type is `localStorage` or `cookie`
+    const syncableStorageTypes = ['localStorage', 'cookie'];
+    const canSyncStorage = typeof args.tokenManager?.storage === 'string' 
+      && syncableStorageTypes.includes(args.tokenManager.storage);
+    if (!canSyncStorage) {
+      args.services = { ...args.services, syncStorage: false };
+    }
+
     this.tx = {
       status: transactionStatus.bind(null, this),
       resume: resumeTransaction.bind(null, this),

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -381,7 +381,7 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
     // TODO: review tokenManager.start
     this.tokenManager.start();
     if (!this.token.isLoginRedirect()) {
-      this.authStateManager.updateAuthState();
+      await this.authStateManager.updateAuthState();
     }
   }
 

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -367,6 +367,11 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
     // AuthStateManager
     this.authStateManager = new AuthStateManager(this);
 
+    // Enable `syncStorage` only if token storage is shared across tabs (type is `localStorage` or `cookie`)
+    if (!this.tokenManager.hasSharedStorage()) {
+      args.services = { ...args.services, syncStorage: false };
+    }
+
     // ServiceManager
     this.serviceManager = new ServiceManager(this, args.services);
   }

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -376,13 +376,13 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
     this.serviceManager = new ServiceManager(this, args.services);
   }
 
-  async start() {
+  start() {
+    this.serviceManager.start();
     // TODO: review tokenManager.start
     this.tokenManager.start();
     if (!this.token.isLoginRedirect()) {
       this.authStateManager.updateAuthState();
     }
-    await this.serviceManager.start();
   }
 
   async stop() {

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -376,8 +376,8 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
     this.serviceManager = new ServiceManager(this, args.services);
   }
 
-  start() {
-    this.serviceManager.start();
+  async start() {
+    await this.serviceManager.start();
     // TODO: review tokenManager.start
     this.tokenManager.start();
     if (!this.token.isLoginRedirect()) {

--- a/lib/SavedObject.ts
+++ b/lib/SavedObject.ts
@@ -53,7 +53,8 @@ export default class SavedObject implements StorageProvider {
   //
 
   isSharedStorage() {
-    return this.storageProvider === localStorage as any || !!this.storageProvider.isSharedStorage?.();
+    return typeof localStorage !== 'undefined' && this.storageProvider === localStorage as any 
+      || !!this.storageProvider.isSharedStorage?.();
   }
 
   getStorage() {

--- a/lib/SavedObject.ts
+++ b/lib/SavedObject.ts
@@ -52,6 +52,10 @@ export default class SavedObject implements StorageProvider {
   // StorageProvider interface
   //
 
+  isSharedStorage() {
+    return this.storageProvider === localStorage as any || !!this.storageProvider.isSharedStorage?.();
+  }
+
   getStorage() {
     var storageString = this.storageProvider.getItem(this.storageName);
     storageString = storageString || '{}';

--- a/lib/ServiceManager.ts
+++ b/lib/ServiceManager.ts
@@ -52,14 +52,6 @@ export class ServiceManager implements ServiceManagerInterface {
       },
       options
     );
-    // Enable `syncStorage` only if token storage type is `localStorage` or `cookie`
-    const syncableStorageTypes = ['localStorage', 'cookie'];
-    const storageType = sdk.tokenManager.getOptions().storage;
-    const canSyncStorage = typeof storageType === 'string'
-      && syncableStorageTypes.includes(storageType);
-    if (!canSyncStorage) {
-      this.options.syncStorage = false;
-    }
 
     this.started = false;
     this.services = new Map();

--- a/lib/ServiceManager.ts
+++ b/lib/ServiceManager.ts
@@ -41,7 +41,7 @@ export class ServiceManager implements ServiceManagerInterface {
     const { autoRenew, autoRemove, syncStorage } = sdk.tokenManager.getOptions();
     this.options = Object.assign({}, 
       ServiceManager.defaultOptions,
-      { autoRenew, autoRemove, syncStorage, broadcastChannelName: sdk.options.clientId },
+      { autoRenew, autoRemove, syncStorage, electionChannelName: sdk.options.clientId },
       options
     );
 

--- a/lib/ServiceManager.ts
+++ b/lib/ServiceManager.ts
@@ -18,6 +18,7 @@ import {
 } from './types';
 import { OktaAuth } from '.';
 import { AutoRenewService, SyncStorageService, LeaderElectionService } from './services';
+import { removeNils } from './util';
 
 const AUTO_RENEW = 'autoRenew';
 const SYNC_STORAGE = 'syncStorage';
@@ -43,6 +44,7 @@ export class ServiceManager implements ServiceManagerInterface {
 
     // TODO: backwards compatibility, remove in next major version - OKTA-473815
     const { autoRenew, autoRemove, syncStorage } = sdk.tokenManager.getOptions();
+    options.electionChannelName = options.broadcastChannelName;
     this.options = Object.assign({}, 
       ServiceManager.defaultOptions,
       { autoRenew, autoRemove, syncStorage }, 
@@ -50,7 +52,7 @@ export class ServiceManager implements ServiceManagerInterface {
         electionChannelName: `${sdk.options.clientId}-election`,
         syncChannelName: `${sdk.options.clientId}-sync`,
       },
-      options
+      removeNils(options)
     );
 
     this.started = false;

--- a/lib/ServiceManager.ts
+++ b/lib/ServiceManager.ts
@@ -125,7 +125,7 @@ export class ServiceManager implements ServiceManagerInterface {
   private createService(name: string): ServiceInterface {
     const tokenManager = this.sdk.tokenManager;
 
-    let service: ServiceInterface | undefined;
+    let service: ServiceInterface;
     switch (name) {
       case LEADER_ELECTION:
         service = new LeaderElectionService({...this.options, onLeader: this.onLeader});

--- a/lib/ServiceManager.ts
+++ b/lib/ServiceManager.ts
@@ -52,6 +52,14 @@ export class ServiceManager implements ServiceManagerInterface {
       },
       options
     );
+    // Enable `syncStorage` only if token storage type is `localStorage` or `cookie`
+    const syncableStorageTypes = ['localStorage', 'cookie'];
+    const storageType = sdk.tokenManager.getOptions().storage;
+    const canSyncStorage = typeof storageType === 'string'
+      && syncableStorageTypes.includes(storageType);
+    if (!canSyncStorage) {
+      this.options.syncStorage = false;
+    }
 
     this.started = false;
     this.services = new Map();

--- a/lib/ServiceManager.ts
+++ b/lib/ServiceManager.ts
@@ -44,7 +44,7 @@ export class ServiceManager implements ServiceManagerInterface {
 
     // TODO: backwards compatibility, remove in next major version - OKTA-473815
     const { autoRenew, autoRemove, syncStorage } = sdk.tokenManager.getOptions();
-    options.electionChannelName = options.broadcastChannelName;
+    options.electionChannelName = options.electionChannelName || options.broadcastChannelName;
     this.options = Object.assign({}, 
       ServiceManager.defaultOptions,
       { autoRenew, autoRemove, syncStorage }, 

--- a/lib/ServiceManager.ts
+++ b/lib/ServiceManager.ts
@@ -66,10 +66,10 @@ export class ServiceManager implements ServiceManagerInterface {
     });
   }
 
-  private onLeader() {
+  private async onLeader() {
     if (this.started) {
       // Start services that requires leadership
-      this.startServices();
+      await this.startServices();
     }
   }
 
@@ -85,12 +85,12 @@ export class ServiceManager implements ServiceManagerInterface {
     if (this.started) {
       return;     // noop if services have already started
     }
-    this.startServices();
+    await this.startServices();
     this.started = true;
   }
   
-  stop() {
-    this.stopServices();
+  async stop() {
+    await this.stopServices();
     this.started = false;
   }
 
@@ -98,17 +98,17 @@ export class ServiceManager implements ServiceManagerInterface {
     return this.services.get(name);
   }
 
-  private startServices() {
+  private async startServices() {
     for (const [name, srv] of this.services.entries()) {
       if (this.canStartService(name, srv)) {
-        srv.start();
+        await srv.start();
       }
     }
   }
 
-  private stopServices() {
+  private async stopServices() {
     for (const srv of this.services.values()) {
-      srv.stop();
+      await srv.stop();
     }
   }
 

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -110,6 +110,10 @@ export class TokenManager implements TokenManagerInterface {
     this.off = this.emitter.off.bind(this.emitter);
   }
 
+  hasSharedStorage() {
+    return this.storage.isSharedStorage();
+  }
+
   start() {
     if (this.options.clearPendingRemoveTokens) {
       this.clearPendingRemoveTokens();

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -432,8 +432,14 @@ export class TokenManager implements TokenManagerInterface {
   }
   
   clear() {
+    const tokens = this.getTokensSync();
     this.clearExpireEventTimeoutAll();
     this.storage.clearStorage();
+    this.emitSetStorageEvent();
+
+    Object.keys(tokens).forEach(key => {
+      this.emitRemoved(key, tokens[key]);
+    });
   }
 
   clearPendingRemoveTokens() {

--- a/lib/TokenManager.ts
+++ b/lib/TokenManager.ts
@@ -468,11 +468,19 @@ export class TokenManager implements TokenManagerInterface {
   }
 
   clearPendingRemoveTokens() {
-    const tokens = this.getTokensSync();
-    Object.keys(tokens).forEach(key => {
-      if (tokens[key].pendingRemove) {
-       this.remove(key);
+    const tokenStorage = this.storage.getStorage();
+    const removedTokens = {};
+    Object.keys(tokenStorage).forEach(key => {
+      if (tokenStorage[key].pendingRemove) {
+        removedTokens[key] = tokenStorage[key];
+        delete tokenStorage[key];
       }
+    });
+    this.storage.setStorage(tokenStorage);
+    this.emitSetStorageEvent();
+    Object.keys(removedTokens).forEach(key => {
+      this.clearExpireEventTimeout(key);
+      this.emitRemoved(key, removedTokens[key]);
     });
   }
 

--- a/lib/browser/browserStorage.ts
+++ b/lib/browser/browserStorage.ts
@@ -150,7 +150,8 @@ var storageUtil: BrowserStorageUtil = {
       },
       removeItem: (key) => {
         this.storage.delete(key);
-      }
+      },
+      isSharedStorage: () => true
     };
 
     if (!options!.useSeparateCookies) {
@@ -191,7 +192,8 @@ var storageUtil: BrowserStorageUtil = {
         Object.keys(existingValues).forEach(k => {
           storage.removeItem(key + '_' + k);
         });
-      }
+      },
+      isSharedStorage: () => true
     };
   },
 
@@ -204,7 +206,8 @@ var storageUtil: BrowserStorageUtil = {
       },
       setItem: (key, value) => {
         this.inMemoryStore[key] = value;
-      }
+      },
+      isSharedStorage: () => false
     };
   },
 

--- a/lib/browser/browserStorage.ts
+++ b/lib/browser/browserStorage.ts
@@ -25,6 +25,7 @@ import {
   CookieStorage
 } from '../types';
 import { warn } from '../util';
+import { isIE11OrLess } from '../features';
 
 // Building this as an object allows us to mock the functions in our tests
 var storageUtil: BrowserStorageUtil = {
@@ -123,6 +124,11 @@ var storageUtil: BrowserStorageUtil = {
   },
 
   getLocalStorage: function() {
+    // Workaound for synchronization issue of LocalStorage cross tabs in IE11
+    if (isIE11OrLess() && !window.onstorage) {
+      window.onstorage = function() {};
+    }
+    
     return localStorage;
   },
 

--- a/lib/server/serverStorage.ts
+++ b/lib/server/serverStorage.ts
@@ -99,7 +99,8 @@ class ServerStorage implements StorageUtil {
       getItem: this.nodeCache.get,
       setItem: (key, value) => {
         this.nodeCache.set(key, value, '2200-01-01T00:00:00.000Z');
-      }
+      },
+      isSharedStorage: () => true
     };
   }
 }

--- a/lib/services/AutoRenewService.ts
+++ b/lib/services/AutoRenewService.ts
@@ -11,9 +11,9 @@
  */
 
 
-import { TokenManager, EVENT_EXPIRED } from '../TokenManager';
+import { TokenManager } from '../TokenManager';
 import { AuthSdkError } from '../errors';
-import { ServiceInterface, ServiceManagerOptions } from '../types';
+import { ServiceInterface, ServiceManagerOptions, EVENT_EXPIRED } from '../types';
 import { isBrowser } from '../features';
 
 export class AutoRenewService implements ServiceInterface {

--- a/lib/services/AutoRenewService.ts
+++ b/lib/services/AutoRenewService.ts
@@ -63,15 +63,15 @@ export class AutoRenewService implements ServiceInterface {
     return (!!this.options.autoRenew || !!this.options.autoRemove);
   }
 
-  start() {
+  async start() {
     if (this.canStart()) {
-      this.stop();
+      await this.stop();
       this.tokenManager.on(EVENT_EXPIRED, this.onTokenExpiredHandler);
       this.started = true;
     }
   }
 
-  stop() {
+  async stop() {
     if (this.started) {
       this.tokenManager.off(EVENT_EXPIRED, this.onTokenExpiredHandler);
       this.renewTimeQueue = [];

--- a/lib/services/LeaderElectionService.ts
+++ b/lib/services/LeaderElectionService.ts
@@ -68,6 +68,8 @@ export class LeaderElectionService implements ServiceInterface {
       this.elector?.die();
       this.elector = undefined;
       this.channel?.close();
+      // Workaround to fix error `Failed to execute 'postMessage' on 'BroadcastChannel': Channel is closed`
+      (this.channel as any).postInternal = () => Promise.resolve();
       this.channel = undefined;
       this.started = false;
     }

--- a/lib/services/LeaderElectionService.ts
+++ b/lib/services/LeaderElectionService.ts
@@ -55,8 +55,8 @@ export class LeaderElectionService implements ServiceInterface {
     this.stop();
     if (this.canStart()) {
       if (!this.channel) {
-        const { broadcastChannelName } = this.options;
-        this.channel = new BroadcastChannel(broadcastChannelName as string);
+        const { electionChannelName } = this.options;
+        this.channel = new BroadcastChannel(electionChannelName as string);
       }
       if (!this.elector) {
         this.elector = createLeaderElection(this.channel);

--- a/lib/services/LeaderElectionService.ts
+++ b/lib/services/LeaderElectionService.ts
@@ -1,0 +1,92 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+import { ServiceInterface, ServiceManagerOptions } from '../types';
+import {
+  BroadcastChannel,
+  createLeaderElection,
+  LeaderElector
+} from 'broadcast-channel';
+import { isBrowser } from '../features';
+
+type OnLeaderHandler = (() => void);
+type Options = ServiceManagerOptions & {
+  onLeader?: OnLeaderHandler;
+};
+
+export class LeaderElectionService implements ServiceInterface {
+  private options: Options;
+  private channel?: BroadcastChannel;
+  private elector?: LeaderElector;
+  private started = false;
+
+  constructor(options: Options = {}) {
+    this.options = options;
+    this.onLeaderDuplicate = this.onLeaderDuplicate.bind(this);
+    this.onLeader = this.onLeader.bind(this);
+  }
+
+  private onLeaderDuplicate() {
+  }
+
+  private onLeader() {
+    this.options.onLeader?.();
+  }
+
+  isLeader() {
+    return !!this.elector?.isLeader;
+  }
+
+  hasLeader() {
+    return !!this.elector?.hasLeader;
+  }
+
+  start() {
+    this.stop();
+    if (this.canStart()) {
+      if (!this.channel) {
+        const { broadcastChannelName } = this.options;
+        this.channel = new BroadcastChannel(broadcastChannelName as string);
+      }
+      if (!this.elector) {
+        this.elector = createLeaderElection(this.channel);
+        this.elector.onduplicate = this.onLeaderDuplicate;
+        this.elector.awaitLeadership().then(this.onLeader);
+      }
+      this.started = true;
+    }
+  }
+
+  stop() {
+    if (this.started) {
+      this.elector?.die();
+      this.elector = undefined;
+      this.channel?.close();
+      this.channel = undefined;
+      this.started = false;
+    }
+  }
+
+  requiresLeadership() {
+    return false;
+  }
+
+  isStarted() {
+    return this.started;
+  }
+
+  canStart() {
+    return isBrowser();
+  }
+
+}

--- a/lib/services/LeaderElectionService.ts
+++ b/lib/services/LeaderElectionService.ts
@@ -19,18 +19,18 @@ import {
 } from 'broadcast-channel';
 import { isBrowser } from '../features';
 
-type OnLeaderHandler = (() => void);
-type Options = ServiceManagerOptions & {
+declare type OnLeaderHandler = (() => void);
+declare type ServiceOptions = ServiceManagerOptions & {
   onLeader?: OnLeaderHandler;
 };
 
 export class LeaderElectionService implements ServiceInterface {
-  private options: Options;
+  private options: ServiceOptions;
   private channel?: BroadcastChannel;
   private elector?: LeaderElector;
   private started = false;
 
-  constructor(options: Options = {}) {
+  constructor(options: ServiceOptions = {}) {
     this.options = options;
     this.onLeaderDuplicate = this.onLeaderDuplicate.bind(this);
     this.onLeader = this.onLeader.bind(this);
@@ -54,15 +54,11 @@ export class LeaderElectionService implements ServiceInterface {
   start() {
     this.stop();
     if (this.canStart()) {
-      if (!this.channel) {
-        const { electionChannelName } = this.options;
-        this.channel = new BroadcastChannel(electionChannelName as string);
-      }
-      if (!this.elector) {
-        this.elector = createLeaderElection(this.channel);
-        this.elector.onduplicate = this.onLeaderDuplicate;
-        this.elector.awaitLeadership().then(this.onLeader);
-      }
+      const { electionChannelName } = this.options;
+      this.channel = new BroadcastChannel(electionChannelName as string);
+      this.elector = createLeaderElection(this.channel);
+      this.elector.onduplicate = this.onLeaderDuplicate;
+      this.elector.awaitLeadership().then(this.onLeader);
       this.started = true;
     }
   }

--- a/lib/services/SyncStorageService.ts
+++ b/lib/services/SyncStorageService.ts
@@ -109,28 +109,29 @@ export class SyncStorageService implements ServiceInterface {
   }
 
   private onSyncMessageHandler(msg: SyncMessage) {
+    // Use `enablePostMessage` flag here to prevent sync message loop
     switch (msg.type) {
       case EVENT_ADDED:
         this.enablePostMessage = false;
-        this.tokenManager.emitAdded(msg.key, msg.token);
-        this.tokenManager.setExpireEventTimeout(msg.key, msg.token);
+        this.tokenManager.add(msg.key, msg.token);
         this.enablePostMessage = true;
         break;
       case EVENT_REMOVED:
         this.enablePostMessage = false;
-        this.tokenManager.clearExpireEventTimeout(msg.key);
-        this.tokenManager.emitRemoved(msg.key, msg.token);
+        this.tokenManager.remove(msg.key);
         this.enablePostMessage = true;
         break;
       case EVENT_RENEWED:
         this.enablePostMessage = false;
-        this.tokenManager.clearExpireEventTimeout(msg.key);
+        this.tokenManager.remove(msg.key);
+        this.tokenManager.add(msg.key, msg.token);
         this.tokenManager.emitRenewed(msg.key, msg.token, msg.oldToken);
-        this.tokenManager.setExpireEventTimeout(msg.key, msg.token);
         this.enablePostMessage = true;
         break;
       default:
         throw new Error(`Unknown message type ${msg.type}`);
     }
+
+
   }
 } 

--- a/lib/services/SyncStorageService.ts
+++ b/lib/services/SyncStorageService.ts
@@ -10,10 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { TokenManager, EVENT_ADDED, EVENT_REMOVED, EVENT_RENEWED, EVENT_SET_STORAGE } from '../TokenManager';
+import { TokenManager } from '../TokenManager';
 import { BroadcastChannel } from 'broadcast-channel';
 import { isBrowser } from '../features';
-import { ServiceManagerOptions, ServiceInterface, Token, Tokens } from '../types';
+import {
+  ServiceManagerOptions, ServiceInterface, Token, Tokens, 
+  EVENT_ADDED, EVENT_REMOVED, EVENT_RENEWED, EVENT_SET_STORAGE
+} from '../types';
 
 export type SyncMessage = {
   type: string;

--- a/lib/services/SyncStorageService.ts
+++ b/lib/services/SyncStorageService.ts
@@ -54,9 +54,9 @@ export class SyncStorageService implements ServiceInterface {
     return !!this.options.syncStorage && isBrowser();
   }
 
-  start() {
+  async start() {
     if (this.canStart()) {
-      this.stop();
+      await this.stop();
       const { syncChannelName } = this.options;
       this.channel = new BroadcastChannel(syncChannelName as string);
       this.tokenManager.on(EVENT_ADDED, this.onTokenAddedHandler);
@@ -68,14 +68,14 @@ export class SyncStorageService implements ServiceInterface {
     }
   }
 
-  stop() {
+  async stop() {
     if (this.started) {
       this.tokenManager.off(EVENT_ADDED, this.onTokenAddedHandler);
       this.tokenManager.off(EVENT_REMOVED, this.onTokenRemovedHandler);
       this.tokenManager.off(EVENT_RENEWED, this.onTokenRenewedHandler);
       this.tokenManager.off(EVENT_SET_STORAGE, this.onSetStorageHandler);
       this.channel?.removeEventListener('message', this.onSyncMessageHandler);
-      this.channel?.close();
+      await this.channel?.close();
       this.channel = undefined;
       this.started = false;
     }

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -13,3 +13,4 @@
 
 export * from './AutoRenewService';
 export * from './SyncStorageService';
+export * from './LeaderElectionService';

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -34,7 +34,6 @@ export interface TokenManagerOptions {
   storageKey?: string;
   expireEarlySeconds?: number;
   syncStorage?: boolean;
-  _storageEventDelay?: number;
 }
 
 export interface CustomUrls {

--- a/lib/types/Service.ts
+++ b/lib/types/Service.ts
@@ -24,7 +24,7 @@ export interface SyncStorageServiceOptions {
 }
 
 export interface LeaderElectionServiceOptions {
-  broadcastChannelName?: string;
+  electionChannelName?: string;
 }
 
 export type ServiceManagerOptions = AutoRenewServiceOptions &

--- a/lib/types/Service.ts
+++ b/lib/types/Service.ts
@@ -21,6 +21,7 @@ export interface AutoRenewServiceOptions {
 
 export interface SyncStorageServiceOptions {
   syncStorage?: boolean;
+  syncChannelName?: string;
 }
 
 export interface LeaderElectionServiceOptions {

--- a/lib/types/Service.ts
+++ b/lib/types/Service.ts
@@ -26,6 +26,8 @@ export interface SyncStorageServiceOptions {
 
 export interface LeaderElectionServiceOptions {
   electionChannelName?: string;
+  // TODO: remove in next major version - OKTA-473815
+  broadcastChannelName?: string;
 }
 
 export type ServiceManagerOptions = AutoRenewServiceOptions &

--- a/lib/types/Service.ts
+++ b/lib/types/Service.ts
@@ -23,8 +23,9 @@ export interface SyncStorageServiceOptions {
   syncStorage?: boolean;
 }
 
+export interface LeaderElectionServiceOptions {
+  broadcastChannelName?: string;
+}
+
 export type ServiceManagerOptions = AutoRenewServiceOptions &
-  SyncStorageServiceOptions & 
-  {
-    broadcastChannelName?: string;
-  };
+  SyncStorageServiceOptions & LeaderElectionServiceOptions;

--- a/lib/types/Service.ts
+++ b/lib/types/Service.ts
@@ -1,7 +1,7 @@
 // only add methods needed internally
 export interface ServiceInterface {
-  start(): void;
-  stop(): void;
+  start(): Promise<void>;
+  stop(): Promise<void>;
   isStarted(): boolean;
   canStart(): boolean;
   requiresLeadership(): boolean;

--- a/lib/types/Storage.ts
+++ b/lib/types/Storage.ts
@@ -26,6 +26,7 @@ export interface SimpleStorage {
   getItem(key: string): any;
   setItem(key: string, value: any): void;
   removeItem?: (key: string) => void;
+  isSharedStorage?(): boolean;
 }
 
 export interface StorageProvider extends SimpleStorage {
@@ -33,6 +34,7 @@ export interface StorageProvider extends SimpleStorage {
   getStorage(): any;
   clearStorage(key?: string): void;
   updateStorage(key: string, value: any): void;
+  isSharedStorage(): boolean;
 }
 
 // will be removed in next version. OKTA-362589

--- a/lib/types/TokenManager.ts
+++ b/lib/types/TokenManager.ts
@@ -11,7 +11,8 @@ export interface TokenManagerError {
 
 export declare type TokenManagerErrorEventHandler = (error: TokenManagerError) => void;
 export declare type TokenManagerEventHandler = (key: string, token: Token, oldtoken?: Token) => void;
-
+export declare type TokenManagerSetStorageEventHandler = (storage: Tokens) => void;
+export declare type TokenManagerAnyEventHandler = TokenManagerEventHandler | TokenManagerErrorEventHandler | TokenManagerSetStorageEventHandler;
 
 export declare type AccessTokenCallback = (key: string, token: AccessToken) => void;
 export declare type IDTokenCallback = (key: string, token: IDToken) => void;
@@ -19,8 +20,8 @@ export declare type RefreshTokenCallback = (key: string, token: RefreshToken) =>
 
 // only add methods needed internally
 export interface TokenManagerInterface {
-  on: (event: string, handler: TokenManagerErrorEventHandler | TokenManagerEventHandler, context?: object) => void;
-  off: (event: string, handler?: TokenManagerErrorEventHandler | TokenManagerEventHandler) => void;
+  on: (event: string, handler: TokenManagerAnyEventHandler, context?: object) => void;
+  off: (event: string, handler?: TokenManagerAnyEventHandler) => void;
   getTokensSync(): Tokens;
   setTokens({ accessToken, idToken, refreshToken }: Tokens, accessTokenCb?: AccessTokenCallback, idTokenCb?: IDTokenCallback, refreshTokenCb?: RefreshTokenCallback): void;
   getStorageKeyByType(type: TokenType): string;

--- a/lib/types/TokenManager.ts
+++ b/lib/types/TokenManager.ts
@@ -9,19 +9,37 @@ export interface TokenManagerError {
   tokenKey: string;
 }
 
-export declare type TokenManagerErrorEventHandler = (error: TokenManagerError) => void;
-export declare type TokenManagerEventHandler = (key: string, token: Token, oldtoken?: Token) => void;
-export declare type TokenManagerSetStorageEventHandler = (storage: Tokens) => void;
-export declare type TokenManagerAnyEventHandler = TokenManagerEventHandler | TokenManagerErrorEventHandler | TokenManagerSetStorageEventHandler;
-
 export declare type AccessTokenCallback = (key: string, token: AccessToken) => void;
 export declare type IDTokenCallback = (key: string, token: IDToken) => void;
 export declare type RefreshTokenCallback = (key: string, token: RefreshToken) => void;
 
+export const EVENT_EXPIRED = 'expired';
+export const EVENT_RENEWED = 'renewed';
+export const EVENT_ADDED = 'added';
+export const EVENT_REMOVED = 'removed';
+export const EVENT_ERROR = 'error';
+export const EVENT_SET_STORAGE = 'set_storage';
+
+export declare type TokenManagerErrorEventHandler = (error: TokenManagerError) => void;
+export declare type TokenManagerEventHandler = (key: string, token: Token) => void;
+export declare type TokenManagerRenewEventHandler = (key: string, token: Token, oldtoken: Token) => void;
+export declare type TokenManagerSetStorageEventHandler = (storage: Tokens) => void;
+
+export declare type TokenManagerAnyEventHandler = TokenManagerErrorEventHandler | TokenManagerRenewEventHandler | TokenManagerSetStorageEventHandler | TokenManagerEventHandler;
+export declare type TokenManagerAnyEvent = typeof EVENT_RENEWED | typeof EVENT_ERROR | typeof EVENT_SET_STORAGE | typeof EVENT_EXPIRED | typeof EVENT_ADDED | typeof EVENT_REMOVED;
+
 // only add methods needed internally
 export interface TokenManagerInterface {
-  on: (event: string, handler: TokenManagerAnyEventHandler, context?: object) => void;
-  off: (event: string, handler?: TokenManagerAnyEventHandler) => void;
+  on(event: typeof EVENT_RENEWED, handler: TokenManagerRenewEventHandler, context?: object): void;
+  on(event: typeof EVENT_ERROR, handler: TokenManagerErrorEventHandler, context?: object): void;
+  on(event: typeof EVENT_SET_STORAGE, handler: TokenManagerSetStorageEventHandler, context?: object): void;
+  on(event: typeof EVENT_EXPIRED | typeof EVENT_ADDED | typeof EVENT_REMOVED, handler: TokenManagerEventHandler, context?: object): void;
+
+  off(event: typeof EVENT_RENEWED, handler?: TokenManagerRenewEventHandler): void;
+  off(event: typeof EVENT_ERROR, handler?: TokenManagerErrorEventHandler): void;
+  off(event: typeof EVENT_SET_STORAGE, handler?: TokenManagerSetStorageEventHandler): void;
+  off(event: typeof EVENT_EXPIRED | typeof EVENT_ADDED | typeof EVENT_REMOVED, handler?: TokenManagerEventHandler): void;
+
   getTokensSync(): Tokens;
   setTokens({ accessToken, idToken, refreshToken }: Tokens, accessTokenCb?: AccessTokenCallback, idTokenCb?: IDTokenCallback, refreshTokenCb?: RefreshTokenCallback): void;
   getStorageKeyByType(type: TokenType): string;

--- a/polyfill/index.js
+++ b/polyfill/index.js
@@ -13,11 +13,18 @@
 
 // Polyfills objects needed to support IE 11+
 require('core-js/features/object/assign');
+require('core-js/features/object/keys');
 require('core-js/features/object/values');
 require('core-js/features/object/from-entries');
+require('core-js/features/object/entries');
+require('core-js/features/object/iterate-entries');
+require('core-js/features/object/iterate-keys');
+require('core-js/features/object/iterate-values');
+require('core-js/features/symbol/iterator');
 require('core-js/es/promise');
 require('core-js/es/typed-array/uint8-array');
 require('core-js/features/array/from');
+require('core-js/features/array/includes');
 require('core-js/web/url');
 require('webcrypto-shim');
 

--- a/samples/generated/static-spa/public/app.js
+++ b/samples/generated/static-spa/public/app.js
@@ -505,7 +505,9 @@ function showRedirectButton() {
 
 function logout(e) {
   e.preventDefault();
-  appState = {};
+  appState = {
+    signedOut: true
+  };
   // Normally tokens are cleared after redirect. For in-memory storage we should clear before.
   const clearTokensBeforeRedirect = config.storage === 'memory';
   authClient.signOut({ clearTokensBeforeRedirect });
@@ -552,6 +554,11 @@ function shouldRedirectToGetTokens(authState) {
     // AuthState error. This can happen when an exception is thrown inside transformAuthState.
     // Return false to break a potential infinite loop
     if (authState.error) {
+      return false;
+    }
+
+    // Don't acquire tokens during signing out
+    if (appState.signedOut) {
       return false;
     }
 

--- a/samples/generated/webpack-spa/src/index.js
+++ b/samples/generated/webpack-spa/src/index.js
@@ -504,7 +504,9 @@ function showRedirectButton() {
 
 function logout(e) {
   e.preventDefault();
-  appState = {};
+  appState = {
+    signedOut: true
+  };
   // Normally tokens are cleared after redirect. For in-memory storage we should clear before.
   const clearTokensBeforeRedirect = config.storage === 'memory';
   authClient.signOut({ clearTokensBeforeRedirect });
@@ -551,6 +553,11 @@ function shouldRedirectToGetTokens(authState) {
     // AuthState error. This can happen when an exception is thrown inside transformAuthState.
     // Return false to break a potential infinite loop
     if (authState.error) {
+      return false;
+    }
+
+    // Don't acquire tokens during signing out
+    if (appState.signedOut) {
       return false;
     }
 

--- a/samples/templates/partials/spa/app.js
+++ b/samples/templates/partials/spa/app.js
@@ -290,7 +290,9 @@ function showRedirectButton() {
 
 function logout(e) {
   e.preventDefault();
-  appState = {};
+  appState = {
+    signedOut: true
+  };
   // Normally tokens are cleared after redirect. For in-memory storage we should clear before.
   const clearTokensBeforeRedirect = config.storage === 'memory';
   authClient.signOut({ clearTokensBeforeRedirect });

--- a/samples/templates/partials/spa/authMethod/redirect.js
+++ b/samples/templates/partials/spa/authMethod/redirect.js
@@ -20,6 +20,11 @@ function shouldRedirectToGetTokens(authState) {
       return false;
     }
 
+    // Don't acquire tokens during signing out
+    if (appState.signedOut) {
+      return false;
+    }
+
     // Call Okta to get tokens. Okta will redirect back to this app
     // The callback is handled by `handleLoginRedirect` which will call `renderApp` again
     return true;

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -881,7 +881,7 @@ class TestApp {
   }
 
   appHTML(props: Tokens): string {
-    if (window.location.pathname.includes('/protected')) {
+    if (window.location.pathname.indexOf('/protected') != -1) {
       return this.appProtectedHTML();
     }
 

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -281,10 +281,14 @@ class TestApp {
   }
 
   subscribeToTokenEvents(): void {
-    ['expired', 'added', 'removed'].forEach(event => {
-      this.oktaAuth.tokenManager.on(event, (arg1: unknown) => {
-        console.log(`TokenManager::${event}`, arg1);
-      });
+    this.oktaAuth.tokenManager.on('added', (arg1: unknown) => {
+      console.log(`TokenManager::added`, arg1);
+    });
+    this.oktaAuth.tokenManager.on('removed', (arg1: unknown) => {
+      console.log(`TokenManager::removed`, arg1);
+    });
+    this.oktaAuth.tokenManager.on('expired', (arg1: unknown) => {
+      console.log(`TokenManager::expired`, arg1);
     });
     this.oktaAuth.tokenManager.on('renewed', (arg1: unknown, arg2: unknown) => {
       console.log(`TokenManager::renewed`, arg1, arg2);

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -281,10 +281,13 @@ class TestApp {
   }
 
   subscribeToTokenEvents(): void {
-    ['expired', 'renewed', 'added', 'removed'].forEach(event => {
-      this.oktaAuth.tokenManager.on(event, (arg1: unknown, arg2?: unknown) => {
-        console.log(`TokenManager::${event}`, arg1, arg2);
+    ['expired', 'added', 'removed'].forEach(event => {
+      this.oktaAuth.tokenManager.on(event, (arg1: unknown) => {
+        console.log(`TokenManager::${event}`, arg1);
       });
+    });
+    this.oktaAuth.tokenManager.on('renewed', (arg1: unknown, arg2: unknown) => {
+      console.log(`TokenManager::renewed`, arg1, arg2);
     });
     this.oktaAuth.tokenManager.on('error', (err: unknown) => {
       console.log('TokenManager::error', err);

--- a/test/apps/app/src/window.ts
+++ b/test/apps/app/src/window.ts
@@ -136,7 +136,7 @@ Object.assign(window, {
           syncStorage: config?.tokenManager?.syncStorage,
         };
         config.services = {
-          broadcastChannelName: config.clientId + '_crossTabTest'
+          electionChannelName: config.clientId + '_crossTabTest'
         };
         config.isTokenRenewPage = true;
     

--- a/test/e2e/specs/authRequired.js
+++ b/test/e2e/specs/authRequired.js
@@ -42,6 +42,7 @@ describe('auth required', () => {
     await openPKCE({}, true);
     await switchToSecondWindow();
     await TestApp.waitForLogoutBtn();
+    await TestApp.startService();
     await TestApp.logoutRedirect();
     await TestApp.assertLoggedOut();
     await browser.closeWindow();

--- a/test/spec/AuthStateManager.js
+++ b/test/spec/AuthStateManager.js
@@ -143,7 +143,7 @@ describe('AuthStateManager', () => {
         await channel.postMessage({
           type: 'added',
           key: 'idToken',
-          token: 'fake_id_token'
+          token: tokens.standardIdToken2Parsed
         });
         expect(auth.authStateManager.updateAuthState).toHaveBeenCalledTimes(1);
         auth.tokenManager.stop();

--- a/test/spec/AuthStateManager.js
+++ b/test/spec/AuthStateManager.js
@@ -10,12 +10,12 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-
-/* global window, StorageEvent */
+/* global window */
 
 import Emitter from 'tiny-emitter';
 import { AuthStateManager, INITIAL_AUTH_STATE } from '../../lib/AuthStateManager';
 import { AuthSdkError } from '../../lib/errors';
+import { BroadcastChannel } from 'broadcast-channel';
 import { OktaAuth } from '@okta/okta-auth-js';
 import tokens from '@okta/test.support/tokens';
 import util from '@okta/test.support/util';
@@ -28,7 +28,10 @@ function createAuth() {
     redirectUri: 'https://example.com/redirect',
     tokenManager: {
       autoRenew: false,
-      autoRemove: false,
+      autoRemove: false
+    },
+    services: {
+      syncChannelName: 'syncChannel'
     }
   });
 }
@@ -131,20 +134,18 @@ describe('AuthStateManager', () => {
       }
       it('should only trigger authStateManager.updateAuthState once when localStorage changed from other dom', async () => {
         util.disableLeaderElection();
-        jest.useFakeTimers();
         const auth = createAuth();
         auth.authStateManager.updateAuthState = jest.fn();
         auth.tokenManager.start(); // uses TokenService / crossTabs
-        await auth.serviceManager.start();
-        // simulate localStorage change from other dom context
-        window.dispatchEvent(new StorageEvent('storage', {
-          key: 'okta-token-storage', 
-          newValue: '{"idToken": "fake_id_token"}',
-          oldValue: '{}'
-        }));
-        jest.runAllTimers();
+        auth.serviceManager.start();
+        // simulate change from other dom context
+        const channel = new BroadcastChannel('syncChannel');
+        await channel.postMessage({
+          type: 'added',
+          key: 'idToken',
+          token: 'fake_id_token'
+        });
         expect(auth.authStateManager.updateAuthState).toHaveBeenCalledTimes(1);
-        jest.useRealTimers();
         auth.tokenManager.stop();
         await auth.serviceManager.stop();
       });

--- a/test/spec/AuthStateManager.js
+++ b/test/spec/AuthStateManager.js
@@ -137,7 +137,7 @@ describe('AuthStateManager', () => {
         const auth = createAuth();
         auth.authStateManager.updateAuthState = jest.fn();
         auth.tokenManager.start(); // uses TokenService / crossTabs
-        auth.serviceManager.start();
+        await auth.serviceManager.start();
         // simulate change from other dom context
         const channel = new BroadcastChannel('syncChannel');
         await channel.postMessage({

--- a/test/spec/OktaAuth/api.ts
+++ b/test/spec/OktaAuth/api.ts
@@ -47,20 +47,20 @@ describe('OktaAuth (api)', function() {
     });
 
     describe('start', () => {
-      it('starts the token service', () => {
+      it('starts the token service', async () => {
         jest.spyOn(auth.tokenManager, 'start');
-        auth.start();
+        await auth.start();
         expect(auth.tokenManager.start).toHaveBeenCalled(); 
       });
-      it('updates auth state', () => {
+      it('updates auth state', async () => {
         jest.spyOn(auth.authStateManager, 'updateAuthState');
-        auth.start();
+        await auth.start();
         expect(auth.authStateManager.updateAuthState).toHaveBeenCalled(); 
       });
-      it('should not update auth state during login redirect', () => {
+      it('should not update auth state during login redirect', async () => {
         jest.spyOn(auth.authStateManager, 'updateAuthState');
         jest.spyOn(auth.token, 'isLoginRedirect').mockReturnValue(true);
-        auth.start();
+        await auth.start();
         expect(auth.authStateManager.updateAuthState).not.toHaveBeenCalled(); 
       });
     });

--- a/test/spec/ServiceManager.ts
+++ b/test/spec/ServiceManager.ts
@@ -24,6 +24,7 @@ jest.mock('../../lib/services/LeaderElectionService', () => {
       this.options = options;
     }
     canStart() { return true; }
+    requiresLeadership() { return false; }
     isStarted() { return this.started; }
     start() { this.started = true; }
     stop() { this.started = false; }

--- a/test/spec/ServiceManager.ts
+++ b/test/spec/ServiceManager.ts
@@ -205,6 +205,31 @@ describe('ServiceManager', () => {
     await client.serviceManager.stop();
   });
 
+  it('sets default channel names', () => {
+    const client = createAuth({});
+    const serviceManagerOptions = (client.serviceManager as any).options;
+    expect(serviceManagerOptions.electionChannelName).toEqual('NPSfOkH5eZrTy8PMDlvx-election');
+    expect(serviceManagerOptions.syncChannelName).toEqual('NPSfOkH5eZrTy8PMDlvx-sync');
+  });
+
+  it('can set channel name for leader election with `services.electionChannelName`', () => {
+    const options = {
+      services: { electionChannelName: 'test-election-channel' }
+    };
+    const client = createAuth(options);
+    const serviceManagerOptions = (client.serviceManager as any).options;
+    expect(serviceManagerOptions.electionChannelName).toEqual('test-election-channel');
+  });
+
+  it('can set channel name for sync service with `services.syncChannelName`', () => {
+    const options = {
+      services: { syncChannelName: 'test-sync-channel' }
+    };
+    const client = createAuth(options);
+    const serviceManagerOptions = (client.serviceManager as any).options;
+    expect(serviceManagerOptions.syncChannelName).toEqual('test-sync-channel');
+  });
+
   // TODO: remove in next major version - OKTA-473815
   describe('Backwards Compatibility', () => {
     it('`services` will supersede `tokenManager` configurations', async () => {

--- a/test/spec/ServiceManager.ts
+++ b/test/spec/ServiceManager.ts
@@ -205,6 +205,7 @@ describe('ServiceManager', () => {
     await client.serviceManager.stop();
   });
 
+  // TODO: remove in next major version - OKTA-473815
   describe('Backwards Compatibility', () => {
     it('`services` will supersede `tokenManager` configurations', async () => {
       const options = {
@@ -215,6 +216,15 @@ describe('ServiceManager', () => {
       util.disableLeaderElection();
       await client.serviceManager.start();
       expect(client.serviceManager.getService('autoRenew')?.isStarted()).toBeFalsy();
+    });
+
+    it('`services` supports `broadcastChannelName` as old name for `electionChannelName`', () => {
+      const options = {
+        services: { broadcastChannelName: 'test-channel' }
+      };
+      const client = createAuth(options);
+      const serviceManagerOptions = (client.serviceManager as any).options;
+      expect(serviceManagerOptions.electionChannelName).toEqual('test-channel');
     });
   });
 

--- a/test/spec/ServiceManager.ts
+++ b/test/spec/ServiceManager.ts
@@ -26,12 +26,12 @@ jest.mock('../../lib/services/LeaderElectionService', () => {
     canStart() { return true; }
     requiresLeadership() { return false; }
     isStarted() { return this.started; }
-    start() { this.started = true; }
-    stop() { this.started = false; }
+    async start() { this.started = true; }
+    async stop() { this.started = false; }
     isLeader() { return this._isLeader; }
     _setLeader() { this._isLeader = true; }
-    public onLeader() {
-      (this.options as any).onLeader?.();
+    async onLeader() {
+      await (this.options as any).onLeader?.();
     }
   }
   return {
@@ -67,128 +67,128 @@ describe('ServiceManager', () => {
   });
 
   describe('syncStorage', () => {
-    it('allows syncStorage for storage type "cookie"', () => {
+    it('allows syncStorage for storage type "cookie"', async () => {
       const options = { tokenManager: { syncStorage: true, storage: 'cookie' } };
       util.disableLeaderElection();
       const client = createAuth(options);
-      client.serviceManager.start();
+      await client.serviceManager.start();
       expect(client.serviceManager.getService('syncStorage')?.isStarted()).toBeTruthy();
-      client.serviceManager.stop();
+      await client.serviceManager.stop();
     });
   
-    it('allows syncStorage for storage type "localStorage"', () => {
+    it('allows syncStorage for storage type "localStorage"', async () => {
       const options = { tokenManager: { syncStorage: true, storage: 'localStorage' } };
       util.disableLeaderElection();
       const client = createAuth(options);
-      client.serviceManager.start();
+      await client.serviceManager.start();
       expect(client.serviceManager.getService('syncStorage')?.isStarted()).toBeTruthy();
-      client.serviceManager.stop();
+      await client.serviceManager.stop();
     });
   
-    it('NOT allows syncStorage for storage type "sessionStorage"', () => {
+    it('NOT allows syncStorage for storage type "sessionStorage"', async () => {
       const options = { tokenManager: { syncStorage: true, storage: 'sessionStorage' } };
       util.disableLeaderElection();
       const client = createAuth(options);
-      client.serviceManager.start();
+      await client.serviceManager.start();
       expect(client.serviceManager.getService('syncStorage')?.isStarted()).toBeFalsy();
-      client.serviceManager.stop();
+      await client.serviceManager.stop();
     });
   
-    it('NOT allows syncStorage for storage type "memory"', () => {
+    it('NOT allows syncStorage for storage type "memory"', async () => {
       const options = { tokenManager: { syncStorage: true, storage: 'memory' } };
       util.disableLeaderElection();
       const client = createAuth(options);
-      client.serviceManager.start();
+      await client.serviceManager.start();
       expect(client.serviceManager.getService('syncStorage')?.isStarted()).toBeFalsy();
-      client.serviceManager.stop();
+      await client.serviceManager.stop();
     });
   });
 
   describe('leaderElection', () => {
-    it('doesn\'t start leaderElection service if other services don\'t require leadership', () => {
+    it('doesn\'t start leaderElection service if other services don\'t require leadership', async () => {
       const options = { tokenManager: { syncStorage: false, autoRenew: true } };
       const client = createAuth(options);
-      client.serviceManager.start();
+      await client.serviceManager.start();
       expect(client.serviceManager.isLeaderRequired()).toBeFalsy();
       expect(client.serviceManager.getService('leaderElection')?.isStarted()).toBeFalsy();
-      client.serviceManager.stop();
+      await client.serviceManager.stop();
     });
   
-    it('starts leaderElection service if any service (autoRenew) requires leadership', () => {
+    it('starts leaderElection service if any service (autoRenew) requires leadership', async () => {
       const options = { tokenManager: { syncStorage: true, autoRenew: true } };
       const client = createAuth(options);
-      client.serviceManager.start();
+      await client.serviceManager.start();
       expect(client.serviceManager.isLeaderRequired()).toBeTruthy();
       expect(client.serviceManager.getService('leaderElection')?.isStarted()).toBeTruthy();
-      client.serviceManager.stop();
+      await client.serviceManager.stop();
     });
   });
 
   describe('autoRenew', () => {
-    it('starts syncStorage service for every tab, autoRenew service for leader tab (for syncStorage == true)', () => {
+    it('starts syncStorage service for every tab, autoRenew service for leader tab (for syncStorage == true)', async () => {
       const options = { tokenManager: { syncStorage: true, autoRenew: true } };
       const client1 = createAuth(options);
       const client2 = createAuth(options);
       util.disableLeaderElection();
       jest.spyOn(client1.serviceManager, 'isLeader').mockReturnValue(true);
       jest.spyOn(client2.serviceManager, 'isLeader').mockReturnValue(false);
-      client1.serviceManager.start();
-      client2.serviceManager.start();
+      await client1.serviceManager.start();
+      await client2.serviceManager.start();
       expect(client1.serviceManager.getService('autoRenew')?.isStarted()).toBeTruthy();
       expect(client2.serviceManager.getService('autoRenew')?.isStarted()).toBeFalsy();
       expect(client1.serviceManager.getService('syncStorage')?.isStarted()).toBeTruthy();
       expect(client2.serviceManager.getService('syncStorage')?.isStarted()).toBeTruthy();
-      client1.serviceManager.stop();
-      client2.serviceManager.stop();
+      await client1.serviceManager.stop();
+      await client2.serviceManager.stop();
     });
   
-    it('starts autoRenew service for every tab (for syncStorage == false)', () => {
+    it('starts autoRenew service for every tab (for syncStorage == false)', async () => {
       const options = { tokenManager: { syncStorage: false, autoRenew: true } };
       const client1 = createAuth(options);
       const client2 = createAuth(options);
       util.disableLeaderElection();
       jest.spyOn(client1.serviceManager, 'isLeader').mockReturnValue(true);
       jest.spyOn(client2.serviceManager, 'isLeader').mockReturnValue(false);
-      client1.serviceManager.start();
-      client2.serviceManager.start();
+      await client1.serviceManager.start();
+      await client2.serviceManager.start();
       expect(client1.serviceManager.getService('autoRenew')?.isStarted()).toBeTruthy();
       expect(client2.serviceManager.getService('autoRenew')?.isStarted()).toBeTruthy();
       expect(client1.serviceManager.getService('syncStorage')?.isStarted()).toBeFalsy();
       expect(client2.serviceManager.getService('syncStorage')?.isStarted()).toBeFalsy();
-      client1.serviceManager.stop();
-      client2.serviceManager.stop();
+      await client1.serviceManager.stop();
+      await client2.serviceManager.stop();
     });
   
-    it('starts no services for syncStorage == false and autoRenew == false', () => {
+    it('starts no services for syncStorage == false and autoRenew == false', async () => {
       const options = { tokenManager: { syncStorage: false, autoRenew: false } };
       const client1 = createAuth(options);
       const client2 = createAuth(options);
       util.disableLeaderElection();
       jest.spyOn(client1.serviceManager, 'isLeader').mockReturnValue(true);
       jest.spyOn(client2.serviceManager, 'isLeader').mockReturnValue(false);
-      client1.serviceManager.start();
-      client2.serviceManager.start();
+      await client1.serviceManager.start();
+      await client2.serviceManager.start();
       expect(client1.serviceManager.getService('autoRenew')?.isStarted()).toBeFalsy();
       expect(client2.serviceManager.getService('autoRenew')?.isStarted()).toBeFalsy();
       expect(client1.serviceManager.getService('syncStorage')?.isStarted()).toBeFalsy();
       expect(client2.serviceManager.getService('syncStorage')?.isStarted()).toBeFalsy();
-      client1.serviceManager.stop();
-      client2.serviceManager.stop();
+      await client1.serviceManager.stop();
+      await client2.serviceManager.stop();
     });
   
     it('starts autoRenew service after becoming leader (for syncStorage == true)', async () => {
       const options = { tokenManager: { syncStorage: true, autoRenew: true } };
       const client = createAuth(options);
-      client.serviceManager.start();
+      await client.serviceManager.start();
       expect(client.serviceManager.isLeader()).toBeFalsy();
       expect(client.serviceManager.getService('autoRenew')?.isStarted()).toBeFalsy();
       expect(client.serviceManager.getService('syncStorage')?.isStarted()).toBeTruthy();
       expect(client.serviceManager.getService('leaderElection')?.isStarted()).toBeTruthy();
       (client.serviceManager.getService('leaderElection') as any)?._setLeader();
-      (client.serviceManager.getService('leaderElection') as any)?.onLeader();
+      await (client.serviceManager.getService('leaderElection') as any)?.onLeader();
       expect(client.serviceManager.isLeader()).toBeTruthy();
       expect(client.serviceManager.getService('autoRenew')?.isStarted()).toBeTruthy();
-      client.serviceManager.stop();
+      await client.serviceManager.stop();
     });
   });
 

--- a/test/spec/TokenManager/core.ts
+++ b/test/spec/TokenManager/core.ts
@@ -700,7 +700,7 @@ describe('TokenManager', function() {
       jest.spyOn(client.tokenManager, 'emitRemoved');
       jest.spyOn(storageProvider, 'setItem');
       client.tokenManager.clearPendingRemoveTokens();
-      expect(storageProvider.setItem).toHaveBeenNthCalledWith(1, 'okta-token-storage', {});
+      expect(storageProvider.setItem).toHaveBeenNthCalledWith(1, 'okta-token-storage', '{}');
       expect(client.tokenManager.emitRemoved).toHaveBeenCalledTimes(2);
       expect(client.tokenManager.emitRemoved).toHaveBeenNthCalledWith(1, 'idToken', tokenStorage.idToken);
       expect(client.tokenManager.emitRemoved).toHaveBeenNthCalledWith(2, 'accessToken', tokenStorage.accessToken);

--- a/test/spec/TokenManager/core.ts
+++ b/test/spec/TokenManager/core.ts
@@ -684,23 +684,26 @@ describe('TokenManager', function() {
 
   describe('clearPendingRemoveTokens', () => {
     it('clears pending remove tokens', () => {
+      const tokenStorage = { 
+        idToken: { ...tokens.standardIdTokenParsed, pendingRemove: true },
+        accessToken: { ...tokens.standardAccessTokenParsed, pendingRemove: true } 
+      };
       const storageProvider = {
-        getItem: jest.fn().mockReturnValue(JSON.stringify({ 
-          idToken: { ...tokens.standardIdTokenParsed, pendingRemove: true },
-          accessToken: { ...tokens.standardAccessTokenParsed, pendingRemove: true } 
-        })),
-        setItem: jest.fn()
+        getItem: jest.fn().mockReturnValue(JSON.stringify(tokenStorage)),
+        setItem: jest.fn(),
       };
       setupSync({
         tokenManager: {
           storage: storageProvider
         }
       });
-      jest.spyOn(client.tokenManager, 'remove');
+      jest.spyOn(client.tokenManager, 'emitRemoved');
+      jest.spyOn(storageProvider, 'setItem');
       client.tokenManager.clearPendingRemoveTokens();
-      expect(client.tokenManager.remove).toHaveBeenCalledTimes(2);
-      expect(client.tokenManager.remove).toHaveBeenNthCalledWith(1, 'idToken');
-      expect(client.tokenManager.remove).toHaveBeenNthCalledWith(2, 'accessToken');
+      expect(storageProvider.setItem).toHaveBeenNthCalledWith(1, 'okta-token-storage', {});
+      expect(client.tokenManager.emitRemoved).toHaveBeenCalledTimes(2);
+      expect(client.tokenManager.emitRemoved).toHaveBeenNthCalledWith(1, 'idToken', tokenStorage.idToken);
+      expect(client.tokenManager.emitRemoved).toHaveBeenNthCalledWith(2, 'accessToken', tokenStorage.accessToken);
     });
   });
 

--- a/test/spec/services/LeaderElectionService.ts
+++ b/test/spec/services/LeaderElectionService.ts
@@ -1,0 +1,84 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+import { LeaderElectionService } from '../../../lib/services/LeaderElectionService';
+import { BroadcastChannel } from 'broadcast-channel';
+
+jest.mock('broadcast-channel', () => {
+  const actual = jest.requireActual('broadcast-channel');
+  class FakeBroadcastChannel {
+    close() {}
+  }
+  return {
+    createLeaderElection: actual.createLeaderElection,
+    BroadcastChannel: FakeBroadcastChannel
+  };
+});
+
+const mocked = {
+  broadcastChannel: require('broadcast-channel'),
+};
+
+describe('LeaderElectionService', () => {
+  let channel;
+  let service;
+  beforeEach(function() {
+    jest.useFakeTimers();
+    channel = null;
+    service = null;
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+    if (service) {
+      service.stop();
+    }
+    if (channel) {
+      channel.close();
+    }
+  });
+
+  function createService(options?) {
+    service = new LeaderElectionService({
+      ...options,
+      electionChannelName: 'electionChannel'
+    });
+    service.start();
+    channel = new BroadcastChannel('electionChannel');
+    return service;
+  }
+
+  it('can await leadership and then call onLeader', async () => {
+    // Become leader in 100ms
+    const mockedElector = {
+      isLeader: false,
+      awaitLeadership: () => new Promise(resolve => {
+        setTimeout(() => {
+          mockedElector.isLeader = true;
+          resolve();
+        }, 100);
+      }) as Promise<void>,
+      die: () => {},
+    };
+
+    const onLeader = jest.fn();
+    jest.spyOn(mocked.broadcastChannel, 'createLeaderElection').mockReturnValue(mockedElector);
+    const service = createService({ onLeader });
+    await Promise.resolve();
+    expect(onLeader).toHaveBeenCalledTimes(0);
+    expect(service.isLeader()).toBeFalsy();
+    jest.runAllTimers();
+    await Promise.resolve();
+    expect(onLeader).toHaveBeenCalledTimes(1);
+    expect(service.isLeader()).toBeTruthy();
+  });
+});

--- a/test/spec/services/SyncStorageService.ts
+++ b/test/spec/services/SyncStorageService.ts
@@ -13,6 +13,7 @@
 
 /* eslint-disable max-statements */
 
+import tokens from '@okta/test.support/tokens';
 import { TokenManager } from '../../../lib/TokenManager';
 import { SyncStorageService } from '../../../lib/services/SyncStorageService';
 import * as features from '../../../lib/features';
@@ -25,17 +26,24 @@ describe('SyncStorageService', () => {
   let instance;
   let channel;
   let service;
+  let storage;
+  let tokenStorage;
   beforeEach(function() {
     instance = null;
     channel = null;
     service = null;
     const emitter = new Emitter();
+    storage = {
+      idToken: tokens.standardIdTokenParsed
+    };
+    tokenStorage = {
+        getStorage: jest.fn().mockImplementation(() => storage),
+        setStorage: jest.fn().mockImplementation(() => {})
+    };
     sdkMock = {
       options: {},
       storageManager: {
-        getTokenStorage: jest.fn().mockReturnValue({
-          getStorage: jest.fn().mockReturnValue({})
-        }),
+        getTokenStorage: jest.fn().mockReturnValue(tokenStorage),
         getOptionsForSection: jest.fn().mockReturnValue({})
       },
       emitter
@@ -72,9 +80,9 @@ describe('SyncStorageService', () => {
     await channel.postMessage({
       type: 'added',
       key: 'idToken',
-      token: 'fake-idToken'
+      token: tokens.standardIdTokenParsed
     });
-    expect(sdkMock.emitter.emit).toHaveBeenCalledWith('added', 'idToken', 'fake-idToken');
+    expect(sdkMock.emitter.emit).toHaveBeenCalledWith('added', 'idToken', tokens.standardIdTokenParsed);
   });
 
   it('should emit "renewed" event if token is changed', async () => {
@@ -83,10 +91,10 @@ describe('SyncStorageService', () => {
     await channel.postMessage({
       type: 'renewed',
       key: 'idToken',
-      token: 'fake-idToken',
-      oldToken: 'old-fake-idToken'
+      token: tokens.standardIdToken2Parsed,
+      oldToken: tokens.standardIdTokenParsed
     });
-    expect(sdkMock.emitter.emit).toHaveBeenCalledWith('renewed', 'idToken', 'fake-idToken', 'old-fake-idToken');
+    expect(sdkMock.emitter.emit).toHaveBeenCalledWith('renewed', 'idToken', tokens.standardIdToken2Parsed, tokens.standardIdTokenParsed);
   });
 
   it('should emit "removed" event if token is removed', async () => {
@@ -95,9 +103,9 @@ describe('SyncStorageService', () => {
     await channel.postMessage({
       type: 'removed',
       key: 'idToken',
-      token: 'fake-idToken'
+      token: tokens.standardIdTokenParsed
     });
-    expect(sdkMock.emitter.emit).toHaveBeenCalledWith('removed', 'idToken', 'fake-idToken');
+    expect(sdkMock.emitter.emit).toHaveBeenCalledWith('removed', 'idToken', tokens.standardIdTokenParsed);
   });
 
 });

--- a/test/spec/services/SyncStorageService.ts
+++ b/test/spec/services/SyncStorageService.ts
@@ -117,7 +117,7 @@ describe('SyncStorageService', () => {
       expect(sdkMock.emitter.emit).toHaveBeenCalledWith('added', 'idToken', tokens.standardIdToken2Parsed);
     });
   
-    it('should emit "removed" event if new token is removed from another tab', async () => {
+    it('should emit "removed" event if token is removed from another tab', async () => {
       createInstance();
       jest.spyOn(sdkMock.emitter, 'emit');
       await channel.postMessage({
@@ -128,7 +128,7 @@ describe('SyncStorageService', () => {
       expect(sdkMock.emitter.emit).toHaveBeenCalledWith('removed', 'idToken', tokens.standardIdTokenParsed);
     });
   
-    it('should emit "renewed" event if new token is chnaged from another tab', async () => {
+    it('should emit "renewed" event if token is chnaged from another tab', async () => {
       createInstance();
       jest.spyOn(sdkMock.emitter, 'emit');
       await channel.postMessage({
@@ -140,7 +140,7 @@ describe('SyncStorageService', () => {
       expect(sdkMock.emitter.emit).toHaveBeenCalledWith('renewed', 'idToken', tokens.standardIdToken2Parsed, tokens.standardIdTokenParsed);
     });
 
-    it('should not post sync message to other tabs', async () => {
+    it('should not post "sync message" to other tabs', async () => {
       createInstance();
       const serviceChannel = (service as any).channel;
       jest.spyOn(serviceChannel, 'postMessage');
@@ -154,7 +154,7 @@ describe('SyncStorageService', () => {
   });
 
   describe('posting sync messages', () => {
-    it('should post "added" sync message', () => {
+    it('should post "added" sync message when new token is added', () => {
       createInstance();
       const serviceChannel = (service as any).channel;
       jest.spyOn(serviceChannel, 'postMessage');
@@ -166,7 +166,44 @@ describe('SyncStorageService', () => {
       });
     });
 
-    it('should not post set_storage event on storage change (for non-IE)', () => {
+    it('should post "removed" sync message when token is removed', () => {
+      createInstance();
+      const serviceChannel = (service as any).channel;
+      jest.spyOn(serviceChannel, 'postMessage');
+      tokenManager.remove('idToken');
+      expect(serviceChannel.postMessage).toHaveBeenCalledWith({
+        type: 'removed',
+        key: 'idToken',
+        token: tokens.standardIdTokenParsed
+      });
+    });
+
+    it('should post "removed", "added", "renewed" sync messages when token is changed', () => {
+      createInstance();
+      const serviceChannel = (service as any).channel;
+      jest.spyOn(serviceChannel, 'postMessage');
+      tokenManager.setTokens({
+        idToken: tokens.standardIdToken2Parsed
+      });
+      expect(serviceChannel.postMessage).toHaveBeenNthCalledWith(1, {
+        type: 'removed',
+        key: 'idToken',
+        token: tokens.standardIdTokenParsed
+      });
+      expect(serviceChannel.postMessage).toHaveBeenNthCalledWith(2, {
+        type: 'added',
+        key: 'idToken',
+        token: tokens.standardIdToken2Parsed
+      });
+      expect(serviceChannel.postMessage).toHaveBeenNthCalledWith(3, {
+        type: 'renewed',
+        key: 'idToken',
+        token: tokens.standardIdToken2Parsed,
+        oldToken: tokens.standardIdTokenParsed
+      });
+    });
+
+    it('should not post "set_storage" event on storage change (for non-IE)', () => {
       createInstance();
       const serviceChannel = (service as any).channel;
       jest.spyOn(serviceChannel, 'postMessage');

--- a/test/spec/services/SyncStorageService.ts
+++ b/test/spec/services/SyncStorageService.ts
@@ -12,21 +12,23 @@
 
 
 /* eslint-disable max-statements */
-/* global window, localStorage, StorageEvent */
 
 import { TokenManager } from '../../../lib/TokenManager';
 import { SyncStorageService } from '../../../lib/services/SyncStorageService';
 import * as features from '../../../lib/features';
+import { BroadcastChannel } from 'broadcast-channel';
 
 const Emitter = require('tiny-emitter');
 
 describe('SyncStorageService', () => {
   let sdkMock;
   let instance;
-  let syncInstance;
+  let channel;
+  let service;
   beforeEach(function() {
-    jest.useFakeTimers();
     instance = null;
+    channel = null;
+    service = null;
     const emitter = new Emitter();
     sdkMock = {
       options: {},
@@ -38,169 +40,64 @@ describe('SyncStorageService', () => {
       },
       emitter
     };
-    jest.spyOn(features, 'isIE11OrLess').mockReturnValue(false);
     jest.spyOn(features, 'isLocalhost').mockReturnValue(true);
   });
   afterEach(() => {
-    jest.useRealTimers();
     if (instance) {
       instance.stop();
     }
-    if (syncInstance) {
-      syncInstance.stop();
+    if (service) {
+      service.stop();
+    }
+    if (channel) {
+      channel.close();
     }
   });
 
   function createInstance(options?) {
     instance = new TokenManager(sdkMock, options);
     instance.start();
-    syncInstance = new SyncStorageService(instance, instance.getOptions());
-    syncInstance.start();
+    service = new SyncStorageService(instance, {
+      ...instance.getOptions(), 
+      syncChannelName: 'syncChannel'
+    });
+    service.start();
+    channel = new BroadcastChannel('syncChannel');
     return instance;
   }
 
-  it('should emit events and reset timeouts when storage event happen with token storage key', () => {
+  it('should emit "added" event if new token is added', async () => {
     createInstance();
-    instance.resetExpireEventTimeoutAll = jest.fn();
-    instance.emitEventsForCrossTabsStorageUpdate = jest.fn();
-    window.dispatchEvent(new StorageEvent('storage', {
-      key: 'okta-token-storage', 
-      newValue: 'fake_new_value',
-      oldValue: 'fake_old_value'
-    }));
-    jest.runAllTimers();
-    expect(instance.resetExpireEventTimeoutAll).toHaveBeenCalled();
-    expect(instance.emitEventsForCrossTabsStorageUpdate).toHaveBeenCalledWith('fake_new_value', 'fake_old_value');
+    jest.spyOn(sdkMock.emitter, 'emit');
+    await channel.postMessage({
+      type: 'added',
+      key: 'idToken',
+      token: 'fake-idToken'
+    });
+    expect(sdkMock.emitter.emit).toHaveBeenCalledWith('added', 'idToken', 'fake-idToken');
   });
-  it('should set options._storageEventDelay default to 1000 in isIE11OrLess env', () => {
-    jest.spyOn(features, 'isIE11OrLess').mockReturnValue(true);
+
+  it('should emit "renewed" event if token is changed', async () => {
     createInstance();
-    expect(instance.getOptions()._storageEventDelay).toBe(1000);
+    jest.spyOn(sdkMock.emitter, 'emit');
+    await channel.postMessage({
+      type: 'renewed',
+      key: 'idToken',
+      token: 'fake-idToken',
+      oldToken: 'old-fake-idToken'
+    });
+    expect(sdkMock.emitter.emit).toHaveBeenCalledWith('renewed', 'idToken', 'fake-idToken', 'old-fake-idToken');
   });
-  it('should use options._storageEventDelay from passed options', () => {
-    createInstance({ _storageEventDelay: 100 });
-    expect(instance.getOptions()._storageEventDelay).toBe(100);
-  });
-  it('should use options._storageEventDelay from passed options in isIE11OrLess env', () => {
-    jest.spyOn(features, 'isIE11OrLess').mockReturnValue(true);
-    createInstance({ _storageEventDelay: 100 });
-    expect(instance.getOptions()._storageEventDelay).toBe(100);
-  });
-  it('should handle storage change based on _storageEventDelay option', () => {
-    jest.spyOn(window, 'setTimeout');
-    createInstance({ _storageEventDelay: 500 });
-    instance.resetExpireEventTimeoutAll = jest.fn();
-    instance.emitEventsForCrossTabsStorageUpdate = jest.fn();
-    window.dispatchEvent(new StorageEvent('storage', {
-      key: 'okta-token-storage', 
-      newValue: 'fake_new_value',
-      oldValue: 'fake_old_value'
-    }));
-    expect(window.setTimeout).toHaveBeenCalledWith(expect.any(Function), 500);
-    jest.runAllTimers();
-    expect(instance.resetExpireEventTimeoutAll).toHaveBeenCalled();
-    expect(instance.emitEventsForCrossTabsStorageUpdate).toHaveBeenCalledWith('fake_new_value', 'fake_old_value');
-  });
-  it('should emit events and reset timeouts when localStorage.clear() has been called from other tabs', () => {
+
+  it('should emit "removed" event if token is removed', async () => {
     createInstance();
-    instance.resetExpireEventTimeoutAll = jest.fn();
-    instance.emitEventsForCrossTabsStorageUpdate = jest.fn();
-    // simulate localStorage.clear()
-    window.dispatchEvent(new StorageEvent('storage', {
-      key: null,
-      newValue: null,
-      oldValue: null
-    }));
-    jest.runAllTimers();
-    expect(instance.resetExpireEventTimeoutAll).toHaveBeenCalled();
-    expect(instance.emitEventsForCrossTabsStorageUpdate).toHaveBeenCalledWith(null, null);
+    jest.spyOn(sdkMock.emitter, 'emit');
+    await channel.postMessage({
+      type: 'removed',
+      key: 'idToken',
+      token: 'fake-idToken'
+    });
+    expect(sdkMock.emitter.emit).toHaveBeenCalledWith('removed', 'idToken', 'fake-idToken');
   });
-  it('should not call localStorage.setItem when token storage changed', () => {
-    createInstance();
-    // https://github.com/facebook/jest/issues/6798#issuecomment-440988627
-    jest.spyOn(window.localStorage.__proto__, 'setItem');
-    window.dispatchEvent(new StorageEvent('storage', {
-      key: 'okta-token-storage', 
-      newValue: 'fake_new_value',
-      oldValue: 'fake_old_value'
-    }));
-    expect(localStorage.setItem).not.toHaveBeenCalled();
-  });
-  it('should not emit events or reset timeouts if the key is not token storage key', () => {
-    createInstance();
-    instance.resetExpireEventTimeoutAll = jest.fn();
-    instance.emitEventsForCrossTabsStorageUpdate = jest.fn();
-    window.dispatchEvent(new StorageEvent('storage', {
-      key: 'fake-key', 
-      newValue: 'fake_new_value',
-      oldValue: 'fake_old_value'
-    }));
-    expect(instance.resetExpireEventTimeoutAll).not.toHaveBeenCalled();
-    expect(instance.emitEventsForCrossTabsStorageUpdate).not.toHaveBeenCalled();
-  });
-  it('should not emit events or reset timeouts if oldValue === newValue', () => {
-    createInstance();
-    instance.resetExpireEventTimeoutAll = jest.fn();
-    instance.emitEventsForCrossTabsStorageUpdate = jest.fn();
-    window.dispatchEvent(new StorageEvent('storage', {
-      key: 'okta-token-storage', 
-      newValue: 'fake_unchanged_value',
-      oldValue: 'fake_unchanged_value'
-    }));
-    expect(instance.resetExpireEventTimeoutAll).not.toHaveBeenCalled();
-    expect(instance.emitEventsForCrossTabsStorageUpdate).not.toHaveBeenCalled();
-  });
-  
-  describe('_emitEventsForCrossTabsStorageUpdate', () => {
-    it('should emit "added" event if new token is added', () => {
-      createInstance();
-      const newValue = '{"idToken": "fake-idToken"}';
-      const oldValue = null;
-      jest.spyOn(sdkMock.emitter, 'emit');
-      instance.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
-      expect(sdkMock.emitter.emit).toHaveBeenCalledWith('added', 'idToken', 'fake-idToken');
-    });
-    it('should emit "added" event if token is changed', () => {
-      createInstance();
-      const newValue = '{"idToken": "fake-idToken"}';
-      const oldValue = '{"idToken": "old-fake-idToken"}';
-      jest.spyOn(sdkMock.emitter, 'emit');
-      instance.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
-      expect(sdkMock.emitter.emit).toHaveBeenCalledWith('added', 'idToken', 'fake-idToken');
-    });
-    it('should emit two "added" event if two token are added', () => {
-      createInstance();
-      const newValue = '{"idToken": "fake-idToken", "accessToken": "fake-accessToken"}';
-      const oldValue = null;
-      jest.spyOn(sdkMock.emitter, 'emit');
-      instance.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
-      expect(sdkMock.emitter.emit).toHaveBeenNthCalledWith(1, 'added', 'idToken', 'fake-idToken');
-      expect(sdkMock.emitter.emit).toHaveBeenNthCalledWith(2, 'added', 'accessToken', 'fake-accessToken');
-    });
-    it('should not emit "added" event if oldToken equal to newToken', () => {
-      createInstance();
-      const newValue = '{"idToken": "fake-idToken"}';
-      const oldValue = '{"idToken": "fake-idToken"}';
-      jest.spyOn(sdkMock.emitter, 'emit');
-      instance.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
-      expect(sdkMock.emitter.emit).not.toHaveBeenCalled();
-    });
-    it('should emit "removed" event if token is removed', () => {
-      createInstance();
-      const newValue = null;
-      const oldValue = '{"idToken": "old-fake-idToken"}';
-      jest.spyOn(sdkMock.emitter, 'emit');
-      instance.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
-      expect(sdkMock.emitter.emit).toHaveBeenCalledWith('removed', 'idToken', 'old-fake-idToken');
-    });
-    it('should emit two "removed" event if two token are removed', () => {
-      createInstance();
-      const newValue = null;
-      const oldValue = '{"idToken": "fake-idToken", "accessToken": "fake-accessToken"}';
-      jest.spyOn(sdkMock.emitter, 'emit');
-      instance.emitEventsForCrossTabsStorageUpdate(newValue, oldValue);
-      expect(sdkMock.emitter.emit).toHaveBeenNthCalledWith(1, 'removed', 'idToken', 'fake-idToken');
-      expect(sdkMock.emitter.emit).toHaveBeenNthCalledWith(2, 'removed', 'accessToken', 'fake-accessToken');
-    });
-  });
+
 });

--- a/test/support/jest/jest.setup.js
+++ b/test/support/jest/jest.setup.js
@@ -29,3 +29,7 @@ global.TextEncoder = TextEncoder;
 
 // Suppress warning messages
 global.console.warn = function() {};
+
+// broadcast-channel should not detect node environment
+// https://github.com/pubkey/broadcast-channel/blob/master/src/util.js#L61
+process[Symbol.toStringTag] = 'Process';

--- a/test/support/util.js
+++ b/test/support/util.js
@@ -459,7 +459,7 @@ util.assertAuthSdkError = function (err, message) {
 };
 
 util.disableLeaderElection = function() {
-  jest.spyOn(ServiceManager, 'canUseLeaderElection').mockReturnValue(false);
+  jest.spyOn(ServiceManager.prototype, 'isLeaderRequired').mockReturnValue(false);
 };
 
 util.mockLeader = function() {


### PR DESCRIPTION
- Reimplement `SyncStorageService` (service to sync authState cross multiple tabs) with using `broadcast-channel` package instead of using `StorageEvent`
- Added `LeaderElectionService` (leader election code was a part of `ServiceManager`)

Internal ref: [OKTA-476153](https://oktainc.atlassian.net/browse/OKTA-476153)





Implementation notes:
---

_**Notes on broadcast-channel issues:**_
1. Error `Failed to execute 'postMessage' on 'BroadcastChannel': Channel is closed` .
See https://github.com/okta/okta-auth-js/issues/1174, https://github.com/okta/okta-react/issues/221, https://github.com/okta/okta-react/issues/232
Cause: broadcast-channel's leader election tries to post internal message after closing the channel.
Workaround: https://github.com/okta/okta-auth-js/blob/4f88408c6282944046576027a67e771be35c465d/lib/services/LeaderElectionService.ts#L72
2. Detection of Node environment in broadcast-channel is naive:
https://github.com/pubkey/broadcast-channel/blob/773fbc3477d246e96f7566b7ac5ff3164042204d/src/util.js#L61
This leads to wrongly selecting 'node' [method](https://github.com/pubkey/broadcast-channel#methods) (based on fs sockets) for broadcast-channel during unit tests. 
Causes tests flakiness. 
For downstream SDKs causes error `No useable method found in ["native","idb","localstorage"]`, see https://github.com/okta/okta-react/issues/224
Workaround: https://github.com/okta/okta-auth-js/blob/4f88408c6282944046576027a67e771be35c465d/test/support/jest/jest.setup.js#L33-L35

---

_**Notes on IE11**_
1. Test app was not working on IE11. Need to add polyfills:
https://github.com/okta/okta-auth-js/pull/1197/files#diff-a861a360629a870e92aba3e9458e109f96ad1c9512f8ff339b0a4072f7ce7d4c
(maybe replace multiple features with 'core-js/stable' ?)
And polyfill FormData: https://github.com/okta/okta-auth-js/pull/1197/files#diff-41fbe6af6c0cd49ffacdf69a8831d1a7327ea9d90849bd4bf95c27e6f6033ffcR210
2. IE11 has known issue with synchronization of `localStorage` across tabs. 
Partial workaround is to set empty event handler for `window.onstorage`: https://github.com/okta/okta-auth-js/pull/1197/files#diff-4190d70999a6d0023de331545bbec8ba4167f9d6d71faa196061946d5f8822d9R129
But it's not 100% working, sometimes you still get old value from LocalStorage.
So to fix this issue I've added a new type of event `EVENT_SET_STORAGE` in TokenManager (only for IE11) to update storage explicitly in other tabs.
https://github.com/okta/okta-auth-js/pull/1197/files#diff-f18cf5684cf053b7ffbc2723f4983f1a26432ef9eade50cbfa00a74a7793dedbR280
https://github.com/okta/okta-auth-js/pull/1197/files#diff-b3d0b7dbba2f28b35e943fe28c40cc6b832b43b2986d5d14dd1ce9b7d164f3deR134


---

_**Other notes**_
1. SyncStorageService works with `localStorage` and `cookie` storage. 
https://github.com/okta/okta-auth-js/pull/1197/files#diff-6d3aacb7a946c6ca690509a0cc75e9880e5ca6942803b7cdd4059a9ba9a31b2dR356
https://github.com/okta/okta-auth-js/pull/1197/files#diff-2128a2510aeabd863495fcf012a579ef877ad61544805295fff687cfce0728c4R55
