### PR TITLE
fix: expand CustomUserClaims to include object type

### DIFF
--- a/lib/types/UserClaims.ts
+++ b/lib/types/UserClaims.ts
@@ -19,8 +19,8 @@
 
  /* eslint-disable camelcase */
 export type CustomUserClaimValue = string | boolean | number;
-
-export type CustomUserClaims = Record<string, CustomUserClaimValue | CustomUserClaimValue[]>;
+export type CustomUserClaim = CustomUserClaimValue | Record<string, CustomUserClaimValue>;
+export type CustomUserClaims = Record<string, CustomUserClaim | CustomUserClaim[]>;
 
 export type UserClaims<T extends CustomUserClaims = CustomUserClaims> = T & {
   auth_time?: number;

--- a/test/types/token.test-d.ts
+++ b/test/types/token.test-d.ts
@@ -122,6 +122,22 @@ const tokens = {
     groups: string[];
     isAdmin: boolean;
     age: number;
+    applicationProfile: {
+      companyId: string;
+      family_name: string;
+      given_name: string;
+      locale: string;
+      name: string;
+      userId: number;
+      userName: string;
+      zoneinfo: string;
+    };
+    optional?: string;
+    pair: [{
+      foo: string
+    }, {
+      bar: boolean
+    }]
   };
 
   const customUserClaims = await authClient.getUser<MyCustomClaims>();


### PR DESCRIPTION
Follows up on PR #1213 adding support for object types in custom claims
- Fixes issue https://github.com/okta/okta-auth-js/issues/1198
- Update TSD test
- OKTA-493385