### PR TITLE
Fix issues with circular dependencies

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,7 +31,6 @@
         "--collectCoverage=false",
         "--testTimeout=120000",
         "--config=jest.browser.js",
-        "--testTimeout=120000",
         "${relativeFile}"
       ],
       "console": "integratedTerminal",
@@ -48,7 +47,6 @@
         "--collectCoverage=false",
         "--testTimeout=120000",
         "--config=jest.server.js",
-        "--testTimeout=120000",
         "${relativeFile}"
       ],
       "console": "integratedTerminal",

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -187,7 +187,7 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
       }),
       introspect: introspectAuthn.bind(null, this),
       createTransaction: (res?: TransactionState) => {
-        return new AuthTransaction(res);
+        return new AuthTransaction(this, res);
       },
       postToTransaction: (url: string, args?: RequestData, options?: RequestOptions) => {
         return postToTransaction(this, url, args, options);

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -302,7 +302,7 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
       'renewTokensWithRefresh',
       'renewTokens'
     ];
-    Object.keys(toWrap).forEach(key => {
+    toWrap.forEach(key => {
       this.token[key] = useQueue(this.token[key]);
     });
 

--- a/lib/OktaAuth.ts
+++ b/lib/OktaAuth.ts
@@ -254,7 +254,7 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
       }
     });
     // eslint-disable-next-line max-len
-    const parseFromUrlFn = useQueue(parseFromUrl.bind(null, this)) as ParseFromUrlInterface;
+    const parseFromUrlFn = parseFromUrl.bind(null, this);
     const parseFromUrlApi: ParseFromUrlInterface = Object.assign(parseFromUrlFn, {
       // This is exposed so we can mock getting window.history in our tests
       _getHistory: function() {
@@ -293,16 +293,17 @@ class OktaAuth implements OktaAuthInterface, SigninAPI, SignoutAPI {
       isLoginRedirect: isLoginRedirect.bind(null, this)
     };
     // Wrap all async token API methods using MethodQueue to avoid issues with concurrency
-    const syncMethods = [
+    const doNotWrap = [
       // sync methods
       'decode',
       'isLoginRedirect',
       // already bound
       'getWithRedirect',
-      'parseFromUrl'
+      // does not call API directly
+      'parseFromUrl',
     ];
     Object.keys(this.token).forEach(key => {
-      if (syncMethods.indexOf(key) >= 0) { // sync methods should not be wrapped
+      if (doNotWrap.indexOf(key) >= 0) { // sync methods should not be wrapped
         return;
       }
       var method = this.token[key];

--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -15,10 +15,15 @@
 /* eslint-disable complexity */
 import { isString, clone, isAbsoluteUrl, removeNils } from '../util';
 import { STATE_TOKEN_KEY_NAME, DEFAULT_CACHE_DURATION } from '../constants';
-import { OktaAuthInterface, RequestOptions, FetchOptions, RequestData } from '../types';
+import {
+  OktaAuthHttpInterface,
+  RequestOptions,
+  FetchOptions,
+  RequestData
+} from '../types';
 import { AuthApiError, OAuthError } from '../errors';
 
-export function httpRequest(sdk: OktaAuthInterface, options: RequestOptions): Promise<any> {
+export function httpRequest(sdk: OktaAuthHttpInterface, options: RequestOptions): Promise<any> {
   options = options || {};
   var url = options.url,
       method = options.method,
@@ -121,7 +126,7 @@ export function httpRequest(sdk: OktaAuthInterface, options: RequestOptions): Pr
     });
 }
 
-export function get(sdk: OktaAuthInterface, url: string, options?: RequestOptions) {
+export function get(sdk: OktaAuthHttpInterface, url: string, options?: RequestOptions) {
   url = isAbsoluteUrl(url) ? url : sdk.getIssuerOrigin() + url;
   var getOptions = {
     url: url,
@@ -131,7 +136,7 @@ export function get(sdk: OktaAuthInterface, url: string, options?: RequestOption
   return httpRequest(sdk, getOptions);
 }
 
-export function post(sdk: OktaAuthInterface, url: string, args?: RequestData, options?: RequestOptions) {
+export function post(sdk: OktaAuthHttpInterface, url: string, args?: RequestData, options?: RequestOptions) {
   url = isAbsoluteUrl(url) ? url : sdk.getIssuerOrigin() + url;
   var postOptions = {
     url: url,

--- a/lib/idx/authenticate.ts
+++ b/lib/idx/authenticate.ts
@@ -12,7 +12,7 @@
 
 
 import { 
-  OktaAuthInterface,
+  OktaAuthIdxInterface,
   IdxTransaction,
   AuthenticatorKey,
   AuthenticationOptions
@@ -20,7 +20,7 @@ import {
 import { run } from './run';
 
 export async function authenticate(
-  authClient: OktaAuthInterface, options: AuthenticationOptions = {}
+  authClient: OktaAuthIdxInterface, options: AuthenticationOptions = {}
 ): Promise<IdxTransaction> {
   if (options.password && !options.authenticator) {
     options.authenticator = AuthenticatorKey.OKTA_PASSWORD;

--- a/lib/idx/cancel.ts
+++ b/lib/idx/cancel.ts
@@ -10,11 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { OktaAuthInterface, CancelOptions, IdxTransactionMeta } from '../types';
+import { OktaAuthIdxInterface, CancelOptions, IdxTransactionMeta } from '../types';
 import { run } from './run';
 import { getFlowSpecification } from './flow';
 
-export async function cancel (authClient: OktaAuthInterface, options?: CancelOptions) {
+export async function cancel (authClient: OktaAuthIdxInterface, options?: CancelOptions) {
   const meta = authClient.transactionManager.load() as IdxTransactionMeta;
   const flowSpec = getFlowSpecification(authClient, meta.flow);
   return run(authClient, {

--- a/lib/idx/emailVerify.ts
+++ b/lib/idx/emailVerify.ts
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { OktaAuthInterface } from '../types';
+import { OktaAuthIdxInterface } from '../types';
 
 import CustomError from '../errors/CustomError';
 import { urlParamsToObject  } from '../oidc/util/urlParams';
@@ -47,7 +47,7 @@ export function parseEmailVerifyCallback(urlPath: string): EmailVerifyCallbackRe
   return urlParamsToObject(urlPath) as EmailVerifyCallbackResponse;
 }
 
-export async function handleEmailVerifyCallback(authClient: OktaAuthInterface, search: string) {
+export async function handleEmailVerifyCallback(authClient: OktaAuthIdxInterface, search: string) {
   if (isEmailVerifyCallback(search)) {
     const { state, otp } = parseEmailVerifyCallback(search);
     if (authClient.idx.canProceed({ state })) {

--- a/lib/idx/flow/FlowSpecification.ts
+++ b/lib/idx/flow/FlowSpecification.ts
@@ -1,4 +1,4 @@
-import { OktaAuthInterface, FlowIdentifier } from '../../types';
+import { OktaAuthIdxInterface, FlowIdentifier } from '../../types';
 import { AuthenticationFlow } from './AuthenticationFlow';
 import { PasswordRecoveryFlow } from './PasswordRecoveryFlow';
 import { RegistrationFlow } from './RegistrationFlow';
@@ -13,7 +13,10 @@ export interface FlowSpecification {
 }
 
 // eslint-disable-next-line complexity
-export function getFlowSpecification(oktaAuth: OktaAuthInterface, flow: FlowIdentifier = 'default'): FlowSpecification {
+export function getFlowSpecification(
+  oktaAuth: OktaAuthIdxInterface,
+  flow: FlowIdentifier = 'default'
+): FlowSpecification {
   let remediators, actions, withCredentials = true;
   switch (flow) {
     case 'register':

--- a/lib/idx/idxState/index.ts
+++ b/lib/idx/idxState/index.ts
@@ -1,5 +1,5 @@
 import { OktaAuthInterface } from '../../types';    // auth-js/types
-import { IdxResponse, RawIdxResponse } from '../types/idx-js';      // idx/types
+import { IdxResponse, IdxToPersist, RawIdxResponse } from '../types/idx-js';      // idx/types
 import { IDX_API_VERSION } from '../../constants';
 import v1 from './v1/parsers';
 
@@ -32,7 +32,7 @@ export function validateVersionConfig(version) {
 export function makeIdxState ( 
   authClient: OktaAuthInterface,
   rawIdxResponse: RawIdxResponse,
-  toPersist: Record<string, unknown> = {},
+  toPersist: IdxToPersist,
   requestDidSucceed: boolean,
 ): IdxResponse {
   const version = rawIdxResponse?.version ?? IDX_API_VERSION;

--- a/lib/idx/idxState/index.ts
+++ b/lib/idx/idxState/index.ts
@@ -1,4 +1,4 @@
-import { OktaAuthInterface } from '../../types';    // auth-js/types
+import { OktaAuthIdxInterface } from '../../types';    // auth-js/types
 import { IdxResponse, IdxToPersist, RawIdxResponse } from '../types/idx-js';      // idx/types
 import { IDX_API_VERSION } from '../../constants';
 import v1 from './v1/parsers';
@@ -30,7 +30,7 @@ export function validateVersionConfig(version) {
 }
 
 export function makeIdxState ( 
-  authClient: OktaAuthInterface,
+  authClient: OktaAuthIdxInterface,
   rawIdxResponse: RawIdxResponse,
   toPersist: IdxToPersist,
   requestDidSucceed: boolean,

--- a/lib/idx/idxState/v1/generateIdxAction.ts
+++ b/lib/idx/idxState/v1/generateIdxAction.ts
@@ -15,7 +15,6 @@ import { httpRequest } from '../../../http';
 import { OktaAuthInterface } from '../../../types';    // auth-js/types
 import { IdxActionFunction, IdxActionParams, IdxResponse, IdxToPersist } from '../../types/idx-js';
 import { divideActionParamsByMutability } from './actionParser';
-import { makeIdxState } from './makeIdxState';
 import AuthApiError from '../../../errors/AuthApiError';
 
 const generateDirectFetch = function generateDirectFetch(authClient: OktaAuthInterface, { 
@@ -45,7 +44,7 @@ const generateDirectFetch = function generateDirectFetch(authClient: OktaAuthInt
         withCredentials: toPersist?.withCredentials ?? true
       });
 
-      return makeIdxState(authClient, { ...response }, toPersist, true);
+      return authClient.idx.makeIdxResponse({ ...response }, toPersist, true);
     }
     catch (err) {
       if (!(err instanceof AuthApiError) || !err?.xhr) {
@@ -56,7 +55,7 @@ const generateDirectFetch = function generateDirectFetch(authClient: OktaAuthInt
       const payload = response.responseJSON || JSON.parse(response.responseText);
       const wwwAuthHeader = response.headers['WWW-Authenticate'] || response.headers['www-authenticate'];
 
-      const idxResponse = makeIdxState(authClient, { ...payload }, toPersist, false);
+      const idxResponse = authClient.idx.makeIdxResponse({ ...payload }, toPersist, false);
       if (response.status === 401 && wwwAuthHeader === 'Oktadevicejwt realm="Okta Device"') {
         // Okta server responds 401 status code with WWW-Authenticate header and new remediation
         // so that the iOS/MacOS credential SSO extension (Okta Verify) can intercept

--- a/lib/idx/idxState/v1/generateIdxAction.ts
+++ b/lib/idx/idxState/v1/generateIdxAction.ts
@@ -12,12 +12,12 @@
 
 /* eslint-disable max-len, complexity */
 import { httpRequest } from '../../../http';
-import { OktaAuthInterface } from '../../../types';    // auth-js/types
+import { OktaAuthIdxInterface } from '../../../types';    // auth-js/types
 import { IdxActionFunction, IdxActionParams, IdxResponse, IdxToPersist } from '../../types/idx-js';
 import { divideActionParamsByMutability } from './actionParser';
 import AuthApiError from '../../../errors/AuthApiError';
 
-const generateDirectFetch = function generateDirectFetch(authClient: OktaAuthInterface, { 
+const generateDirectFetch = function generateDirectFetch(authClient: OktaAuthIdxInterface, { 
   actionDefinition, 
   defaultParamsForAction = {}, 
   immutableParamsForAction = {}, 
@@ -87,7 +87,7 @@ const generateDirectFetch = function generateDirectFetch(authClient: OktaAuthInt
 //   };
 // };
 
-const generateIdxAction = function generateIdxAction( authClient: OktaAuthInterface, actionDefinition, toPersist ): IdxActionFunction {
+const generateIdxAction = function generateIdxAction( authClient: OktaAuthIdxInterface, actionDefinition, toPersist ): IdxActionFunction {
   // TODO: leaving this here to see where the polling is EXPECTED to drop into the code, but removing any accidental trigger of incomplete code
   // const generator =  actionDefinition.refresh ? generatePollingFetch : generateDirectFetch;
   const generator = generateDirectFetch;

--- a/lib/idx/idxState/v1/idxResponseParser.ts
+++ b/lib/idx/idxState/v1/idxResponseParser.ts
@@ -13,7 +13,7 @@
 /* eslint-disable max-len */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { OktaAuthInterface } from '../../../types';    // auth-js/types
+import { OktaAuthIdxInterface } from '../../../types';    // auth-js/types
 import { generateRemediationFunctions } from './remediationParser';
 import generateIdxAction from './generateIdxAction';
 import { JSONPath } from 'jsonpath-plus';
@@ -23,7 +23,7 @@ const SKIP_FIELDS = Object.fromEntries([
   'context', // the API response of 'context' isn't externally useful.  We ignore it and put all non-action (contextual) info into idxState.context
 ].map( (field) => [ field, !!'skip this field' ] ));
 
-export const parseNonRemediations = function parseNonRemediations( authClient: OktaAuthInterface, idxResponse, toPersist = {} ) {
+export const parseNonRemediations = function parseNonRemediations( authClient: OktaAuthIdxInterface, idxResponse, toPersist = {} ) {
   const actions = {};
   const context = {};
 
@@ -89,7 +89,7 @@ const expandRelatesTo = (idxResponse, value) => {
   });
 };
 
-const convertRemediationAction = (authClient: OktaAuthInterface, remediation, toPersist) => {
+const convertRemediationAction = (authClient: OktaAuthIdxInterface, remediation, toPersist) => {
   // Only remediation that has `rel` field (indicator for form submission) can have http action
   if (remediation.rel) {
     const remediationActions = generateRemediationFunctions( authClient, [remediation], toPersist );
@@ -103,7 +103,7 @@ const convertRemediationAction = (authClient: OktaAuthInterface, remediation, to
   return remediation;
 };
 
-export const parseIdxResponse = function parseIdxResponse( authClient: OktaAuthInterface, idxResponse, toPersist = {} ): {
+export const parseIdxResponse = function parseIdxResponse( authClient: OktaAuthIdxInterface, idxResponse, toPersist = {} ): {
   remediations: IdxRemediation[];
   context: IdxContext;
   actions: IdxActions;

--- a/lib/idx/idxState/v1/makeIdxState.ts
+++ b/lib/idx/idxState/v1/makeIdxState.ts
@@ -11,11 +11,11 @@
  */
 
 import { IdxResponse, IdxToPersist } from '../../types/idx-js';
-import { OktaAuthInterface, RawIdxResponse } from '../../../types';    // auth-js/types
+import { OktaAuthIdxInterface, RawIdxResponse } from '../../../types';    // auth-js/types
 import { parseIdxResponse } from './idxResponseParser';
 
 export function makeIdxState( 
-  authClient: OktaAuthInterface,
+  authClient: OktaAuthIdxInterface,
   idxResponse: RawIdxResponse,
   toPersist: IdxToPersist,
   requestDidSucceed: boolean

--- a/lib/idx/idxState/v1/makeIdxState.ts
+++ b/lib/idx/idxState/v1/makeIdxState.ts
@@ -10,14 +10,14 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxResponse } from '../../types/idx-js';
+import { IdxResponse, IdxToPersist } from '../../types/idx-js';
 import { OktaAuthInterface, RawIdxResponse } from '../../../types';    // auth-js/types
 import { parseIdxResponse } from './idxResponseParser';
 
 export function makeIdxState( 
   authClient: OktaAuthInterface,
   idxResponse: RawIdxResponse,
-  toPersist,
+  toPersist: IdxToPersist,
   requestDidSucceed: boolean
 ): IdxResponse {
   const rawIdxResponse =  idxResponse;

--- a/lib/idx/idxState/v1/remediationParser.ts
+++ b/lib/idx/idxState/v1/remediationParser.ts
@@ -12,11 +12,11 @@
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { OktaAuthInterface } from '../../../types';    // auth-js/types
+import { OktaAuthIdxInterface } from '../../../types';    // auth-js/types
 import generateIdxAction from './generateIdxAction';
 
 export const generateRemediationFunctions = function generateRemediationFunctions(
-  authClient: OktaAuthInterface,
+  authClient: OktaAuthIdxInterface,
   remediationValue,
   toPersist = {}
 ) {

--- a/lib/idx/interact.ts
+++ b/lib/idx/interact.ts
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 /* eslint complexity:[0,8] */
-import { OktaAuthInterface, IdxTransactionMeta, InteractOptions, InteractResponse } from '../types';
+import { OktaAuthIdxInterface, IdxTransactionMeta, InteractOptions, InteractResponse } from '../types';
 import { getSavedTransactionMeta, saveTransactionMeta, createTransactionMeta } from './transactionMeta';
 import { getOAuthBaseUrl } from '../oidc';
 import { removeNils } from '../util';
@@ -43,7 +43,7 @@ function getResponse(meta: IdxTransactionMeta): InteractResponse {
 
 // Begin or resume a transaction. Returns an interaction handle
 export async function interact (
-  authClient: OktaAuthInterface, 
+  authClient: OktaAuthIdxInterface, 
   options: InteractOptions = {}
 ): Promise<InteractResponse> {
   options = removeNils(options);

--- a/lib/idx/interact.ts
+++ b/lib/idx/interact.ts
@@ -12,9 +12,8 @@
  */
 /* eslint complexity:[0,8] */
 import { OktaAuthInterface, IdxTransactionMeta, InteractOptions, InteractResponse } from '../types';
-import { getSavedTransactionMeta, saveTransactionMeta } from './transactionMeta';
+import { getSavedTransactionMeta, saveTransactionMeta, createTransactionMeta } from './transactionMeta';
 import { getOAuthBaseUrl } from '../oidc';
-import { createTransactionMeta } from '.';
 import { removeNils } from '../util';
 import { httpRequest } from '../http';
 

--- a/lib/idx/introspect.ts
+++ b/lib/idx/introspect.ts
@@ -12,7 +12,7 @@
  */
 
 import { makeIdxState, validateVersionConfig } from './idxState';
-import { IntrospectOptions, OktaAuthInterface } from '../types';
+import { IntrospectOptions, OktaAuthIdxInterface } from '../types';
 import { IdxResponse, isRawIdxResponse } from './types/idx-js';
 import { getOAuthDomain } from '../oidc';
 import { IDX_API_VERSION } from '../constants';
@@ -20,7 +20,7 @@ import { httpRequest } from '../http';
 import { isAuthApiError } from '../errors';
 
 export async function introspect (
-  authClient: OktaAuthInterface, 
+  authClient: OktaAuthIdxInterface, 
   options: IntrospectOptions = {}
 ): Promise<IdxResponse> {
   let rawIdxResponse;

--- a/lib/idx/poll.ts
+++ b/lib/idx/poll.ts
@@ -15,12 +15,12 @@ import { proceed } from './proceed';
 import { 
   IdxPollOptions,
   IdxTransaction,
-  OktaAuthInterface,
+  OktaAuthIdxInterface,
 } from '../types';
 import { getSavedTransactionMeta } from './transactionMeta';
 import { warn } from '../util';
 
-export async function poll(authClient: OktaAuthInterface, options: IdxPollOptions = {}): Promise<IdxTransaction> {
+export async function poll(authClient: OktaAuthIdxInterface, options: IdxPollOptions = {}): Promise<IdxTransaction> {
   let transaction = await proceed(authClient, {
     startPolling: true
   });

--- a/lib/idx/proceed.ts
+++ b/lib/idx/proceed.ts
@@ -12,7 +12,7 @@
 
 
 import { 
-  OktaAuthInterface,
+  OktaAuthIdxInterface,
   IdxTransaction,
   ProceedOptions,
 } from '../types';
@@ -20,13 +20,13 @@ import { run } from './run';
 import { getSavedTransactionMeta } from './transactionMeta';
 import { AuthSdkError } from '../errors';
 
-export function canProceed(authClient: OktaAuthInterface, options: ProceedOptions = {}): boolean {
+export function canProceed(authClient: OktaAuthIdxInterface, options: ProceedOptions = {}): boolean {
   const meta = getSavedTransactionMeta(authClient, options);
   return !!(meta || options.stateHandle);
 }
 
 export async function proceed(
-  authClient: OktaAuthInterface,
+  authClient: OktaAuthIdxInterface,
   options: ProceedOptions = {}
 ): Promise<IdxTransaction> {
 

--- a/lib/idx/recoverPassword.ts
+++ b/lib/idx/recoverPassword.ts
@@ -14,13 +14,13 @@
 import { run } from './run';
 import { getFlowSpecification } from './flow';
 import { 
-  OktaAuthInterface, 
+  OktaAuthIdxInterface, 
   PasswordRecoveryOptions, 
   IdxTransaction,
 } from '../types';
 
 export async function recoverPassword(
-  authClient: OktaAuthInterface, options: PasswordRecoveryOptions = {}
+  authClient: OktaAuthIdxInterface, options: PasswordRecoveryOptions = {}
 ): Promise<IdxTransaction> {
   const flowSpec = getFlowSpecification(authClient, 'recoverPassword');
   return run(

--- a/lib/idx/register.ts
+++ b/lib/idx/register.ts
@@ -18,12 +18,12 @@ import { AuthSdkError } from '../errors';
 import { 
   RegistrationOptions, 
   IdxTransaction, 
-  OktaAuthInterface, 
+  OktaAuthIdxInterface, 
   IdxFeature,
 } from '../types';
 
 export async function register(
-  authClient: OktaAuthInterface, options: RegistrationOptions = {}
+  authClient: OktaAuthIdxInterface, options: RegistrationOptions = {}
 ): Promise<IdxTransaction> {
 
   // Only check at the beginning of the transaction

--- a/lib/idx/remediate.ts
+++ b/lib/idx/remediate.ts
@@ -12,7 +12,7 @@
 
 
 /* eslint-disable max-statements, max-depth, complexity */
-import { OktaAuthInterface } from '../types';
+import { OktaAuthIdxInterface } from '../types';
 import { AuthSdkError } from '../errors';
 import { RemediationValues } from './remediators';
 import { RemediateOptions, RemediationResponse } from './types';
@@ -64,7 +64,7 @@ function removeActionFromOptions(options: RemediateOptions, actionName: string):
 
 // This function is called recursively until it reaches success or cannot be remediated
 export async function remediate(
-  authClient: OktaAuthInterface,
+  authClient: OktaAuthIdxInterface,
   idxResponse: IdxResponse,
   values: RemediationValues,
   options: RemediateOptions

--- a/lib/idx/remediators/Base/AuthenticatorData.ts
+++ b/lib/idx/remediators/Base/AuthenticatorData.ts
@@ -16,7 +16,7 @@ import { Remediator, RemediationValues } from './Remediator';
 import { IdxRemediationValue, IdxOption, IdxRemediation, IdxAuthenticator } from '../../types/idx-js';
 import { isAuthenticator } from '../../types';
 import { compareAuthenticators } from '../../authenticator/util';
-import { OktaAuthInterface } from '../../../types';
+import { OktaAuthIdxInterface } from '../../../types';
 
 export type AuthenticatorDataValues = RemediationValues & {
   methodType?: string;
@@ -63,7 +63,7 @@ export class AuthenticatorData<T extends AuthenticatorDataValues = Authenticator
   }
 
   // TODO: remove this override method in the next major version - OKTA-491236
-  getNextStep(authClient: OktaAuthInterface) {
+  getNextStep(authClient: OktaAuthIdxInterface) {
     const common = super.getNextStep(authClient);
     const options = this.getMethodTypes();
     return { 

--- a/lib/idx/remediators/Base/Remediator.ts
+++ b/lib/idx/remediators/Base/Remediator.ts
@@ -17,7 +17,7 @@ import { NextStep, IdxMessage, Authenticator, Input, RemediateOptions } from '..
 import { IdxAuthenticator, IdxRemediation, IdxContext } from '../../types/idx-js';
 import { getAllValues, getRequiredValues, titleCase, getAuthenticatorFromRemediation } from '../util';
 import { formatAuthenticator, compareAuthenticators } from '../../authenticator/util';
-import { OktaAuthInterface } from '../../../types';
+import { OktaAuthIdxInterface } from '../../../types';
 
 // A map from IDX data values (server spec) to RemediationValues (client spec)
 export type IdxToRemediationValueMap = Record<string, string[]>;
@@ -149,7 +149,7 @@ export class Remediator<T extends RemediationValues = RemediationValues> {
     return !!this.getData(key);
   }
 
-  getNextStep(_authClient: OktaAuthInterface, _context?: IdxContext): NextStep {
+  getNextStep(_authClient: OktaAuthIdxInterface, _context?: IdxContext): NextStep {
     const name = this.getName();
     const inputs = this.getInputs();
     const authenticator = this.getAuthenticator();

--- a/lib/idx/remediators/Base/SelectAuthenticator.ts
+++ b/lib/idx/remediators/Base/SelectAuthenticator.ts
@@ -17,7 +17,7 @@ import { getAuthenticatorFromRemediation } from '../util';
 import { IdxOption, IdxRemediationValue } from '../../types/idx-js';
 import { Authenticator, isAuthenticator } from '../../types';
 import { compareAuthenticators, findMatchedOption} from '../../authenticator/util';
-import { OktaAuthInterface } from '../../../types';
+import { OktaAuthIdxInterface } from '../../../types';
 
 export type SelectAuthenticatorValues = RemediationValues & {
   authenticator?: string | Authenticator;
@@ -66,7 +66,7 @@ export class SelectAuthenticator<T extends SelectAuthenticatorValues = SelectAut
   }
 
   // TODO: remove this override method in the next major version - OKTA-491236
-  getNextStep(authClient: OktaAuthInterface) {
+  getNextStep(authClient: OktaAuthIdxInterface) {
     const common = super.getNextStep(authClient);
     const authenticatorFromRemediation = getAuthenticatorFromRemediation(this.remediation);
     const options = authenticatorFromRemediation.options!.map(option => {

--- a/lib/idx/remediators/Base/VerifyAuthenticator.ts
+++ b/lib/idx/remediators/Base/VerifyAuthenticator.ts
@@ -15,7 +15,7 @@ import { Remediator, RemediationValues } from './Remediator';
 import { getAuthenticator, Authenticator, AuthenticatorValues } from '../../authenticator';
 import { IdxRemediation, IdxContext } from '../../types/idx-js';
 import { NextStep } from '../../types';
-import { OktaAuthInterface } from '../../../types';
+import { OktaAuthIdxInterface } from '../../../types';
 
 export type VerifyAuthenticatorValues = AuthenticatorValues & RemediationValues;
 
@@ -30,7 +30,7 @@ export class VerifyAuthenticator<T extends VerifyAuthenticatorValues = VerifyAut
     this.authenticator = getAuthenticator(remediation);
   }
 
-  getNextStep(authClient: OktaAuthInterface, context?: IdxContext): NextStep {
+  getNextStep(authClient: OktaAuthIdxInterface, context?: IdxContext): NextStep {
     const nextStep = super.getNextStep(authClient, context);
     const authenticatorEnrollments = context?.authenticatorEnrollments?.value;
 

--- a/lib/idx/remediators/EnrollPoll.ts
+++ b/lib/idx/remediators/EnrollPoll.ts
@@ -12,7 +12,7 @@
 
 
 import { Remediator, RemediationValues } from './Base/Remediator';
-import { NextStep, OktaAuthInterface } from '../../types';
+import { NextStep, OktaAuthIdxInterface } from '../../types';
 import { IdxContext } from '../types/idx-js';
 
 export interface EnrollPollValues extends RemediationValues {
@@ -26,7 +26,7 @@ export class EnrollPoll extends Remediator<EnrollPollValues> {
     return !!this.values.startPolling || this.options.step === 'enroll-poll';
   }
 
-  getNextStep(authClient: OktaAuthInterface, context?: IdxContext): NextStep {
+  getNextStep(authClient: OktaAuthIdxInterface, context?: IdxContext): NextStep {
     const common = super.getNextStep(authClient, context);
     let authenticator = this.getAuthenticator();
     if (!authenticator && context?.currentAuthenticator) {

--- a/lib/idx/remediators/EnrollmentChannelData.ts
+++ b/lib/idx/remediators/EnrollmentChannelData.ts
@@ -13,7 +13,7 @@
 
 import { Remediator, RemediationValues } from './Base/Remediator';
 import { IdxContext } from '../types/idx-js';
-import { OktaAuthInterface } from '../../types';
+import { OktaAuthIdxInterface } from '../../types';
 
 
 export type EnrollmentChannelDataValues = RemediationValues & {
@@ -40,7 +40,7 @@ export class EnrollmentChannelData extends Remediator<EnrollmentChannelDataValue
     return Boolean(this.values.email || this.values.phoneNumber);
   }
 
-  getNextStep(authClient: OktaAuthInterface, context: IdxContext) {
+  getNextStep(authClient: OktaAuthIdxInterface, context: IdxContext) {
     const common = super.getNextStep(authClient, context);
     const authenticator = context.currentAuthenticator.value;
     return {

--- a/lib/idx/remediators/GenericRemediator/GenericRemediator.ts
+++ b/lib/idx/remediators/GenericRemediator/GenericRemediator.ts
@@ -1,7 +1,7 @@
 import { IdxContext, NextStep, Input } from '../../types';
 import { Remediator } from '../Base/Remediator';
 import { unwrapFormValue, hasValidInputValue } from './util';
-import { OktaAuthInterface } from '../../../types';
+import { OktaAuthIdxInterface } from '../../../types';
 
 export class GenericRemediator extends Remediator {
   canRemediate(): boolean {
@@ -25,7 +25,7 @@ export class GenericRemediator extends Remediator {
     return data;
   }
 
-  getNextStep(authClient: OktaAuthInterface, _context?: IdxContext): NextStep {
+  getNextStep(authClient: OktaAuthIdxInterface, _context?: IdxContext): NextStep {
     const name = this.getName();
     const inputs = this.getInputs();
     

--- a/lib/idx/remediators/GenericRemediator/GenericRemediator.ts
+++ b/lib/idx/remediators/GenericRemediator/GenericRemediator.ts
@@ -1,7 +1,6 @@
 import { IdxContext, NextStep, Input } from '../../types';
 import { Remediator } from '../Base/Remediator';
 import { unwrapFormValue, hasValidInputValue } from './util';
-import { proceed } from '../../proceed';
 import { OktaAuthInterface } from '../../../types';
 
 export class GenericRemediator extends Remediator {
@@ -53,7 +52,7 @@ export class GenericRemediator extends Remediator {
         ...rest,
         ...(!!inputs.length && { inputs }),
         action: async (params?) => {
-          return proceed(authClient, {
+          return authClient.idx.proceed({
             step: name,
             ...params
           });

--- a/lib/idx/remediators/SelectEnrollmentChannel.ts
+++ b/lib/idx/remediators/SelectEnrollmentChannel.ts
@@ -14,7 +14,7 @@
 import { Remediator, RemediationValues } from './Base/Remediator';
 import { IdxRemediationValueForm, IdxOption, IdxRemediationValue, IdxContext } from '../types/idx-js';
 import { getAuthenticatorFromRemediation } from './util';
-import { OktaAuthInterface } from '../../types';
+import { OktaAuthIdxInterface } from '../../types';
 
 
 export type SelectEnrollmentChannelValues = RemediationValues & {
@@ -28,7 +28,7 @@ export class SelectEnrollmentChannel extends Remediator<SelectEnrollmentChannelV
     return Boolean(this.values.channel);
   }
 
-  getNextStep(authClient: OktaAuthInterface, context: IdxContext) {
+  getNextStep(authClient: OktaAuthIdxInterface, context: IdxContext) {
     const common = super.getNextStep(authClient, context);
     const options = this.getChannels();
     const authenticator = context.currentAuthenticator.value;

--- a/lib/idx/run.ts
+++ b/lib/idx/run.ts
@@ -19,7 +19,7 @@ import { remediate } from './remediate';
 import { getFlowSpecification } from './flow';
 import * as remediators from './remediators';
 import { 
-  OktaAuthInterface,
+  OktaAuthIdxInterface,
   IdxStatus,
   IdxTransaction,
   IdxFeature,
@@ -313,7 +313,7 @@ function handleError(err, data: RunData): RunData {
 }
 
 export async function run(
-  authClient: OktaAuthInterface, 
+  authClient: OktaAuthIdxInterface, 
   options: RunOptions = {},
 ): Promise<IdxTransaction> {
   let data: RunData = {

--- a/lib/idx/startTransaction.ts
+++ b/lib/idx/startTransaction.ts
@@ -12,10 +12,10 @@
 
 
 import { run } from './run';
-import { OktaAuthInterface, IdxTransaction, StartOptions } from '../types';
+import { OktaAuthIdxInterface, IdxTransaction, StartOptions } from '../types';
 
 export async function startTransaction(
-  authClient: OktaAuthInterface, 
+  authClient: OktaAuthIdxInterface, 
   options: StartOptions = {}
 ): Promise<IdxTransaction> {
   // Clear IDX response cache and saved transaction meta (if any)

--- a/lib/idx/transactionMeta.ts
+++ b/lib/idx/transactionMeta.ts
@@ -11,13 +11,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { OktaAuthInterface, IdxTransactionMeta, TransactionMetaOptions, PKCETransactionMeta } from '../types';
+import { OktaAuthIdxInterface, IdxTransactionMeta, TransactionMetaOptions, PKCETransactionMeta } from '../types';
 import { removeNils, warn } from '../util';
 import { createOAuthMeta } from '../oidc';
 
 // Calculate new values
 export async function createTransactionMeta(
-  authClient: OktaAuthInterface,
+  authClient: OktaAuthIdxInterface,
   options: TransactionMetaOptions = {}
 ): Promise<IdxTransactionMeta> {
   const tokenParams = await authClient.token.prepareTokenParams(options);
@@ -41,7 +41,7 @@ export async function createTransactionMeta(
   return meta;
 }
 
-export function hasSavedInteractionHandle(authClient: OktaAuthInterface, options?: TransactionMetaOptions): boolean {
+export function hasSavedInteractionHandle(authClient: OktaAuthIdxInterface, options?: TransactionMetaOptions): boolean {
   const savedMeta = getSavedTransactionMeta(authClient, options);
   if (savedMeta?.interactionHandle) {
     return true;
@@ -51,7 +51,7 @@ export function hasSavedInteractionHandle(authClient: OktaAuthInterface, options
 
 // Returns the saved transaction meta, if it exists and is valid
 export function getSavedTransactionMeta(
-  authClient: OktaAuthInterface,
+  authClient: OktaAuthIdxInterface,
   options?: TransactionMetaOptions
 ): IdxTransactionMeta | undefined {
   options = removeNils(options);
@@ -80,7 +80,7 @@ export function getSavedTransactionMeta(
 }
 
 export async function getTransactionMeta(
-  authClient: OktaAuthInterface,
+  authClient: OktaAuthIdxInterface,
   options?: TransactionMetaOptions
 ): Promise<IdxTransactionMeta> {
   options = removeNils(options);
@@ -94,11 +94,11 @@ export async function getTransactionMeta(
   return createTransactionMeta(authClient, options);
 }
 
-export function saveTransactionMeta (authClient: OktaAuthInterface, meta): void {
+export function saveTransactionMeta (authClient: OktaAuthIdxInterface, meta): void {
   authClient.transactionManager.save(meta, { muteWarning: true });
 }
 
-export function clearTransactionMeta (authClient: OktaAuthInterface): void {
+export function clearTransactionMeta (authClient: OktaAuthIdxInterface): void {
   authClient.transactionManager.clear();
 }
 

--- a/lib/idx/unlockAccount.ts
+++ b/lib/idx/unlockAccount.ts
@@ -16,14 +16,14 @@ import { hasSavedInteractionHandle } from './transactionMeta';
 import { startTransaction } from './startTransaction';
 import { AuthSdkError } from '../errors';
 import { 
-  OktaAuthInterface, 
+  OktaAuthIdxInterface, 
   AccountUnlockOptions, 
   IdxTransaction,
   IdxFeature,
 } from '../types';
 
 export async function unlockAccount(
-  authClient: OktaAuthInterface, options: AccountUnlockOptions = {}
+  authClient: OktaAuthIdxInterface, options: AccountUnlockOptions = {}
 ): Promise<IdxTransaction> {
   options.flow = 'unlockAccount';
 

--- a/lib/idx/util.ts
+++ b/lib/idx/util.ts
@@ -2,7 +2,6 @@ import { warn } from '../util';
 import * as remediators from './remediators';
 import { RemediationValues, Remediator, RemediatorConstructor } from './remediators';
 import { GenericRemediator } from './remediators/GenericRemediator';
-import { proceed } from './proceed';
 import { IdxFeature, NextStep, RemediateOptions, RemediationResponse } from './types';
 import { IdxMessage, IdxRemediation, IdxRemediationValue, IdxResponse, isIdxResponse } from './types/idx-js';
 import { OktaAuthInterface } from '../types';
@@ -133,7 +132,7 @@ export function getAvailableSteps(
     res.push({ 
       name, 
       action: async (params?) => {
-        return proceed(authClient, { 
+        return authClient.idx.proceed({ 
           actions: [{ name, params }] 
         });
       }

--- a/lib/idx/util.ts
+++ b/lib/idx/util.ts
@@ -4,7 +4,7 @@ import { RemediationValues, Remediator, RemediatorConstructor } from './remediat
 import { GenericRemediator } from './remediators/GenericRemediator';
 import { IdxFeature, NextStep, RemediateOptions, RemediationResponse } from './types';
 import { IdxMessage, IdxRemediation, IdxRemediationValue, IdxResponse, isIdxResponse } from './types/idx-js';
-import { OktaAuthInterface } from '../types';
+import { OktaAuthIdxInterface } from '../types';
 
 export function isTerminalResponse(idxResponse: IdxResponse) {
   const { neededToProceed, interactionCode } = idxResponse;
@@ -105,7 +105,7 @@ export function getEnabledFeatures(idxResponse: IdxResponse): IdxFeature[] {
 }
 
 export function getAvailableSteps(
-  authClient: OktaAuthInterface, 
+  authClient: OktaAuthIdxInterface, 
   idxResponse: IdxResponse, 
   useGenericRemediator?: boolean
 ): NextStep[] {
@@ -238,7 +238,7 @@ export function getRemediator(
 
 
 export function getNextStep(
-  authClient: OktaAuthInterface, remediator: Remediator, idxResponse: IdxResponse
+  authClient: OktaAuthIdxInterface, remediator: Remediator, idxResponse: IdxResponse
 ): NextStep {
   const nextStep = remediator.getNextStep(authClient, idxResponse.context);
   const canSkip = canSkipFn(idxResponse);
@@ -250,7 +250,7 @@ export function getNextStep(
   };
 }
 
-export function handleIdxError(authClient: OktaAuthInterface, e, remediator?): RemediationResponse {
+export function handleIdxError(authClient: OktaAuthIdxInterface, e, remediator?): RemediationResponse {
   // Handle idx messages
   let idxResponse = isIdxResponse(e) ? e : null;
   if (!idxResponse) {

--- a/lib/oidc/endpoints/token.ts
+++ b/lib/oidc/endpoints/token.ts
@@ -12,7 +12,7 @@
 
 
 import { AuthSdkError } from '../../errors';
-import { CustomUrls, OAuthParams, OAuthResponse, RefreshToken, TokenParams } from '../../types';
+import { CustomUrls, OAuthParams, OAuthResponse, OktaAuthHttpInterface, RefreshToken, TokenParams } from '../../types';
 import { removeNils, toQueryString } from '../../util';
 import { httpRequest } from '../../http';
 
@@ -76,7 +76,11 @@ export function postToTokenEndpoint(sdk, options: TokenParams, urls: CustomUrls)
   });
 }
 
-export function postRefreshToken(sdk, options: TokenParams, refreshToken: RefreshToken): Promise<OAuthResponse> {
+export function postRefreshToken(
+  sdk: OktaAuthHttpInterface,
+  options: TokenParams,
+  refreshToken: RefreshToken
+): Promise<OAuthResponse> {
   return httpRequest(sdk, {
     url: refreshToken.tokenUrl,
     method: 'POST',

--- a/lib/oidc/endpoints/well-known.ts
+++ b/lib/oidc/endpoints/well-known.ts
@@ -12,17 +12,17 @@
  */
 import { get } from '../../http';
 import { find } from '../../util';
-import { OktaAuthInterface, WellKnownResponse } from '../../types';
+import { OktaAuthOIDCInterface, WellKnownResponse } from '../../types';
 import AuthSdkError from '../../errors/AuthSdkError';
 
-export function getWellKnown(sdk: OktaAuthInterface, issuer?: string): Promise<WellKnownResponse> {
+export function getWellKnown(sdk: OktaAuthOIDCInterface, issuer?: string): Promise<WellKnownResponse> {
   var authServerUri = (issuer || sdk.options.issuer);
   return get(sdk, authServerUri + '/.well-known/openid-configuration', {
     cacheResponse: true
   });
 }
 
-export function getKey(sdk: OktaAuthInterface, issuer: string, kid: string): Promise<string> {
+export function getKey(sdk: OktaAuthOIDCInterface, issuer: string, kid: string): Promise<string> {
   var httpCache = sdk.storageManager.getHttpCache(sdk.options.cookies);
 
   return getWellKnown(sdk, issuer)

--- a/lib/oidc/exchangeCodeForTokens.ts
+++ b/lib/oidc/exchangeCodeForTokens.ts
@@ -12,14 +12,14 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-import { CustomUrls, OAuthResponse, OAuthResponseType, OktaAuthInterface, TokenParams, TokenResponse } from '../types';
+import { CustomUrls, OAuthResponse, OAuthResponseType, OktaAuthOIDCInterface, TokenParams, TokenResponse } from '../types';
 import { getOAuthUrls, getDefaultTokenParams } from './util';
 import { clone } from '../util';
 import { postToTokenEndpoint } from './endpoints/token';
 import { handleOAuthResponse } from './handleOAuthResponse';
 
 // codeVerifier is required. May pass either an authorizationCode or interactionCode
-export function exchangeCodeForTokens(sdk: OktaAuthInterface, tokenParams: TokenParams, urls?: CustomUrls): Promise<TokenResponse> {
+export function exchangeCodeForTokens(sdk: OktaAuthOIDCInterface, tokenParams: TokenParams, urls?: CustomUrls): Promise<TokenResponse> {
   urls = urls || getOAuthUrls(sdk, tokenParams);
   // build params using defaults + options
   tokenParams = Object.assign({}, getDefaultTokenParams(sdk), clone(tokenParams));

--- a/lib/oidc/getToken.ts
+++ b/lib/oidc/getToken.ts
@@ -22,7 +22,7 @@ import {
 import AuthSdkError from '../errors/AuthSdkError';
 
 import {
-  OktaAuthInterface,
+  OktaAuthOIDCInterface,
   TokenParams,
   PopupParams,
   OAuthResponse,
@@ -81,7 +81,7 @@ import { handleOAuthResponse } from './handleOAuthResponse';
  * @param {String} [options.popupTitle] Title dispayed in the popup.
  *                                      Defaults to 'External Identity Provider User Authentication'
  */
-export function getToken(sdk: OktaAuthInterface, options: TokenParams & PopupParams) {
+export function getToken(sdk: OktaAuthOIDCInterface, options: TokenParams & PopupParams) {
   if (arguments.length > 2) {
     return Promise.reject(new AuthSdkError('As of version 3.0, "getToken" takes only a single set of options'));
   }

--- a/lib/oidc/getWithPopup.ts
+++ b/lib/oidc/getWithPopup.ts
@@ -11,12 +11,12 @@
  *
  */
 import { AuthSdkError } from '../errors';
-import { OktaAuthInterface, TokenParams, TokenResponse } from '../types';
+import { OktaAuthOIDCInterface, TokenParams, TokenResponse } from '../types';
 import { clone } from '../util';
 import { getToken } from './getToken';
 import { loadPopup } from './util';
 
-export function getWithPopup(sdk: OktaAuthInterface, options: TokenParams): Promise<TokenResponse> {
+export function getWithPopup(sdk: OktaAuthOIDCInterface, options: TokenParams): Promise<TokenResponse> {
   if (arguments.length > 2) {
     return Promise.reject(new AuthSdkError('As of version 3.0, "getWithPopup" takes only a single set of options'));
   }

--- a/lib/oidc/getWithRedirect.ts
+++ b/lib/oidc/getWithRedirect.ts
@@ -12,12 +12,12 @@
  *
  */
 import { AuthSdkError } from '../errors';
-import { OktaAuthInterface, TokenParams } from '../types';
+import { OktaAuthOIDCInterface, TokenParams } from '../types';
 import { clone } from '../util';
 import { prepareTokenParams, createOAuthMeta } from './util';
 import { buildAuthorizeParams } from './endpoints/authorize';
 
-export async function getWithRedirect(sdk: OktaAuthInterface, options?: TokenParams): Promise<void> {
+export async function getWithRedirect(sdk: OktaAuthOIDCInterface, options?: TokenParams): Promise<void> {
   if (arguments.length > 2) {
     return Promise.reject(new AuthSdkError('As of version 3.0, "getWithRedirect" takes only a single set of options'));
   }

--- a/lib/oidc/getWithoutPrompt.ts
+++ b/lib/oidc/getWithoutPrompt.ts
@@ -11,11 +11,11 @@
  *
  */
 import { AuthSdkError } from '../errors';
-import { OktaAuthInterface, TokenParams, TokenResponse } from '../types';
+import { OktaAuthOIDCInterface, TokenParams, TokenResponse } from '../types';
 import { clone } from '../util';
 import { getToken } from './getToken';
 
-export function getWithoutPrompt(sdk: OktaAuthInterface, options: TokenParams): Promise<TokenResponse> {
+export function getWithoutPrompt(sdk: OktaAuthOIDCInterface, options: TokenParams): Promise<TokenResponse> {
   if (arguments.length > 2) {
     return Promise.reject(new AuthSdkError('As of version 3.0, "getWithoutPrompt" takes only a single set of options'));
   }

--- a/lib/oidc/handleOAuthResponse.ts
+++ b/lib/oidc/handleOAuthResponse.ts
@@ -28,7 +28,6 @@ import {
   CustomUrls,
   Tokens,
 } from '../types';
-import { exchangeCodeForTokens } from './exchangeCodeForTokens';
 import { verifyToken } from './verifyToken';
 import { getDefaultTokenParams } from './util';
 
@@ -53,7 +52,7 @@ export async function handleOAuthResponse(
   // The result contains an authorization_code and PKCE is enabled 
   // `exchangeCodeForTokens` will call /token then call `handleOauthResponse` recursively with the result
   if (pkce && (res.code || res.interaction_code)) {
-    return exchangeCodeForTokens(sdk, Object.assign({}, tokenParams, {
+    return sdk.token.exchangeCodeForTokens(Object.assign({}, tokenParams, {
       authorizationCode: res.code,
       interactionCode: res.interaction_code
     }), urls);

--- a/lib/oidc/handleOAuthResponse.ts
+++ b/lib/oidc/handleOAuthResponse.ts
@@ -19,7 +19,7 @@ import {
 } from './util/oauth';
 import { AuthSdkError, OAuthError } from '../errors';
 import {
-  OktaAuthInterface,
+  OktaAuthOIDCInterface,
   TokenVerifyParams,
   IDToken,
   OAuthResponse,
@@ -42,7 +42,7 @@ function validateResponse(res: OAuthResponse, oauthParams: TokenParams) {
 }
 
 export async function handleOAuthResponse(
-  sdk: OktaAuthInterface,
+  sdk: OktaAuthOIDCInterface,
   tokenParams: TokenParams,
   res: OAuthResponse,
   urls?: CustomUrls

--- a/lib/oidc/renewToken.ts
+++ b/lib/oidc/renewToken.ts
@@ -11,7 +11,7 @@
  *
  */
 import { AuthSdkError } from '../errors';
-import { OktaAuthInterface, Token, Tokens, isAccessToken, AccessToken, IDToken, isIDToken } from '../types';
+import { OktaAuthOIDCInterface, Token, Tokens, isAccessToken, AccessToken, IDToken, isIDToken } from '../types';
 import { getWithoutPrompt } from './getWithoutPrompt';
 import { renewTokensWithRefresh } from './renewTokensWithRefresh';
 
@@ -33,7 +33,7 @@ function getSingleToken(originalToken: Token, tokens: Tokens) {
 }
 
 // If we have a refresh token, renew using that, otherwise getWithoutPrompt
-export async function renewToken(sdk: OktaAuthInterface, token: Token): Promise<Token | undefined> {
+export async function renewToken(sdk: OktaAuthOIDCInterface, token: Token): Promise<Token | undefined> {
   if (!isIDToken(token) && !isAccessToken(token)) {
     throwInvalidTokenError();
   }

--- a/lib/oidc/renewTokensWithRefresh.ts
+++ b/lib/oidc/renewTokensWithRefresh.ts
@@ -13,12 +13,12 @@
 import { AuthSdkError } from '../errors';
 import { getOAuthUrls } from './util/oauth';
 import { isSameRefreshToken } from './util/refreshToken';
-import { OktaAuthInterface, TokenParams, RefreshToken, Tokens } from '../types';
+import { OktaAuthOIDCInterface, TokenParams, RefreshToken, Tokens } from '../types';
 import { handleOAuthResponse } from './handleOAuthResponse';
 import { postRefreshToken } from './endpoints/token';
 
 export async function renewTokensWithRefresh(
-  sdk: OktaAuthInterface,
+  sdk: OktaAuthOIDCInterface,
   tokenParams: TokenParams,
   refreshTokenObject: RefreshToken
 ): Promise<Tokens> {

--- a/lib/oidc/revokeToken.ts
+++ b/lib/oidc/revokeToken.ts
@@ -20,14 +20,14 @@ import {
 import { btoa } from '../crypto';
 import AuthSdkError from '../errors/AuthSdkError';
 import {
-  OktaAuthInterface,
+  OktaAuthOIDCInterface,
   RevocableToken,
   AccessToken,
   RefreshToken
 } from '../types';
 
 // refresh tokens have precedence to be revoked if no token is specified
-export async function revokeToken(sdk: OktaAuthInterface, token: RevocableToken): Promise<any> {
+export async function revokeToken(sdk: OktaAuthOIDCInterface, token: RevocableToken): Promise<any> {
   let accessToken = '';
   let refreshToken = '';
   if (token) { 

--- a/lib/oidc/util/browser.ts
+++ b/lib/oidc/util/browser.ts
@@ -13,7 +13,7 @@
 /* global window, document */
 /* eslint-disable complexity, max-statements */
 import { AuthSdkError } from '../../errors';
-import { OktaAuthInterface } from '../../types';
+import { OktaAuthOptionsInterface } from '../../types';
 
 export function addListener(eventTarget, name, fn) {
   if (eventTarget.addEventListener) {
@@ -46,7 +46,7 @@ export function loadPopup(src, options) {
   return window.open(src, title, appearance);
 }
 
-export function addPostMessageListener(sdk: OktaAuthInterface, timeout, state) {
+export function addPostMessageListener(sdk: OktaAuthOptionsInterface, timeout, state) {
   var responseHandler;
   var timeoutId;
   var msgReceivedOrTimeout = new Promise(function (resolve, reject) {

--- a/lib/oidc/util/defaultTokenParams.ts
+++ b/lib/oidc/util/defaultTokenParams.ts
@@ -13,11 +13,11 @@
  *
  */
 import { generateNonce, generateState } from './oauth';
-import { OktaAuthInterface, TokenParams } from '../../types';
+import { OktaAuthOptionsInterface, TokenParams } from '../../types';
 import { isBrowser } from '../../features';
 import { removeNils } from '../../util';
 
-export function getDefaultTokenParams(sdk: OktaAuthInterface): TokenParams {
+export function getDefaultTokenParams(sdk: OktaAuthOptionsInterface): TokenParams {
   const {
     pkce,
     clientId,

--- a/lib/oidc/util/errors.ts
+++ b/lib/oidc/util/errors.ts
@@ -11,7 +11,7 @@
  */
 
 
-import { OktaAuthInterface } from '../../types';
+import { OktaAuthOptionsInterface } from '../../types';
 import { OAuthError, AuthApiError } from '../../errors';
 
 export function isInteractionRequiredError(error: Error) {
@@ -22,7 +22,7 @@ export function isInteractionRequiredError(error: Error) {
   return (oauthError.errorCode === 'interaction_required');
 }
 
-export function isAuthorizationCodeError(sdk: OktaAuthInterface, error: Error) {
+export function isAuthorizationCodeError(sdk: OktaAuthOptionsInterface, error: Error) {
   if (error.name !== 'AuthApiError') {
     return false;
   }

--- a/lib/oidc/util/loginRedirect.ts
+++ b/lib/oidc/util/loginRedirect.ts
@@ -12,7 +12,7 @@
  */
 /* global window */
 /* eslint-disable complexity, max-statements */
-import { OktaAuthInterface, OktaAuthOptions } from '../../types';
+import { OktaAuthOptionsInterface, OktaAuthOptions } from '../../types';
 
 export function hasTokensInHash(hash: string): boolean {
   return /((id|access)_token=)/i.test(hash);
@@ -32,7 +32,7 @@ export function hasErrorInUrl(hashOrSearch: string): boolean {
   return /(error=)/i.test(hashOrSearch) || /(error_description)/i.test(hashOrSearch);
 }
 
-export function isRedirectUri(uri: string, sdk: OktaAuthInterface): boolean {
+export function isRedirectUri(uri: string, sdk: OktaAuthOptionsInterface): boolean {
   var authParams = sdk.options;
   if (!uri || !authParams.redirectUri) {
     return false;
@@ -54,7 +54,7 @@ export function getHashOrSearch(options: OktaAuthOptions) {
  * Check if tokens or a code have been passed back into the url, which happens in
  * the OIDC (including social auth IDP) redirect flow.
  */
-export function isLoginRedirect (sdk: OktaAuthInterface) {
+export function isLoginRedirect (sdk: OktaAuthOptionsInterface) {
   // First check, is this a redirect URI?
   if (!isRedirectUri(window.location.href, sdk)){
     return false;
@@ -81,7 +81,7 @@ export function isLoginRedirect (sdk: OktaAuthInterface) {
  * Check if error=interaction_required has been passed back in the url, which happens in
  * the social auth IDP redirect flow.
  */
-export function isInteractionRequired (sdk: OktaAuthInterface, hashOrSearch?: string) {
+export function isInteractionRequired (sdk: OktaAuthOptionsInterface, hashOrSearch?: string) {
   if (!hashOrSearch) { // web only
     // First check, is this a redirect URI?
     if (!isLoginRedirect(sdk)){

--- a/lib/oidc/util/oauth.ts
+++ b/lib/oidc/util/oauth.ts
@@ -13,7 +13,7 @@
 /* eslint-disable complexity, max-statements */
 import { genRandomString, removeTrailingSlash } from '../../util';
 import AuthSdkError from '../../errors/AuthSdkError';
-import { OktaAuthInterface, CustomUrls } from '../../types';
+import { OktaAuthOptionsInterface, CustomUrls } from '../../types';
 
 export function generateState() {
   return genRandomString(64);
@@ -23,24 +23,24 @@ export function generateNonce() {
   return genRandomString(64);
 }
 
-function getIssuer(sdk: OktaAuthInterface, options: CustomUrls = {}) {
+function getIssuer(sdk: OktaAuthOptionsInterface, options: CustomUrls = {}) {
   const issuer = removeTrailingSlash(options.issuer) || sdk.options.issuer;
   return issuer;
 }
 
-export function getOAuthBaseUrl(sdk: OktaAuthInterface, options: CustomUrls = {}) {
+export function getOAuthBaseUrl(sdk: OktaAuthOptionsInterface, options: CustomUrls = {}) {
   const issuer = getIssuer(sdk, options);
   const baseUrl = issuer.indexOf('/oauth2') > 0 ? issuer : issuer + '/oauth2';
   return baseUrl;
 }
 
-export function getOAuthDomain(sdk: OktaAuthInterface, options: CustomUrls = {}) {
+export function getOAuthDomain(sdk: OktaAuthOptionsInterface, options: CustomUrls = {}) {
   const issuer = getIssuer(sdk, options);
   const domain = issuer.split('/oauth2')[0];
   return domain;
 }
 
-export function getOAuthUrls(sdk: OktaAuthInterface, options?: CustomUrls): CustomUrls {
+export function getOAuthUrls(sdk: OktaAuthOptionsInterface, options?: CustomUrls): CustomUrls {
   if (arguments.length > 2) {
     throw new AuthSdkError('As of version 3.0, "getOAuthUrls" takes only a single set of options');
   }

--- a/lib/oidc/util/oauthMeta.ts
+++ b/lib/oidc/util/oauthMeta.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { OAuthTransactionMeta, OktaAuthInterface, PKCETransactionMeta, TokenParams } from '../../types';
+import { OAuthTransactionMeta, OktaAuthOptionsInterface, PKCETransactionMeta, TokenParams } from '../../types';
 import { getOAuthUrls } from './oauth';
 
 export function createOAuthMeta(
-  sdk: OktaAuthInterface, 
+  sdk: OktaAuthOptionsInterface, 
   tokenParams: TokenParams
 ): OAuthTransactionMeta | PKCETransactionMeta {
   const issuer = sdk.options.issuer!;

--- a/lib/oidc/util/prepareTokenParams.ts
+++ b/lib/oidc/util/prepareTokenParams.ts
@@ -13,12 +13,12 @@
  */
 import { getWellKnown } from '../endpoints/well-known';
 import { AuthSdkError } from '../../errors';
-import { OktaAuthInterface, TokenParams } from '../../types';
+import { OktaAuthFeaturesInterface, OktaAuthOIDCInterface, TokenParams } from '../../types';
 import { getDefaultTokenParams } from './defaultTokenParams';
 import { DEFAULT_CODE_CHALLENGE_METHOD } from '../../constants';
 import PKCE from './pkce';
 
-export function assertPKCESupport(sdk: OktaAuthInterface) {
+export function assertPKCESupport(sdk: OktaAuthFeaturesInterface) {
   if (!sdk.features.isPKCESupported()) {
     var errorMessage = 'PKCE requires a modern browser with encryption support running in a secure context.';
     if (!sdk.features.isHTTPS()) {
@@ -33,7 +33,7 @@ export function assertPKCESupport(sdk: OktaAuthInterface) {
   }
 }
 
-export async function validateCodeChallengeMethod(sdk: OktaAuthInterface, codeChallengeMethod?: string) {
+export async function validateCodeChallengeMethod(sdk: OktaAuthOIDCInterface, codeChallengeMethod?: string) {
   // set default code challenge method, if none provided
   codeChallengeMethod = codeChallengeMethod || sdk.options.codeChallengeMethod || DEFAULT_CODE_CHALLENGE_METHOD;
 
@@ -47,7 +47,7 @@ export async function validateCodeChallengeMethod(sdk: OktaAuthInterface, codeCh
 }
 
 export async function preparePKCE(
-  sdk: OktaAuthInterface, 
+  sdk: OktaAuthOIDCInterface, 
   tokenParams: TokenParams
 ): Promise<TokenParams> {
   let {
@@ -79,7 +79,7 @@ export async function preparePKCE(
 
 // Prepares params for a call to /authorize or /token
 export async function prepareTokenParams(
-  sdk: OktaAuthInterface,
+  sdk: OktaAuthOIDCInterface,
   tokenParams: TokenParams = {}
 ): Promise<TokenParams> {
   // build params using defaults + options

--- a/lib/oidc/util/validateClaims.ts
+++ b/lib/oidc/util/validateClaims.ts
@@ -14,9 +14,9 @@
 /* eslint-disable complexity, max-statements */
 
 import AuthSdkError from '../../errors/AuthSdkError';
-import { OktaAuthInterface, TokenVerifyParams, UserClaims } from '../../types';
+import { OktaAuthOptionsInterface, TokenVerifyParams, UserClaims } from '../../types';
 
-export function validateClaims(sdk: OktaAuthInterface, claims: UserClaims, validationParams: TokenVerifyParams) {
+export function validateClaims(sdk: OktaAuthOptionsInterface, claims: UserClaims, validationParams: TokenVerifyParams) {
   var aud = validationParams.clientId;
   var iss = validationParams.issuer;
   var nonce = validationParams.nonce;

--- a/lib/oidc/verifyToken.ts
+++ b/lib/oidc/verifyToken.ts
@@ -15,12 +15,12 @@
 import { getWellKnown, getKey } from './endpoints/well-known';
 import { validateClaims } from './util';
 import { AuthSdkError } from '../errors';
-import { IDToken, OktaAuthInterface, TokenVerifyParams } from '../types';
+import { IDToken, OktaAuthOIDCInterface, TokenVerifyParams } from '../types';
 import { decodeToken } from './decodeToken';
 import * as sdkCrypto from '../crypto';
 
 // Verify the id token
-export async function verifyToken(sdk: OktaAuthInterface, token: IDToken, validationParams: TokenVerifyParams): Promise<IDToken> {
+export async function verifyToken(sdk: OktaAuthOIDCInterface, token: IDToken, validationParams: TokenVerifyParams): Promise<IDToken> {
   if (!token || !token.idToken) {
     throw new AuthSdkError('Only idTokens may be verified');
   }

--- a/lib/tx/AuthTransaction.ts
+++ b/lib/tx/AuthTransaction.ts
@@ -98,7 +98,7 @@ export class AuthTransaction implements TransactionState, AuthTransactionFunctio
       // when OKTA-75434 is resolved
       if (res.status === 'RECOVERY_CHALLENGE' && !res._links) {
         this.cancel = function() {
-          return Promise.resolve(new AuthTransaction(sdk));
+          return Promise.resolve(sdk.tx.createTransaction());
         };
       }
     }

--- a/lib/tx/api.ts
+++ b/lib/tx/api.ts
@@ -16,7 +16,6 @@ import { post } from '../http';
 import AuthSdkError from '../errors/AuthSdkError';
 import { STATE_TOKEN_KEY_NAME } from '../constants';
 import { addStateToken } from './util';
-import { AuthTransaction } from './AuthTransaction';
 
 export function transactionStatus(sdk, args) {
   args = addStateToken(sdk, args);
@@ -36,7 +35,7 @@ export function resumeTransaction(sdk, args) {
   }
   return sdk.tx.status(args)
     .then(function(res) {
-      return new AuthTransaction(sdk, res);
+      return sdk.tx.createTransaction(res);
     });
 }
 
@@ -53,7 +52,7 @@ export function introspectAuthn (sdk, args) {
   }
   return transactionStep(sdk, args)
     .then(function (res) {
-      return new AuthTransaction(sdk, res);
+      return sdk.tx.createTransaction(res);
     });
 }
 
@@ -72,6 +71,6 @@ export function postToTransaction(sdk, url, args, options?) {
   options = Object.assign({ withCredentials: true }, options);
   return post(sdk, url, args, options)
     .then(function(res) {
-      return new AuthTransaction(sdk, res);
+      return sdk.tx.createTransaction(res);
     });
 }

--- a/lib/tx/poll.ts
+++ b/lib/tx/poll.ts
@@ -17,7 +17,6 @@ import { DEFAULT_POLLING_DELAY } from '../constants';
 import AuthSdkError from '../errors/AuthSdkError';
 import AuthPollStopError from '../errors/AuthPollStopError';
 import { TransactionState } from './TransactionState';
-import { AuthTransaction } from './AuthTransaction';
 import { getStateToken } from './util';
 
 export interface PollOptions {
@@ -115,7 +114,7 @@ export function getPollFn(sdk, res: TransactionState, ref) {
             // Any non-waiting result, even if polling was stopped
             // during a request, will return
             ref.isPolling = false;
-            return new AuthTransaction(sdk, pollRes);
+            return sdk.tx.createTransaction(pollRes);
           }
         })
         .catch(function(err) {

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -12,6 +12,7 @@
  */
 
 import { AuthTransaction } from '../tx/AuthTransaction';
+import { TransactionState } from '../tx/TransactionState';
 import { Token, Tokens, RevocableToken, AccessToken, IDToken, RefreshToken } from './Token';
 import { JWTObject } from './JWT';
 import { CustomUserClaims, UserClaims } from './UserClaims';
@@ -45,6 +46,9 @@ import {
   StartOptions
 } from '../idx/types';
 import { TransactionMetaOptions } from './Transaction';
+import { RequestData, RequestOptions } from './http';
+import { IdxToPersist, RawIdxResponse } from '../idx/types/idx-js';
+
 export interface OktaAuthInterface {
   options: OktaAuthOptions;
   getIssuerOrigin(): string;
@@ -91,11 +95,14 @@ export interface TransactionExists extends TransactionExistsFunction {
   _get: (key: string) => string;
 }
 
+// Authn (classic) api
 export interface TransactionAPI {
   exists: TransactionExists;
   status: (args?: object) => Promise<object>;
   resume: (args?: object) => Promise<AuthTransaction>;
   introspect: (args?: object) => Promise<AuthTransaction>;
+  createTransaction: (res?: TransactionState) => AuthTransaction;
+  postToTransaction: (url: string, args?: RequestData, options?: RequestOptions) => Promise<AuthTransaction>;
 }
 
 // Fingerprint
@@ -282,6 +289,7 @@ export interface IdxAPI {
   // lowest level api
   interact: (options?: InteractOptions) => Promise<InteractResponse>;
   introspect: (options?: IntrospectOptions) => Promise<IdxResponse>;
+  makeIdxResponse: (rawIdxResponse: RawIdxResponse, toPersist: IdxToPersist, requestDidSucceed: boolean) => IdxResponse;
 
   // flow entrypoints
   authenticate: (options?: AuthenticationOptions) => Promise<IdxTransaction>;

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -49,22 +49,62 @@ import { TransactionMetaOptions } from './Transaction';
 import { RequestData, RequestOptions } from './http';
 import { IdxToPersist, RawIdxResponse } from '../idx/types/idx-js';
 
-export interface OktaAuthInterface {
+export interface OktaAuthOptionsInterface {
   options: OktaAuthOptions;
   getIssuerOrigin(): string;
+}
+
+export interface OktaAuthStorageInterface {
+  storageManager: StorageManager;
+
+}
+export interface OktaAuthHttpInterface extends 
+  OktaAuthOptionsInterface,
+  OktaAuthStorageInterface
+{
+  _oktaUserAgent: OktaUserAgent;
+}
+
+export interface OktaAuthFeaturesInterface {
+  // Functional on browser only
+  features: FeaturesAPI;
+}
+
+export interface OktaAuthTransactionInterface {
+  transactionManager: TransactionManager;
+}
+
+export interface OktaAuthOIDCInterface extends
+  OktaAuthOptionsInterface,
+  OktaAuthHttpInterface,
+  OktaAuthFeaturesInterface,
+  OktaAuthTransactionInterface
+{
+  token: TokenAPI;
+  tokenManager: TokenManagerInterface;
+}
+
+export interface OktaAuthIdxInterface extends
+  OktaAuthHttpInterface,
+  OktaAuthTransactionInterface,
+  Pick<OktaAuthOIDCInterface, 'token'>
+{
+  idx: IdxAPI;
+}
+
+export interface OktaAuthInterface extends
+  OktaAuthOptionsInterface,
+  OktaAuthStorageInterface,
+  OktaAuthFeaturesInterface,
+  OktaAuthHttpInterface,
+  OktaAuthTransactionInterface,
+  OktaAuthIdxInterface,
+  OktaAuthOIDCInterface
+{
   getOriginalUri(): string | undefined;
   
-  _oktaUserAgent: OktaUserAgent;
-  storageManager: StorageManager;
-  transactionManager: TransactionManager;
-  tokenManager: TokenManagerInterface;
+  
   serviceManager: ServiceManagerInterface;
-
-  idx: IdxAPI;
-
-  // Browser only
-  features: FeaturesAPI;
-  token: TokenAPI;
 }
 
 export interface FieldError {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,12 +8,14 @@ import pkg from './package.json';
 
 const path = require('path');
 
-const makeExternalPredicate = () => {
+const makeExternalPredicate = (env) => {
   const externalArr = [
     ...Object.keys(pkg.peerDependencies || {}),
     ...Object.keys(pkg.dependencies || {}),
   ];
-
+  if (env === 'node') {
+    externalArr.push('crypto');
+  }
   if (externalArr.length === 0) {
     return () => false;
   }
@@ -22,7 +24,6 @@ const makeExternalPredicate = () => {
 };
 
 const extensions = ['js', 'ts'];
-const external = makeExternalPredicate();
 
 const getPlugins = (env) => {
   return [
@@ -79,7 +80,7 @@ const getPlugins = (env) => {
 export default [
   {
     input: 'lib/index.ts',
-    external,
+    external: makeExternalPredicate('browser'),
     plugins: getPlugins('browser'),
     output: [
       {
@@ -101,7 +102,7 @@ export default [
   },
   {
     input: 'lib/index.ts',
-    external,
+    external: makeExternalPredicate('node'),
     plugins: getPlugins('node'),
     output: [
       {

--- a/scripts/e2e-mfa.sh
+++ b/scripts/e2e-mfa.sh
@@ -14,9 +14,6 @@ get_secret prod/okta-sdk-vars/password PASSWORD
 get_vault_secret_key devex/auth-js-sdk-vars security_question_answer SECURITY_QUESTION_ANSWER
 get_vault_secret_key devex/auth-js-sdk-vars a18n_api_key A18N_API_KEY
 
-echo "SECURITY_QUESTION_ANSWER"
-echo $SECURITY_QUESTION_ANSWER
-
 export CI=true
 export DBUS_SESSION_BUS_ADDRESS=/dev/null
 

--- a/scripts/e2e-mfa.sh
+++ b/scripts/e2e-mfa.sh
@@ -14,6 +14,9 @@ get_secret prod/okta-sdk-vars/password PASSWORD
 get_vault_secret_key devex/auth-js-sdk-vars security_question_answer SECURITY_QUESTION_ANSWER
 get_vault_secret_key devex/auth-js-sdk-vars a18n_api_key A18N_API_KEY
 
+echo "SECURITY_QUESTION_ANSWER"
+echo $SECURITY_QUESTION_ANSWER
+
 export CI=true
 export DBUS_SESSION_BUS_ADDRESS=/dev/null
 

--- a/test/spec/idx/remediators/GenericRemediator.ts
+++ b/test/spec/idx/remediators/GenericRemediator.ts
@@ -8,14 +8,7 @@ import {
   StateHandleValueFactory
 } from '@okta/test.support/idx';
 
-jest.mock('../../../../lib/idx/proceed', () => {
-  return {
-    proceed: jest.fn()
-  };
-});
-
 const mocked = {
-  proceed: require('../../../../lib/idx/proceed'),
   util: require('../../../../lib/idx/remediators/GenericRemediator/util'),
 };
 
@@ -161,7 +154,11 @@ describe('remediators/GenericRemediator', () => {
         ],
         action: jest.fn()
       });
-      const authClient = {} as OktaAuthInterface;
+      const authClient = {
+        idx: {
+          proceed: jest.fn()
+        }
+      } as unknown as OktaAuthInterface;
       const remediator = new GenericRemediator(remediation, {});
       const nextStep = remediator.getNextStep(authClient);
       expect(nextStep).toMatchObject({
@@ -200,7 +197,7 @@ describe('remediators/GenericRemediator', () => {
 
       // calls proceed in the attached action function
       await nextStep.action!({ foobar: 'foobar' });
-      expect(mocked.proceed.proceed).toHaveBeenCalledWith(authClient, {
+      expect(authClient.idx.proceed).toHaveBeenCalledWith({
         step: 'foo',
         foobar: 'foobar'
       });

--- a/test/spec/idx/remediators/GenericRemediator.ts
+++ b/test/spec/idx/remediators/GenericRemediator.ts
@@ -1,5 +1,5 @@
 import { GenericRemediator, RemediationValues, Remediator } from '../../../../lib/idx/remediators';
-import { OktaAuthInterface } from '../../../../lib/types';
+import { OktaAuthIdxInterface } from '../../../../lib/types';
 import { IdxRemediation } from '../../../../lib/idx/types/idx-js';
 import { 
   IdxRemediationFactory,
@@ -158,7 +158,7 @@ describe('remediators/GenericRemediator', () => {
         idx: {
           proceed: jest.fn()
         }
-      } as unknown as OktaAuthInterface;
+      } as unknown as OktaAuthIdxInterface;
       const remediator = new GenericRemediator(remediation, {});
       const nextStep = remediator.getNextStep(authClient);
       expect(nextStep).toMatchObject({
@@ -212,7 +212,7 @@ describe('remediators/GenericRemediator', () => {
           fake2: 'fake2'
         }
       });
-      const authClient = {} as OktaAuthInterface;
+      const authClient = {} as OktaAuthIdxInterface;
       const remediator = new GenericRemediator(remediation, {});
       const nextStep = remediator.getNextStep(authClient);
       expect(nextStep).toEqual({

--- a/test/spec/idx/util.ts
+++ b/test/spec/idx/util.ts
@@ -23,20 +23,20 @@ import {
 } from '@okta/test.support/idx';
 import { IdxFeature, IdxResponse, } from '../../../lib/idx/types';
 import { Remediator, GenericRemediator } from '../../../lib/idx/remediators';
-import { OktaAuthInterface } from '../../../lib/types';
+import { OktaAuthIdxInterface } from '../../../lib/types';
 
 jest.mock('../../../lib/idx/remediators/GenericRemediator');
 
 describe('idx/util', () => {
   describe('getAvailableSteps', () => {
     it('returns an empty array if there are no remediations', () => {
-      const authClient = {} as OktaAuthInterface;
+      const authClient = {} as OktaAuthIdxInterface;
       const idxResponse = IdxResponseFactory.build();
       const res = getAvailableSteps(authClient, idxResponse);
       expect(res.length).toBe(0);
     });
     it('returns next step for identify remediation', () => {
-      const authClient = {} as OktaAuthInterface;
+      const authClient = {} as OktaAuthIdxInterface;
       const idxResponse = IdxResponseFactory.build({
         neededToProceed: [
           IdentifyRemediationFactory.build()
@@ -349,7 +349,7 @@ describe('idx/util', () => {
       const remediator: Remediator = {
         getNextStep: jest.fn().mockReturnValue(nextStep)
       } as unknown as Remediator;
-      const authClient = {} as OktaAuthInterface;
+      const authClient = {} as OktaAuthIdxInterface;
       const context = {
          foo: 'bar'
       };
@@ -408,7 +408,7 @@ describe('idx/util', () => {
   describe('handleIdxError', () => {
     let testContext;
     beforeEach(() => {
-      const authClient = {} as OktaAuthInterface;
+      const authClient = {} as OktaAuthIdxInterface;
       const idxResponse = {
         neededToProceed: [],
         actions: {},

--- a/test/spec/oidc/exchangeCodeForTokens.ts
+++ b/test/spec/oidc/exchangeCodeForTokens.ts
@@ -17,9 +17,9 @@ const handleOAuthResponse = jest.fn();
 jest.mock('../../../lib/oidc/handleOAuthResponse', () => { return { handleOAuthResponse }; });
 
 import { exchangeCodeForTokens, getOAuthUrls } from '../../../lib/oidc';
-import { OktaAuthInterface } from '../../../lib/types';
+import { OktaAuthOIDCInterface } from '../../../lib/types';
 
-function mockOktaAuth(): OktaAuthInterface {
+function mockOktaAuth(): OktaAuthOIDCInterface {
   return {
     options: {
       issuer: 'http://fake'
@@ -27,7 +27,7 @@ function mockOktaAuth(): OktaAuthInterface {
     transactionManager: {
       clear: jest.fn()
     }
-  } as unknown as OktaAuthInterface;
+  } as unknown as OktaAuthOIDCInterface;
 }
 
 describe('exchangeCodeForTokens', () => {

--- a/test/spec/oidc/util/defaultTokenParams.ts
+++ b/test/spec/oidc/util/defaultTokenParams.ts
@@ -22,7 +22,7 @@ jest.mock('lib/features',() => {
   return mocked.features;
 });
 import { getDefaultTokenParams } from '../../../../lib/oidc/util/defaultTokenParams';
-import { OktaAuthInterface } from '../../../../lib/types';
+import { OktaAuthOIDCInterface } from '../../../../lib/types';
 
 describe('getDefaultTokenParams', () => {
   beforeEach(() => {
@@ -41,12 +41,12 @@ describe('getDefaultTokenParams', () => {
     }
   });
   it('`pkce`: uses value from sdk.options', () => {
-    const sdk = { options: { pkce: true } } as OktaAuthInterface;
+    const sdk = { options: { pkce: true } } as OktaAuthOIDCInterface;
     expect(getDefaultTokenParams(sdk).pkce).toBe(true);
   });
   
   it('`clientId`: uses value from sdk.options', () => {
-    const sdk = { options: { clientId: 'abc' } } as OktaAuthInterface;
+    const sdk = { options: { clientId: 'abc' } } as OktaAuthOIDCInterface;
     expect(getDefaultTokenParams(sdk).clientId).toBe('abc');
   });
   
@@ -54,40 +54,40 @@ describe('getDefaultTokenParams', () => {
     it('isBrowser: defaults to window.location.href', () => {
       jest.spyOn(mocked.features, 'isBrowser').mockReturnValue(true);
       expect(window.location.href).toBeTruthy();
-      expect(getDefaultTokenParams({ options: {} } as OktaAuthInterface).redirectUri).toBe(window.location.href);
+      expect(getDefaultTokenParams({ options: {} } as OktaAuthOIDCInterface).redirectUri).toBe(window.location.href);
     });
     it('uses values from sdk.options', () => {
-      const sdk = { options: { redirectUri: 'abc' } } as OktaAuthInterface;
+      const sdk = { options: { redirectUri: 'abc' } } as OktaAuthOIDCInterface;
       expect(getDefaultTokenParams(sdk).redirectUri).toBe('abc');
     });
   });
   
   describe('`responseType`: ', () => {
     it('defaults to ["token", "id_token"]', () => {
-      expect(getDefaultTokenParams({ options: {} } as OktaAuthInterface).responseType).toEqual(['token', 'id_token']);
+      expect(getDefaultTokenParams({ options: {} } as OktaAuthOIDCInterface).responseType).toEqual(['token', 'id_token']);
     });
     it('uses values from sdk.options', () => {
-      const sdk = { options: { responseType: 'code' } } as OktaAuthInterface;
+      const sdk = { options: { responseType: 'code' } } as OktaAuthOIDCInterface;
       expect(getDefaultTokenParams(sdk).responseType).toBe('code');
     });
   });
 
   it('`responseMode`: uses value from sdk.options', () => {
-    const sdk = { options: { responseMode: 'fragment' } } as OktaAuthInterface;
+    const sdk = { options: { responseMode: 'fragment' } } as OktaAuthOIDCInterface;
     expect(getDefaultTokenParams(sdk).responseMode).toBe('fragment');
   });
 
   describe('`state`: ', () => {
     it('generates a default value', () => {
-      expect(getDefaultTokenParams({ options: {} } as OktaAuthInterface).state).toBeTruthy();
+      expect(getDefaultTokenParams({ options: {} } as OktaAuthOIDCInterface).state).toBeTruthy();
     });
     it('uses values from sdk.options', () => {
-      const sdk = { options: { state: 'abc' } } as OktaAuthInterface;
+      const sdk = { options: { state: 'abc' } } as OktaAuthOIDCInterface;
       expect(getDefaultTokenParams(sdk).state).toBe('abc');
     });
   });
 
   it('`nonce`: generates a default value', () => {
-    expect(getDefaultTokenParams({ options: {} } as OktaAuthInterface).nonce).toBeTruthy();
+    expect(getDefaultTokenParams({ options: {} } as OktaAuthOIDCInterface).nonce).toBeTruthy();
   });
 });

--- a/test/spec/oidc/util/handleOAuthResponse.ts
+++ b/test/spec/oidc/util/handleOAuthResponse.ts
@@ -10,10 +10,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-
-const exchangeCodeForTokens = jest.fn();
-jest.mock('../../../../lib/oidc/exchangeCodeForTokens', () => { return { exchangeCodeForTokens }; });
-
 const verifyToken = jest.fn();
 jest.mock('../../../../lib/oidc/verifyToken', () => { return { verifyToken }; });
 
@@ -36,7 +32,8 @@ describe('handleOAuthResponse', () => {
       token: {
         decode: jest.fn().mockReturnValue({
           payload: {}
-        })
+        }),
+        exchangeCodeForTokens: jest.fn()
       }
     };
   }
@@ -188,7 +185,7 @@ describe('handleOAuthResponse', () => {
         pkce: true
       });
       mockTokens = {};
-      exchangeCodeForTokens.mockResolvedValue(mockTokens);
+      sdk.token.exchangeCodeForTokens.mockResolvedValue(mockTokens);
     });
 
     addBaselineTests();
@@ -196,7 +193,7 @@ describe('handleOAuthResponse', () => {
     describe('Authorization code flow', () => {
       it('calls `exchangeCodeForTokens` if response contains "code"', async () => {
         const res = await handleOAuthResponse(sdk, {}, { code: 'blah' }, undefined as unknown as CustomUrls);
-        expect(exchangeCodeForTokens).toHaveBeenCalledWith(sdk, {
+        expect(sdk.token.exchangeCodeForTokens).toHaveBeenCalledWith({
           authorizationCode: 'blah',
           interactionCode: undefined
         }, undefined);
@@ -207,7 +204,7 @@ describe('handleOAuthResponse', () => {
     describe('Interaction code flow', () => {
       it('calls `exchangeCodeForTokens` if response contains "interaction_code"', async () => {
         const res = await handleOAuthResponse(sdk, {}, { 'interaction_code': 'blah' }, undefined as unknown as CustomUrls);
-        expect(exchangeCodeForTokens).toHaveBeenCalledWith(sdk, {
+        expect(sdk.token.exchangeCodeForTokens).toHaveBeenCalledWith({
           authorizationCode: undefined,
           interactionCode: 'blah'
         }, undefined);

--- a/test/spec/tx/api.ts
+++ b/test/spec/tx/api.ts
@@ -20,11 +20,15 @@ import { postToTransaction } from '../../../lib/tx';
 describe('tx - api', () => {
   let auth;
   beforeEach(() => {
-    auth = {};
+    auth = {
+      tx: {
+        createTransaction() {}
+      }
+    };
   });
 
   describe('postToTransaction', () => {
-    it('sets default withCrednetials options as true', async () => {
+    it('sets default withCredentials options as true', async () => {
       const url = 'http://fake.domain.com/api';
       const args = { fake1: 'fake1' };
       const options = { fake2: 'fake2' };


### PR DESCRIPTION
avoids circular dependencies by using SDK facades
(these can be scoped down to use smaller individual facades such as tx, idx, token as we refactor for tree shaking)

Adds some new methods to SDK facades:

tx:
- createTransaction
- postToTransaction

idx:
- makeIdxResponse

OKTA-473004