### PR TITLE
feat: add sdk level option for idx.exchangeCodeForTokens

### DIFF
--- a/lib/idx/run.ts
+++ b/lib/idx/run.ts
@@ -59,7 +59,9 @@ function initializeValues(options: RunOptions) {
     'remediators', 
     'actions', 
     'withCredentials', 
-    'step', 
+    'step',
+    'useGenericRemediator',
+    'exchangeCodeForTokens',
     'shouldProceedWithEmailAuthenticator'
   ];
   const values = { ...options };
@@ -70,13 +72,16 @@ function initializeValues(options: RunOptions) {
 }
 
 function initializeData(authClient, data: RunData): RunData {
-  const { options } = data;
+  let { options } = data;
+  options = {
+    ...authClient.options.idx,
+    ...options
+  };
   let {
     flow,
     withCredentials,
     remediators,
     actions,
-    useGenericRemediator
   } = options;
 
   const status = IdxStatus.PENDING;
@@ -92,8 +97,6 @@ function initializeData(authClient, data: RunData): RunData {
     actions = actions || flowSpec.actions;
   }
 
-  useGenericRemediator = useGenericRemediator || authClient.options.idx?.useGenericRemediator || false;
-
   return { 
     ...data,
     options: { 
@@ -102,7 +105,6 @@ function initializeData(authClient, data: RunData): RunData {
       withCredentials, 
       remediators, 
       actions,
-      useGenericRemediator
     },
     status
   };

--- a/lib/idx/types/api.ts
+++ b/lib/idx/types/api.ts
@@ -86,7 +86,6 @@ export interface IdxTransactionMeta extends PKCETransactionMeta {
   activationToken?: string;
   recoveryToken?: string;
   maxAge?: string | number;
-  useGenericRemediator?: boolean;
 }
 
 export interface IdxTransaction {

--- a/lib/options/index.ts
+++ b/lib/options/index.ts
@@ -79,7 +79,8 @@ export function buildOptions(args: OktaAuthOptions = {}): OktaAuthOptions {
     activationToken: args.activationToken,
     // BETA WARNING: configs in this section are subject to change without a breaking change notice
     idx: {
-      useGenericRemediator: !!args.idx?.useGenericRemediator,
+      useGenericRemediator: !!args.idx?.useGenericRemediator, // false by default
+      exchangeCodeForTokens: args.idx?.exchangeCodeForTokens !== false // true by default
     },
 
     // Give the developer the ability to disable token signature validation.

--- a/lib/types/OktaAuthOptions.ts
+++ b/lib/types/OktaAuthOptions.ts
@@ -15,7 +15,7 @@ import { CookieOptions } from './Cookies';
 import { HttpRequestClient } from './http';
 import { AuthState } from './AuthState';
 import { TransactionManagerOptions } from './Transaction';
-import { IdxTransactionMeta } from '../idx/types';
+import { IdxTransactionMeta, RunOptions } from '../idx/types';
 import { ServiceManagerOptions } from './Service';
 import OktaAuth from '../OktaAuth';
 import { OAuthResponseMode, OAuthResponseType } from './OAuth';
@@ -113,8 +113,9 @@ export interface OktaAuthOptions extends
   services?: ServiceManagerOptions;
   transactionManager?: TransactionManagerOptions;
   // BETA WARNING: configs in this section are subject to change without a breaking change notice
-  idx?: Pick<IdxTransactionMeta,
-    'useGenericRemediator' 
+  idx?: Pick<RunOptions,
+    'useGenericRemediator' |
+    'exchangeCodeForTokens'
   >;
   
   // For server-side web applications ONLY!

--- a/test/spec/idx/run.ts
+++ b/test/spec/idx/run.ts
@@ -226,6 +226,7 @@ describe('idx/run', () => {
       username,
       password,
       flow,
+      useGenericRemediator: true,
       shouldProceedWithEmailAuthenticator // will be removed in next major version
     };
     const values = { 
@@ -241,8 +242,8 @@ describe('idx/run', () => {
       actions,
       flow,
       flowMonitor,
+      useGenericRemediator: true,
       shouldProceedWithEmailAuthenticator, // will be removed in next major version
-      useGenericRemediator: false,
     });
   });
 
@@ -689,6 +690,31 @@ describe('idx/run', () => {
       },
       {
         'authorizeUrl': 'meta-authorizeUrl'
+      });
+    });
+
+    it('can disable call to `exchangeCodeForTokens` with `exchangeCodeForTokens` option passed directly', async () => {
+      const { authClient } = testContext;
+      jest.spyOn(authClient.token, 'exchangeCodeForTokens');
+      const res = await run(authClient, { exchangeCodeForTokens: false });
+      expect(authClient.token.exchangeCodeForTokens).not.toHaveBeenCalled();
+      expect(res).toMatchObject({
+        nextStep: 'remediate-nextStep',
+        status: IdxStatus.SUCCESS,
+        interactionCode: 'idx-interactionCode'
+      });
+    });
+
+    it('can disable call to `exchangeCodeForTokens` with `exchangeCodeForTokens` option passed to SDK', async () => {
+      const { authClient } = testContext;
+      authClient.options = { idx: { exchangeCodeForTokens: false }};
+      jest.spyOn(authClient.token, 'exchangeCodeForTokens');
+      const res = await run(authClient);
+      expect(authClient.token.exchangeCodeForTokens).not.toHaveBeenCalled();
+      expect(res).toMatchObject({
+        nextStep: 'remediate-nextStep',
+        status: IdxStatus.SUCCESS,
+        interactionCode: 'idx-interactionCode'
       });
     });
   });

--- a/test/spec/idx/startTransaction.ts
+++ b/test/spec/idx/startTransaction.ts
@@ -114,7 +114,6 @@ describe('idx/startTransaction', () => {
       idxResponse,
       // values
       {
-        exchangeCodeForTokens: false,
         stateHandle: 'unknown-stateHandle'
       },
       // flowMonitor


### PR DESCRIPTION
- also simplifies some logic with `useGenericRemediator`