### PR TITLE
fix: polling issue with using generic remediator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.5.2
+
+### Fixes
+
+- [#1215](https://github.com/okta/okta-auth-js/pull/1215) Fixes polling issue in GenericRemediator (beta)
+
 ## 6.5.1
 
 ### Fixes

--- a/lib/idx/remediate.ts
+++ b/lib/idx/remediate.ts
@@ -177,6 +177,20 @@ export async function remediate(
     // Let the remediator decide what the values should be (default to current values)
     values = remediator.getValuesAfterProceed();
     options = { ...options, step: undefined }; // do not re-use the step
+
+    // generic remediator should not auto proceed in pending status
+    // return nextStep directly
+    if (options.useGenericRemediator && !idxResponse.interactionCode) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const gr = getRemediator(idxResponse.neededToProceed, values, options)!;
+      const nextStep = getNextStep(authClient, gr, idxResponse);
+      return {
+        idxResponse,
+        nextStep,
+        messages: messages.length ? messages: undefined
+      };
+    }
+    
     return remediate(authClient, idxResponse, values, options); // recursive call
   } catch (e) {
     return handleIdxError(authClient, e, remediator);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "build/cjs/index.js",

--- a/test/spec/idx/remediate.ts
+++ b/test/spec/idx/remediate.ts
@@ -94,7 +94,7 @@ describe('idx/remediate', () => {
           });
           expect(util.getRemediator).toHaveBeenCalledTimes(2);
           expect(util.getRemediator).toHaveBeenNthCalledWith(1, idxResponse.neededToProceed, { resend: true }, {});
-          expect(util.getRemediator).toHaveBeenNthCalledWith(2, responseFromAction.neededToProceed, {}, { actions: []});
+          expect(util.getRemediator).toHaveBeenNthCalledWith(2, responseFromAction.neededToProceed, {}, { actions: [] });
         });
 
         it('will handle exceptions', async () => {
@@ -161,7 +161,7 @@ describe('idx/remediate', () => {
             },
             rawIdxState: {}
           } as unknown as IdxResponse;
-          const res = await remediate(authClient, idxResponse, { resend: true }, { actions: ['some-action']});
+          const res = await remediate(authClient, idxResponse, { resend: true }, { actions: ['some-action'] });
           expect(res).toEqual(errorResponse);
           expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, remediator);
         });
@@ -192,7 +192,7 @@ describe('idx/remediate', () => {
             nextStep: {}
           });
           expect(util.getRemediator).toHaveBeenCalledTimes(2);
-          expect(util.getRemediator).toHaveBeenNthCalledWith(1, idxResponse.neededToProceed, { }, { actions: ['some-remediation'] });
+          expect(util.getRemediator).toHaveBeenNthCalledWith(1, idxResponse.neededToProceed, {}, { actions: ['some-remediation'] });
           expect(util.getRemediator).toHaveBeenNthCalledWith(2, responseFromRemediation.neededToProceed, {}, { actions: [] });
         });
         it('will handle exceptions', async () => {
@@ -206,7 +206,7 @@ describe('idx/remediate', () => {
               name: 'some-remediation'
             }],
           } as unknown as IdxResponse;
-          const res = await remediate(authClient, idxResponse, {}, { actions: ['some-remediation']});
+          const res = await remediate(authClient, idxResponse, {}, { actions: ['some-remediation'] });
           expect(res).toBe(errorResponse);
           expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, remediator);
         });
@@ -295,7 +295,7 @@ describe('idx/remediate', () => {
             name: 'some-action',
             params: { foo: 'bar' }
           };
-          const res = await remediate(authClient, idxResponse, {}, { actions: [action]});
+          const res = await remediate(authClient, idxResponse, {}, { actions: [action] });
           expect(res).toBe(errorResponse);
           expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, remediator);
           expect(actionFn).toHaveBeenCalledWith({ foo: 'bar' });
@@ -330,7 +330,7 @@ describe('idx/remediate', () => {
             nextStep: {}
           });
           expect(util.getRemediator).toHaveBeenCalledTimes(2);
-          expect(util.getRemediator).toHaveBeenNthCalledWith(1, idxResponse.neededToProceed, { }, { actions: [action] });
+          expect(util.getRemediator).toHaveBeenNthCalledWith(1, idxResponse.neededToProceed, {}, { actions: [action] });
           expect(util.getRemediator).toHaveBeenNthCalledWith(2, responseFromRemediation.neededToProceed, {}, { actions: [] });
         });
         it('will handle exceptions', async () => {
@@ -347,7 +347,7 @@ describe('idx/remediate', () => {
           const action = {
             name: 'some-remediation'
           };
-          const res = await remediate(authClient, idxResponse, {}, { actions: [action]});
+          const res = await remediate(authClient, idxResponse, {}, { actions: [action] });
           expect(res).toBe(errorResponse);
           expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, remediator);
         });
@@ -420,27 +420,27 @@ describe('idx/remediate', () => {
           },
         });
         expect(util.getRemediator).toHaveBeenCalledTimes(1);
-        expect(util.getRemediator).toHaveBeenNthCalledWith(1, idxResponse.neededToProceed, { }, { step: 'some-remediation' });
+        expect(util.getRemediator).toHaveBeenNthCalledWith(1, idxResponse.neededToProceed, {}, { step: 'some-remediation' });
         expect(idxResponse.proceed).toHaveBeenCalledWith('some-remediation', {});
       });
       it('will handle exceptions', async () => {
         let { authClient, idxResponse } = testContext;
-          const { errorResponse } = testContext;
-          const error = new Error('my test error');
-          idxResponse = {
-            ...idxResponse,
-            proceed: jest.fn().mockRejectedValue(error),
-            neededToProceed: [{
-              name: 'some-remediation',
-              value: [{
-                name: 'foo'
-              }]
-            }],
-          } as unknown as IdxResponse;
-          const res = await remediate(authClient, idxResponse, {}, { step: 'some-remediation' });
-          expect(res).toBe(errorResponse);
-          expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error);
-          expect(idxResponse.proceed).toHaveBeenCalledWith('some-remediation', {});
+        const { errorResponse } = testContext;
+        const error = new Error('my test error');
+        idxResponse = {
+          ...idxResponse,
+          proceed: jest.fn().mockRejectedValue(error),
+          neededToProceed: [{
+            name: 'some-remediation',
+            value: [{
+              name: 'foo'
+            }]
+          }],
+        } as unknown as IdxResponse;
+        const res = await remediate(authClient, idxResponse, {}, { step: 'some-remediation' });
+        expect(res).toBe(errorResponse);
+        expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error);
+        expect(idxResponse.proceed).toHaveBeenCalledWith('some-remediation', {});
       });
     });
     describe('flow is "default"', () => {
@@ -556,6 +556,26 @@ describe('idx/remediate', () => {
   });
 
   describe('use generic remediator', () => {
-
+    it('does not auto proceed', async () => {
+      let { authClient, idxResponse, remediator } = testContext;
+      idxResponse = {
+        ...idxResponse,
+        neededToProceed: [{
+          name: 'some-remediation'
+        }]
+      };
+      const responseFromProceed = {
+        ...idxResponse,
+        rawIdxState: {
+          messages: {
+            value: ['hello']
+          }
+        }
+      };
+      idxResponse.proceed.mockResolvedValue(responseFromProceed);
+      remediator.canRemediate.mockReturnValue(true);
+      await remediate(authClient, idxResponse, {}, { useGenericRemediator: true });
+      expect(idxResponse.proceed).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
Issue description:

Due to no required field in polling related step, authjs (when use genericRemediator) keeps calling idxResponse.proceed without resolving a nextStep

Fix:
For generic remediator, stop potential auto proceed to leave response close to ionResponse by request