### PR TITLE
Added e2e test for scenarios 10.4.1, 10.4.3, 10.4.4

### DIFF
--- a/samples/test/features/security-questions-enrollment.feature
+++ b/samples/test/features/security-questions-enrollment.feature
@@ -74,6 +74,29 @@ Feature: Security Questions
       And the cell for the value of "email" is shown and contains her "email"
       And the cell for the value of "name" is shown and contains her "first name and last name"
 
+  Scenario: Mary Logs into the Sample App and enrolls in a predefined Security Question
+    Given she has an account with "active" state in the org
+    When she clicks the "login" button
+    Then she is redirected to the "Login" page
+    When she has inserted her username
+      And she has inserted her password
+      And her password is correct
+    When she submits the form
+    Then she is redirected to the "Select Authenticator" page
+    When she selects the "Security Question" factor
+      And she submits the form
+    Then she is redirected to the "Enroll security question authenticator" page
+      And she sees a radio option to "Choose a Security Question" or "Create my own security question"
+      And the option "Choose a Security Question" is selected
+      And she sees dropdown list of questions with the question "What is the food you least liked as a child?" is selected 
+      And she sees an input box to enter her answer
+      And she enters "Okta" in the answer
+      And she submits the form
+    Then she is redirected to the "Root" page
+      And she sees a table with her profile info
+      And the cell for the value of "email" is shown and contains her "email"
+      And the cell for the value of "name" is shown and contains her "first name and last name"
+
   Scenario: Mary Logs into the Sample App and enrolls in a custom Security Question
     Given she has an account with "active" state in the org
     When she clicks the "login" button

--- a/samples/test/features/security-questions-enrollment.feature
+++ b/samples/test/features/security-questions-enrollment.feature
@@ -73,3 +73,28 @@ Feature: Security Questions
       And she sees a table with her profile info
       And the cell for the value of "email" is shown and contains her "email"
       And the cell for the value of "name" is shown and contains her "first name and last name"
+
+  Scenario: Mary Logs into the Sample App and enrolls in a custom Security Question
+    Given she has an account with "active" state in the org
+    When she clicks the "login" button
+    Then she is redirected to the "Login" page
+    When she has inserted her username
+      And she has inserted her password
+      And her password is correct
+    When she submits the form
+    Then she is redirected to the "Select Authenticator" page
+    When she selects the "Security Question" factor
+      And she submits the form
+    Then she is redirected to the "Enroll security question authenticator" page
+      And she sees a radio option to "Choose a Security Question" or "Create my own security question"
+      And the option "Choose a Security Question" is selected
+    When she selects the radio option to "Create my own security question"
+    Then she sees the dropdown list change to an input box to "Create my own security question"
+      And she enters "Atko" in the question
+      And she enters "Okta" in the answer
+      And she submits the form
+    Then she is redirected to the "Root" page
+      And she sees a table with her profile info
+      And the cell for the value of "email" is shown and contains her "email"
+      And the cell for the value of "name" is shown and contains her "first name and last name"
+    

--- a/samples/test/features/security-questions-enrollment.feature
+++ b/samples/test/features/security-questions-enrollment.feature
@@ -11,6 +11,37 @@ Feature: Security Questions
       And a user named "Mary"
       And she does not have account in the org
 
+  Scenario: Mary signs up for an account and enrolls in Password and a predefined Security Question
+    When she clicks the 'signup' button
+    Then she is redirected to the "Self Service Registration" page
+    When she fills out her First Name
+      And she fills out her Last Name
+      And she fills out her Email
+      And she submits the form
+    Then she is redirected to the "Select Authenticator" page
+    When she selects the "Password" factor
+      And she submits the form
+    Then she is redirected to the "Set up Password" page
+      And she fills out her Password
+      And she confirms her Password
+      And she submits the form
+    Then she is redirected to the "Select Authenticator" page
+    When she selects the "Security Question" factor
+      And she submits the form
+    Then she is redirected to the "Enroll security question authenticator" page
+      And she sees a radio option to "Choose a Security Question" or "Create my own security question"
+      And the option "Choose a Security Question" is selected
+      And she sees dropdown list of questions with the question "What is the food you least liked as a child?" is selected 
+      And she sees an input box to enter her answer
+      And she enters "Okta" in the answer
+      And she submits the form
+    Then she is redirected to the "Select Authenticator" page
+    When she selects "Skip" on Email
+    Then she is redirected to the "Root" page
+      And she sees a table with her profile info
+      And the cell for the value of "email" is shown and contains her "email"
+      And the cell for the value of "name" is shown and contains her "first name and last name"
+
   Scenario: Mary signs up for an account and enrolls in Password and a custom Security Question
     When she clicks the 'signup' button
     Then she is redirected to the "Self Service Registration" page
@@ -42,4 +73,3 @@ Feature: Security Questions
       And she sees a table with her profile info
       And the cell for the value of "email" is shown and contains her "email"
       And the cell for the value of "name" is shown and contains her "first name and last name"
-    

--- a/samples/test/steps/then.ts
+++ b/samples/test/steps/then.ts
@@ -33,8 +33,10 @@ import { camelize } from '../util';
 import checkEnrollMethods from '../support/check/checkEnrollMethods';
 import checkSelectedEnrollMethod from '../support/check/checkSelectedEnrollMethod';
 import checkCustomSecurityQuestion from '../support/check/checkCustomSecurityQuestion';
+import checkQuestionAnswerDisplayed from '../support/check/checkQuestionAnswerDisplayed';
 import enterCustomQuestion from '../support/action/enterCustomQuestion';
 import enterQuestionAnswer from '../support/action/enterQuestionAnswer';
+import selectSecurityQuestion from '../support/action/selectSecurityQuestion';
 
 Then('she is redirected to the {string} page', checkIsOnPage);
 
@@ -221,6 +223,16 @@ Then(
 Then(
   'she sees the dropdown list change to an input box to "Create my own security question"',
   () => checkCustomSecurityQuestion()
+);
+
+Then(
+  'she sees dropdown list of questions with the question {string} is selected',
+  (option: string) => selectSecurityQuestion(option)
+);
+
+Then(
+  'she sees an input box to enter her answer',
+  () => checkQuestionAnswerDisplayed()
 );
 
 Then(

--- a/samples/test/support/action/selectSecurityQuestion.ts
+++ b/samples/test/support/action/selectSecurityQuestion.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+import EnrollSecurityQuestion from '../selectors/EnrollSecurityQuestion';
+import selectOption from './selectOption';
+
+export default async (question: string) => {
+    await selectOption('text', question, EnrollSecurityQuestion.predefinedQuestions);
+};

--- a/samples/test/support/check/checkQuestionAnswerDisplayed.ts
+++ b/samples/test/support/check/checkQuestionAnswerDisplayed.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+import EnrollSecurityQuestion from '../selectors/EnrollSecurityQuestion';
+import isDisplayed from './isDisplayed';
+
+export default async () => {
+  const selector = EnrollSecurityQuestion.answer;
+  await isDisplayed(selector, false);
+};

--- a/samples/test/support/selectors/EnrollSecurityQuestion.ts
+++ b/samples/test/support/selectors/EnrollSecurityQuestion.ts
@@ -19,6 +19,7 @@ class EnrollSecurityQuestion extends PageWithTitle {
   get createQuestion() { return 'input[name="enroll-method"][value="create-question"]'; }
   get chooseQuestion() { return 'input[name="enroll-method"][value="choose-question"]'; }
   get customQuestion() { return '#security-question-question'; }
+  get predefinedQuestions() { return 'select[name="questionKey"]'; }
   get answer() { return '#security-question-answer'; }  
   get submit() { return '#submit-button';}
 


### PR DESCRIPTION
Added e2e tests for sample app for [scenarios](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2046692364/OIE+SDK+-+Cucumber+Features+and+Scenarios#Feature-10.4%3A-Security-Questions-NEW):
- 10.4.1: Mary signs up for an account and enrolls in Password and a predefined Security Question
Internal ref: [OKTA-448299](https://oktainc.atlassian.net/browse/OKTA-448299)
- 10.4.3: Mary Logs into the Sample App and enrolls in a predefined Security Question
Internal ref: [OKTA-456256](https://oktainc.atlassian.net/browse/OKTA-456256)
- 10.4.4: Mary Logs into the Sample App and enrolls in a custom Security Question
Internal ref: [OKTA-456257](https://oktainc.atlassian.net/browse/OKTA-456257)
