### PR TITLE
FixIT: Updates E2E tests to run them against new test org with OIE LGA flags

### DIFF
--- a/samples/config.js
+++ b/samples/config.js
@@ -100,6 +100,7 @@ const samples = [
       'self-service-registration-activation-token',
       'mfa-password-and-email',
       'mfa-password-and-email-magic-link',
+      'mfa-password-and-question',
       // This feature is not well defined and introduce flakiness, disable it
       // 'social-login-mfa',
       'social-idp',

--- a/samples/test/features/identifier-first-auth.feature
+++ b/samples/test/features/identifier-first-auth.feature
@@ -10,6 +10,7 @@ Feature: Login with Identifier First
       And a Policy that defines "MFA Enrollment" with properties
         | okta_password | OPTIONAL |
         | okta_email    | REQUIRED |
+      And with a Policy Rule that defines "MFA Enrollment Challenge"
       And a user named "Mary"
       And she has an account with "active" state in the org
 

--- a/samples/test/features/mfa-password-and-email-magic-link.feature
+++ b/samples/test/features/mfa-password-and-email-magic-link.feature
@@ -15,9 +15,10 @@ Feature: Multi-Factor Authentication with Password and Email Magic Link
       And she has inserted her password
       And her password is correct
     When she submits the form
-    Then she is redirected to the "Select Authenticator" page
-    When she selects the "Email" factor
-      And she submits the form
+    # ENG_REMEMBER_LAST_USED_FACTOR_OIE feature avoids these steps
+    # Then she is redirected to the "Select Authenticator" page
+    # When she selects the "Email" factor
+    #   And she submits the form
       And she clicks the Email magic link
     Then she is redirected to the "Root" page
       And she sees a table with her profile info

--- a/samples/test/features/mfa-password-and-email.feature
+++ b/samples/test/features/mfa-password-and-email.feature
@@ -13,9 +13,10 @@ Feature: Multi-Factor Authentication with Password and Email
     When she fills in her username
       And she fills in her correct password
       And she submits the form
-    Then she is redirected to the "Select Authenticator" page
-    When she selects the "Email" factor
-      And she submits the form
+    # ENG_REMEMBER_LAST_USED_FACTOR_OIE feature avoids these steps
+    # Then she is redirected to the "Select Authenticator" page
+    # When she selects the "Email" factor
+    #   And she submits the form
     Then she is redirected to the "Challenge email authenticator" page
     When she inputs an incorrect code
       And she submits the form
@@ -28,9 +29,10 @@ Feature: Multi-Factor Authentication with Password and Email
       And she has inserted her password
       And her password is correct
     When she submits the form
-    Then she is redirected to the "Select Authenticator" page
-    When she selects the "Email" factor
-      And she submits the form
+    # ENG_REMEMBER_LAST_USED_FACTOR_OIE feature avoids these steps
+    # Then she is redirected to the "Select Authenticator" page
+    # When she selects the "Email" factor
+    #   And she submits the form
     Then the screen changes to receive an input for a Email code
     When she inputs the correct code from her "Email"
       And she submits the form

--- a/samples/test/features/mfa-password-and-question.feature
+++ b/samples/test/features/mfa-password-and-question.feature
@@ -8,6 +8,7 @@ Feature: Multi-Factor Authentication with Password and Security Question
       And a Policy that defines "MFA Enrollment" with properties
         | okta_password | REQUIRED |
         | security_question  | REQUIRED |
+      And with a Policy Rule that defines "MFA Enrollment Challenge"
       And a user named "Mary"
       And she has an account with "active" state in the org
 
@@ -20,9 +21,11 @@ Feature: Multi-Factor Authentication with Password and Security Question
     When she submits the form
     Then she is redirected to the "Select Authenticator" page
     When She selects Security Question from the list
-    Then the screen changes to challenge the Security Question
-    When She inputs the correct answer for the Question
-      And she submits the form
+    Then she is redirected to the "Enroll security question authenticator" page
+      And she sees a radio option to "Choose a Security Question" or "Create my own security question"
+      And the option "Choose a Security Question" is selected
+    And she enters "Okta" in the answer
+    And she submits the form
     Then she is redirected to the "Root" page
       And she sees a table with her profile info
       And the cell for the value of "email" is shown and contains her "email"

--- a/samples/test/features/security-questions-enrollment.feature
+++ b/samples/test/features/security-questions-enrollment.feature
@@ -36,8 +36,6 @@ Feature: Security Questions
       And she enters "Atko" in the question
       And she enters "Okta" in the answer
       And she submits the form
-    Then she is redirected to the "Select Authenticator" page
-    When she selects "Skip" on Email
     Then she is redirected to the "Root" page
       And she sees a table with her profile info
       And the cell for the value of "email" is shown and contains her "email"

--- a/samples/test/features/self-service-password-recovery.feature
+++ b/samples/test/features/self-service-password-recovery.feature
@@ -7,7 +7,6 @@ Background:
     And a user named "Mary"
     And she has an account with "active" state in the org
 
-
   Scenario: Mary resets her password
     When she clicks the "login" button
     Then she is redirected to the "Login" page
@@ -15,10 +14,11 @@ Background:
     Then she is redirected to the "Self Service Password Reset" page
     When she inputs her correct Email
     And she submits the form
-    Then she is redirected to the "Select Authenticator" page
-    And password authenticator is not in options
-    When she selects the "Email" factor
-    And she submits the form
+    # ENG_REMEMBER_LAST_USED_FACTOR_OIE feature avoids these steps
+    # Then she is redirected to the "Select Authenticator" page
+    # And password authenticator is not in options
+    # When she selects the "Email" factor
+    # And she submits the form
     Then she sees a page to challenge her email authenticator
     When she inputs the correct code from her "Email"
     And she submits the form

--- a/samples/test/features/self-service-password-recovery.feature
+++ b/samples/test/features/self-service-password-recovery.feature
@@ -7,6 +7,7 @@ Background:
     And a user named "Mary"
     And she has an account with "active" state in the org
 
+
   Scenario: Mary resets her password
     When she clicks the "login" button
     Then she is redirected to the "Login" page

--- a/samples/test/features/self-service-registration.feature
+++ b/samples/test/features/self-service-registration.feature
@@ -21,9 +21,6 @@ Scenario: Mary signs up for an account with Password, setups up required Email f
   And she fills out her Password
   And she confirms her Password
   And she submits the form
-  Then she is redirected to the "Select Authenticator" page
-  When she selects the "Email" factor
-  And she submits the form
   Then she sees a page to input a code for email authenticator enrollment
   When she inputs the correct code from her "Email"
   And she submits the form
@@ -47,9 +44,6 @@ Scenario: Mary signs up for an account with Password, setups up required Email f
     And she fills out her Password
     And she confirms her Password
     And she submits the form
-  Then she is redirected to the "Select Authenticator" page
-  When she selects the "Email" factor
-    And she submits the form
   Then she sees a page to input a code for email authenticator enrollment
   When she inputs the correct code from her "Email"
     And she submits the form
@@ -62,6 +56,8 @@ Scenario: Mary signs up for an account with Password, setups up required Email f
   Then the screen changes to receive an input for a code
   When she inputs the correct code from her "SMS"
     And she submits the form
+  Then she is redirected to the "Select Authenticator" page
+  When she selects "Skip"
   Then she is redirected to the "Root" page
     And she sees a table with her profile info
     And the cell for the value of "email" is shown and contains her "email"
@@ -90,9 +86,6 @@ Scenario: Mary signs up for an account with Password, sets up required Email fac
   And she fills out her Password
   And she confirms her Password
   And she submits the form
-  Then she is redirected to the "Select Authenticator" page
-  When she selects the "Email" factor
-    And she submits the form
   Then she sees a page to input a code for email authenticator enrollment
   When she inputs the correct code from her "Email"
     And she submits the form

--- a/samples/test/features/totp-signup.feature
+++ b/samples/test/features/totp-signup.feature
@@ -34,8 +34,6 @@ Feature: TOTP Support (Google Authenticator) Sign Up
     Then the screen changes to receive an input for a code
     When she inputs the correct code from her Google Authenticator App for "enrollment"
       And she submits the form
-    Then she is redirected to the "Select Authenticator" page
-    When she selects "Skip"
     Then she is redirected to the "Root" page
       And she sees a table with her profile info
       And the cell for the value of "email" is shown and contains her "email"

--- a/samples/test/steps/when.ts
+++ b/samples/test/steps/when.ts
@@ -23,6 +23,7 @@ import selectAuthenticator from '../support/action/selectAuthenticator';
 import inputInvalidEmail from '../support/action/inputInvalidEmail';
 import enterRegistrationField from '../support/action/context-enabled/live-user/enterRegistrationField';
 import selectSmsAuthenticator from '../support/action/selectSmsAuthenticator';
+import selectSecurityQuestionAuthenticator from '../support/action/selectSecurityQuestionAuthenticator';
 import enterCorrectPhoneNumber from '../support/action/context-enabled/live-user/enterCorrectPhoneNumber';
 import selectVerifyBySms from '../support/action/selectVerifyBySms';
 import skipForm from '../support/action/skipForm';
@@ -290,4 +291,9 @@ When(
 When(
   /^She selects "Next"/,
   noop
+);
+
+When(
+  /^She selects Security Question from the list$/,
+  selectSecurityQuestionAuthenticator
 );

--- a/samples/test/support/action/selectSecurityQuestionAuthenticator.ts
+++ b/samples/test/support/action/selectSecurityQuestionAuthenticator.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+import checkIsOnPage from '../check/checkIsOnPage';
+import SelectAuthenticator from '../selectors/SelectAuthenticator';
+import clickElement from './clickElement';
+import selectOption from './selectOption';
+
+export default async () => {
+  await selectOption('value', 'security_question', SelectAuthenticator.options);
+  await clickElement('click', 'selector', SelectAuthenticator.submit);
+  await checkIsOnPage('Enroll security question authenticator');
+};

--- a/scripts/e2e-express-embedded-auth-with-sdk.sh
+++ b/scripts/e2e-express-embedded-auth-with-sdk.sh
@@ -16,10 +16,8 @@ export MAX_INSTANCES=2
 export SAMPLE_NAME=@okta/samples.express-embedded-auth-with-sdk
 export ORG_OIE_ENABLED=true 
 export USERNAME=mary@acme.com
-get_secret prod/okta-sdk-vars/password PASSWORD
+get_vault_secret_key devex/prod-js-idx-sdk-vars password PASSWORD
 get_vault_secret_key devex/auth-js-sdk-vars a18n_api_key A18N_API_KEY
-export FB_USERNAME=js_ekdtypn_user@tfbnw.net
-get_secret prod/okta-sdk-vars/fb_password FB_PASSWORD
 
 # If this script is run as a bacon task, run against trexcloud environment
 if [[ "${BACON_TASK}" == true ]]; then
@@ -30,24 +28,14 @@ if [[ "${BACON_TASK}" == true ]]; then
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_client_secret CLIENT_SECRET
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_idx_sdk_org_api_key OKTA_API_KEY
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_idx_idfirst_sdk_org_api_key OKTA_API_KEY_IDFIRST
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_id MFA_CLIENT_ID
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_secret MFA_CLIENT_SECRET
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_id CUSTOM_CLIENT_ID
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_secret CUSTOM_CLIENT_SECRET
 else
-  echo "Running tests against production (ok12) org"
-  export ISSUER=https://javascript-idx-sdk.okta.com
+  echo "Running tests against production (ok14) org"
+  export ISSUER=https://javascript-idx-sdk-new.okta.com
   export ISSUER_IDFIRST=https://javascript-idx-sdk-idfirst.okta.com
-  export CLIENT_ID=0oav2oxnlYjULp0Cy5d6
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_client_secret CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_idx_sdk_org_api_key OKTA_API_KEY
+  export CLIENT_ID=0oax3dcx0sak1KKb9696
+  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_client_secret_new CLIENT_SECRET
+  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_idx_sdk_org_api_key_new OKTA_API_KEY
   get_vault_secret_key devex/prod-js-idx-sdk-vars prod_idx_idfirst_sdk_org_api_key OKTA_API_KEY_IDFIRST
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_mfa_client_id MFA_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_mfa_client_secret MFA_CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_custom_client_id CUSTOM_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_custom_client_secret CUSTOM_CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_totp_client_id TOTP_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_totp_client_secret TOTP_CLIENT_SECRET
 fi
 
 # Run the tests


### PR DESCRIPTION
- Previous E2E Test org didn't have all OIE flags enabled (Since new flags were introduced after the org was created)
- Created a new E2E test org which has all necessary flags (Remember last used factor, password optional etc)
- Updated the tests to remove redundant steps due to new behavior (selecting email when it's the only authenticator)
- Added password + security question login test