### PR TITLE
fix: add stepUp to IdxTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.4.5
+
+- [#1240](https://github.com/okta/okta-auth-js/pull/1204) Fixes Apple SSO flow: includes `stepUp` on returned `IdxTransaction`
+
 ## 6.4.4
 
 - [#1199](https://github.com/okta/okta-auth-js/pull/1199) Fixes webauthn enrollment/verification to accept `credentials` object

--- a/lib/idx/run.ts
+++ b/lib/idx/run.ts
@@ -343,8 +343,8 @@ export async function run(
     }
   }
   
-  // from idx-js, used by the widget
-  const { actions, context, neededToProceed, proceed, rawIdxState, requestDidSucceed } = idxResponse || {};
+  // copy all fields from idxResponse which are needed by the widget
+  const { actions, context, neededToProceed, proceed, rawIdxState, requestDidSucceed, stepUp } = idxResponse || {};
   return {
     status: status!,
     ...(meta && { meta }),
@@ -354,6 +354,7 @@ export async function run(
     ...(nextStep && { nextStep }),
     ...(messages && messages.length && { messages }),
     ...(error && { error }),
+    ...(stepUp && { stepUp }),
     interactionCode, // if options.exchangeCodeForTokens is false
 
     // from idx-js

--- a/lib/idx/types/api.ts
+++ b/lib/idx/types/api.ts
@@ -87,7 +87,8 @@ export interface IdxTransaction {
   enabledFeatures?: IdxFeature[];
   availableSteps?: NextStep[];
   requestDidSucceed?: boolean;
-
+  stepUp?: boolean;
+  
   // from idx-js, used by signin widget
   proceed: (remediationName: string, params: unknown) => Promise<IdxResponse>;
   neededToProceed: IdxRemediation[];

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "6.4.4",
+  "version": "6.4.5",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "build/cjs/index.js",

--- a/test/spec/idx/run.ts
+++ b/test/spec/idx/run.ts
@@ -351,20 +351,39 @@ describe('idx/run', () => {
         expect(authClient.transactionManager.clear).not.toHaveBeenCalled();
       });
 
-      // Special case of an error response that can be continued
-      it('does save the idxResponse if stepUp is true', async () =>{
-        const { authClient, idxResponse, transactionMeta } = testContext;
-        idxResponse.requestDidSucceed = false;
-        idxResponse.stepUp = true;
-        jest.spyOn(authClient.transactionManager, 'saveIdxResponse');
-        await run(authClient);
-        expect(authClient.transactionManager.saveIdxResponse).toHaveBeenCalledWith({
-          rawIdxResponse: idxResponse.rawIdxState,
-          requestDidSucceed: false,
-          stateHandle: idxResponse.context.stateHandle,
-          interactionHandle: transactionMeta.interactionHandle
-        });
+      it('does not include "stepUp" on the returned transaction', async () => {
+        const { authClient } = testContext;
+        const res = await run(authClient);
+        expect(res.stepUp).toBe(undefined);
       });
+
+      // Special case of an error response that can be continued
+      describe('stepUp', () => {
+        beforeEach(() => {
+          const { idxResponse } = testContext;
+          idxResponse.stepUp = true;
+        });
+
+        it('does save the idxResponse', async () =>{
+          const { authClient, idxResponse, transactionMeta } = testContext;
+          jest.spyOn(authClient.transactionManager, 'saveIdxResponse');
+          await run(authClient);
+          expect(authClient.transactionManager.saveIdxResponse).toHaveBeenCalledWith({
+            rawIdxResponse: idxResponse.rawIdxState,
+            requestDidSucceed: false,
+            stateHandle: idxResponse.context.stateHandle,
+            interactionHandle: transactionMeta.interactionHandle
+          });
+        });
+
+        it('includes "stepUp" on the returned transaction', async () => {
+          const { authClient } = testContext;
+          const res = await run(authClient);
+          expect(res.stepUp).toBe(true);
+        });
+
+      });
+
     });
   });
 


### PR DESCRIPTION
Fixes Apple SSO flow with Okta Verify / FastPass: include `stepUp` on the returned `IdxTransaction` object if it is set on the `IdxResponse`