### PR TITLE
e2e Account unlock with Email OTP and Phone SMS OTP

### DIFF
--- a/samples/config.js
+++ b/samples/config.js
@@ -48,100 +48,98 @@ const templateDefaults = {
 };
 
 const samples = [
-  // {
-  //   name: '@okta/samples.static-spa',
-  //   appType: 'browser',
-  //   template: 'static-spa',
-  //   generateType: GENERATE_TYPE_FULL,
-  //   specs: ['spa-app'],
-  //   features: []
-  // },
-  // {
-  //   name: '@okta/samples.webpack-spa',
-  //   appType: 'browser',
-  //   template: 'webpack-spa',
-  //   generateType: GENERATE_TYPE_FULL,
-  //   specs: ['spa-app'],
-  //   features: []
-  // },
-  // {
-  //   name: '@okta/samples.express-web-no-oidc',
-  //   appType: 'web',
-  //   template: 'express-web',
-  //   generateType: GENERATE_TYPE_FULL,
-  //   specs: ['web-app'],
-  //   oidc: false
-  // },
-  // {
-  //   name: '@okta/samples.express-web-with-oidc',
-  //   appType: 'web',
-  //   template: 'express-web',
-  //   generateType: GENERATE_TYPE_FULL,
-  //   specs: ['web-app']
-  // },
+  {
+    name: '@okta/samples.static-spa',
+    appType: 'browser',
+    template: 'static-spa',
+    generateType: GENERATE_TYPE_FULL,
+    specs: ['spa-app'],
+    features: []
+  },
+  {
+    name: '@okta/samples.webpack-spa',
+    appType: 'browser',
+    template: 'webpack-spa',
+    generateType: GENERATE_TYPE_FULL,
+    specs: ['spa-app'],
+    features: []
+  },
+  {
+    name: '@okta/samples.express-web-no-oidc',
+    appType: 'web',
+    template: 'express-web',
+    generateType: GENERATE_TYPE_FULL,
+    specs: ['web-app'],
+    oidc: false
+  },
+  {
+    name: '@okta/samples.express-web-with-oidc',
+    appType: 'web',
+    template: 'express-web',
+    generateType: GENERATE_TYPE_FULL,
+    specs: ['web-app']
+  },
   {
     name: '@okta/samples.express-embedded-auth-with-sdk',
     appType: 'web',
     template: 'express-embedded-auth-with-sdk',
     generateType: GENERATE_TYPE_OVERWRITE,
-    specs: [
-      //'express-embedded-auth-with-sdk'
-    ],
+    specs: ['express-embedded-auth-with-sdk'],
     features: [
       // group sms related specs together, so they do not run in parallel
       // this spec takes time to finish, run it first
-      // [
-      //   'self-service-registration',
-      //   'mfa-password-and-sms',
-      // ],
-      // 'root-page', 
-      // 'basic-auth', 
-      // 'identifier-first-auth',
-      // 'self-service-password-recovery', 
-      // 'self-service-registration-custom-attribute',
-      // 'self-service-registration-activation-token',
-      // 'mfa-password-and-email',
-      // 'mfa-password-and-email-magic-link',
-      // 'mfa-password-and-question',
-      // // This feature is not well defined and introduce flakiness, disable it
-      // // 'social-login-mfa',
-      // 'social-idp',
-      // 'totp-signup',
-      // 'totp-signin',
-      // 'security-questions-enrollment',
-      // 'self-service-registration-password-optional',
+      [
+        'self-service-registration',
+        'mfa-password-and-sms',
+      ],
+      'root-page', 
+      'basic-auth', 
+      'identifier-first-auth',
+      'self-service-password-recovery', 
+      'self-service-registration-custom-attribute',
+      'self-service-registration-activation-token',
+      'mfa-password-and-email',
+      'mfa-password-and-email-magic-link',
+      'mfa-password-and-question',
+      // This feature is not well defined and introduce flakiness, disable it
+      // 'social-login-mfa',
+      'social-idp',
+      'totp-signup',
+      'totp-signin',
+      'security-questions-enrollment',
+      'self-service-registration-password-optional',
       'account-unlock'
     ],
     useEnv: true,
   },
-  // {
-  //   name: '@okta/samples.express-embedded-sign-in-widget',
-  //   appType: 'web',
-  //   template: 'express-embedded-sign-in-widget',
-  //   generateType: GENERATE_TYPE_OVERWRITE,
-  //   specs: [],
-  //   features: [
-  //     'embedded-widget-basic-auth',
-  //     'social-idp-with-widget'
-  //   ],
-  //   useEnv: true
-  // },
-  // {
-  //   name: '@okta/test.app.react-oie',
-  //   appType: 'browser',
-  //   features: [
-  //     // group sms related specs together, so they do not run in parallel
-  //     // this spec takes time to finish, run it first
-  //     [
-  //       'progressive-profiling-manage-phone-numbers',
-  //     ],
-  //     'basic-auth',
-  //     'progressive-profiling-view-profile',
-  //     'progressive-profiling-update-profile-info',
-  //     'progressive-profiling-update-email-address',
-  //   ],
-  //   useEnv: true
-  // },
+  {
+    name: '@okta/samples.express-embedded-sign-in-widget',
+    appType: 'web',
+    template: 'express-embedded-sign-in-widget',
+    generateType: GENERATE_TYPE_OVERWRITE,
+    specs: [],
+    features: [
+      'embedded-widget-basic-auth',
+      'social-idp-with-widget'
+    ],
+    useEnv: true
+  },
+  {
+    name: '@okta/test.app.react-oie',
+    appType: 'browser',
+    features: [
+      // group sms related specs together, so they do not run in parallel
+      // this spec takes time to finish, run it first
+      [
+        'progressive-profiling-manage-phone-numbers',
+      ],
+      'basic-auth',
+      'progressive-profiling-view-profile',
+      'progressive-profiling-update-profile-info',
+      'progressive-profiling-update-email-address',
+    ],
+    useEnv: true
+  },
 ].map(function(sampleConfig) {
   if (!sampleConfig.name) {
     throw new Error('sample "name" is required');

--- a/samples/config.js
+++ b/samples/config.js
@@ -48,97 +48,100 @@ const templateDefaults = {
 };
 
 const samples = [
-  {
-    name: '@okta/samples.static-spa',
-    appType: 'browser',
-    template: 'static-spa',
-    generateType: GENERATE_TYPE_FULL,
-    specs: ['spa-app'],
-    features: []
-  },
-  {
-    name: '@okta/samples.webpack-spa',
-    appType: 'browser',
-    template: 'webpack-spa',
-    generateType: GENERATE_TYPE_FULL,
-    specs: ['spa-app'],
-    features: []
-  },
-  {
-    name: '@okta/samples.express-web-no-oidc',
-    appType: 'web',
-    template: 'express-web',
-    generateType: GENERATE_TYPE_FULL,
-    specs: ['web-app'],
-    oidc: false
-  },
-  {
-    name: '@okta/samples.express-web-with-oidc',
-    appType: 'web',
-    template: 'express-web',
-    generateType: GENERATE_TYPE_FULL,
-    specs: ['web-app']
-  },
+  // {
+  //   name: '@okta/samples.static-spa',
+  //   appType: 'browser',
+  //   template: 'static-spa',
+  //   generateType: GENERATE_TYPE_FULL,
+  //   specs: ['spa-app'],
+  //   features: []
+  // },
+  // {
+  //   name: '@okta/samples.webpack-spa',
+  //   appType: 'browser',
+  //   template: 'webpack-spa',
+  //   generateType: GENERATE_TYPE_FULL,
+  //   specs: ['spa-app'],
+  //   features: []
+  // },
+  // {
+  //   name: '@okta/samples.express-web-no-oidc',
+  //   appType: 'web',
+  //   template: 'express-web',
+  //   generateType: GENERATE_TYPE_FULL,
+  //   specs: ['web-app'],
+  //   oidc: false
+  // },
+  // {
+  //   name: '@okta/samples.express-web-with-oidc',
+  //   appType: 'web',
+  //   template: 'express-web',
+  //   generateType: GENERATE_TYPE_FULL,
+  //   specs: ['web-app']
+  // },
   {
     name: '@okta/samples.express-embedded-auth-with-sdk',
     appType: 'web',
     template: 'express-embedded-auth-with-sdk',
     generateType: GENERATE_TYPE_OVERWRITE,
-    specs: ['express-embedded-auth-with-sdk'],
+    specs: [
+      //'express-embedded-auth-with-sdk'
+    ],
     features: [
       // group sms related specs together, so they do not run in parallel
       // this spec takes time to finish, run it first
-      [
-        'self-service-registration',
-        'mfa-password-and-sms',
-      ],
-      'root-page', 
-      'basic-auth', 
-      'identifier-first-auth',
-      'self-service-password-recovery', 
-      'self-service-registration-custom-attribute',
-      'self-service-registration-activation-token',
-      'mfa-password-and-email',
-      'mfa-password-and-email-magic-link',
-      'mfa-password-and-question',
-      // This feature is not well defined and introduce flakiness, disable it
-      // 'social-login-mfa',
-      'social-idp',
-      'totp-signup',
-      'totp-signin',
-      'security-questions-enrollment',
-      'self-service-registration-password-optional',
+      // [
+      //   'self-service-registration',
+      //   'mfa-password-and-sms',
+      // ],
+      // 'root-page', 
+      // 'basic-auth', 
+      // 'identifier-first-auth',
+      // 'self-service-password-recovery', 
+      // 'self-service-registration-custom-attribute',
+      // 'self-service-registration-activation-token',
+      // 'mfa-password-and-email',
+      // 'mfa-password-and-email-magic-link',
+      // 'mfa-password-and-question',
+      // // This feature is not well defined and introduce flakiness, disable it
+      // // 'social-login-mfa',
+      // 'social-idp',
+      // 'totp-signup',
+      // 'totp-signin',
+      // 'security-questions-enrollment',
+      // 'self-service-registration-password-optional',
+      'account-unlock'
     ],
     useEnv: true,
   },
-  {
-    name: '@okta/samples.express-embedded-sign-in-widget',
-    appType: 'web',
-    template: 'express-embedded-sign-in-widget',
-    generateType: GENERATE_TYPE_OVERWRITE,
-    specs: [],
-    features: [
-      'embedded-widget-basic-auth',
-      'social-idp-with-widget'
-    ],
-    useEnv: true
-  },
-  {
-    name: '@okta/test.app.react-oie',
-    appType: 'browser',
-    features: [
-      // group sms related specs together, so they do not run in parallel
-      // this spec takes time to finish, run it first
-      [
-        'progressive-profiling-manage-phone-numbers',
-      ],
-      'basic-auth',
-      'progressive-profiling-view-profile',
-      'progressive-profiling-update-profile-info',
-      'progressive-profiling-update-email-address',
-    ],
-    useEnv: true
-  },
+  // {
+  //   name: '@okta/samples.express-embedded-sign-in-widget',
+  //   appType: 'web',
+  //   template: 'express-embedded-sign-in-widget',
+  //   generateType: GENERATE_TYPE_OVERWRITE,
+  //   specs: [],
+  //   features: [
+  //     'embedded-widget-basic-auth',
+  //     'social-idp-with-widget'
+  //   ],
+  //   useEnv: true
+  // },
+  // {
+  //   name: '@okta/test.app.react-oie',
+  //   appType: 'browser',
+  //   features: [
+  //     // group sms related specs together, so they do not run in parallel
+  //     // this spec takes time to finish, run it first
+  //     [
+  //       'progressive-profiling-manage-phone-numbers',
+  //     ],
+  //     'basic-auth',
+  //     'progressive-profiling-view-profile',
+  //     'progressive-profiling-update-profile-info',
+  //     'progressive-profiling-update-email-address',
+  //   ],
+  //   useEnv: true
+  // },
 ].map(function(sampleConfig) {
   if (!sampleConfig.name) {
     throw new Error('sample "name" is required');

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/views/home.mustache
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/views/home.mustache
@@ -34,7 +34,7 @@
 
             <div class="row">
               <button id="register-button" name="signup" class="ui primary basic button" onclick="location.href='/register?transactionId={{transactionId}}'">Register</button>
-              <button id="account-unlock-button" name="unlock-account" class="ui primary basic button" onclick="location.href='/unlock-account?transactionId={{transactionId}}'">Unlock Account</button>
+              <button id="account-unlock-button" name="unlockAccount" class="ui primary basic button" onclick="location.href='/unlock-account?transactionId={{transactionId}}'">Unlock Account</button>
               <button id="login-button" name="signin" class="ui primary basic button" onclick="location.href='/login?transactionId={{transactionId}}'">Login</button>
             </div>
           {{/isLoggedIn}}

--- a/samples/generated/express-embedded-auth-with-sdk/web-server/views/menu.mustache
+++ b/samples/generated/express-embedded-auth-with-sdk/web-server/views/menu.mustache
@@ -1,5 +1,5 @@
 <div class="ui inverted left fixed vertical menu">
-  <a id="item-overview" class="item" href="/">Home</a>
+  <a id="item-overview" name="home" class="item" href="/">Home</a>
   <div id="section-authorization-code" class="item">
     <div class="menu">
       {{#isLoggedIn}}

--- a/samples/generated/express-embedded-sign-in-widget/web-server/views/menu.mustache
+++ b/samples/generated/express-embedded-sign-in-widget/web-server/views/menu.mustache
@@ -1,5 +1,5 @@
 <div class="ui inverted left fixed vertical menu">
-  <a id="item-overview" class="item" href="/">Home</a>
+  <a id="item-overview" name="home" class="item" href="/">Home</a>
   <div id="section-authorization-code" class="item">
     <div class="menu">
       {{#isLoggedIn}}

--- a/samples/test/features/account-unlock.feature
+++ b/samples/test/features/account-unlock.feature
@@ -4,13 +4,10 @@ Feature: Account Unlock with Single factor (Email, Phone, Okta Verify Push)
   Given an App that assigned to a test group
     And a Policy that defines "Authentication"
      And with a Policy Rule that defines "Password as the only factor"
-    And a Policy that defines "Account Recovery"
-     And with a Policy Rule that defines "Account Unlock with Email or SMS"
-     # Defined rules are:
-     # - Lock out user after 1 unsuccessful attempt
-     # - Users can perform self-service Unlock Account
-     # - Users can initiate Recovery with Phone (SMS / Voice Call) and Email
-     # - Additional Verification is Not Required
+    And a Password Policy is set to Lock out user after 1 unsuccessful attempt
+     And the Password Policy Rule "Users can perform self-service" has "Unlock Account" checked
+     And the Password Policy Rule "Users can initiate Recovery with" has "Phone (SMS / Voice Call)" and "Email" checked
+     And the Password Policy Rule "Additional Verification is" has "Not Required" checked
     And a user named "Mary"
      And she has an account with "active" state in the org
 

--- a/samples/test/features/account-unlock.feature
+++ b/samples/test/features/account-unlock.feature
@@ -15,14 +15,7 @@ Feature: Account Unlock with Single factor (Email, Phone, Okta Verify Push)
      And she has an account with "active" state in the org
 
   Scenario: Mary recovers from a locked account with Email OTP
-    # Mary has entered an incorrect password to trigger an account lockout
-    When she clicks the "login" button
-    Then she is redirected to the "Login" page
-    When she fills in her "username"
-     And she fills in an incorrect "password"
-     And she submits the form
-    Then she should see the message "Authentication failed"
-    # Mary performs account lockout
+    Given Mary has entered an incorrect password to trigger an account lockout
     When she clicks the "Home" link
      And she clicks the "Unlock Account" button
     Then she is redirected to the "Unlock Account" page
@@ -38,14 +31,7 @@ Feature: Account Unlock with Single factor (Email, Phone, Okta Verify Push)
 
   Scenario: Mary recovers from a locked account with Phone SMS OTP
     Given she has enrolled in the "SMS" factor
-    # Mary has entered an incorrect password to trigger an account lockout
-    When she clicks the "login" button
-    Then she is redirected to the "Login" page
-    When she fills in her "username"
-     And she fills in an incorrect "password"
-     And she submits the form
-    Then she should see the message "Authentication failed"
-    # Mary performs account lockout
+     And Mary has entered an incorrect password to trigger an account lockout
     When she clicks the "Home" link
      And she clicks the "Unlock Account" button
     Then she is redirected to the "Unlock Account" page

--- a/samples/test/features/account-unlock.feature
+++ b/samples/test/features/account-unlock.feature
@@ -30,3 +30,26 @@ Feature: Account Unlock with Single factor (Email, Phone, Okta Verify Push)
     When she inputs the correct code from her "Email"
      And she submits the form
     Then she should see a message "Your account is now unlocked!"
+
+  Scenario: Mary recovers from a locked account with Phone SMS OTP
+    Given she has enrolled in the "SMS" factor
+    ## Mary has entered an incorrect password to trigger an account lockout
+    When she clicks the "login" button
+    Then she is redirected to the "Login" page
+    When she fills in her "username"
+     And she fills in an incorrect "password"
+     And she submits the form
+    Then she should see the message "Authentication failed"
+    When she clicks the "Home" link
+    ## Perform account lockout
+     And she clicks the "Unlock Account" button
+    Then she is redirected to the "Unlock Account" page
+    When she submits the form
+    Then she sees a page to input her user name and select Email, Phone, or Okta Verify to unlock her account
+    When she inputs her recovery email
+     And she selects the "Phone" factor
+     And she submits the form
+    Then the screen changes to receive an input for a code to verify
+    When she inputs the correct code from her "SMS"
+     And she submits the form
+    Then she should see a message "Your account is now unlocked!"

--- a/samples/test/features/account-unlock.feature
+++ b/samples/test/features/account-unlock.feature
@@ -1,0 +1,35 @@
+Feature: Account Unlock with Single factor (Email, Phone, Okta Verify Push)
+
+  Background:
+  Given an App that assigned to a test group
+    And a Policy that defines "Authentication"
+     And with a Policy Rule that defines "Password as the only factor"
+    And a Policy that defines "Account Recovery"
+     And with a Policy Rule that defines "Account Unlock with Email or SMS"
+    And a user named "Mary"
+     And she has an account with "active" state in the org
+
+
+#  Background:
+#    GIVEN a SPA, WEB APP or MOBILE Sign On Policy that defines Password as required
+#    AND Password Policy is set to Lock out user after 1 unsuccessful attempt
+#    AND the Password Policy Rule "Users can perform self-service" has "Unlock Account" checked
+#    AND the Password Policy Rule "Users can initiate Recovery with" has "Phone (SMS / Voice Call)" and "Email" checked
+#    AND the Password Policy Rule "Additional Verification is" has "Not Required" checked
+#    AND a User named "Mary" exists, and this user has already setup email and password factors
+#    AND Mary has entered an incorrect password to trigger an account lockout
+
+
+  Scenario: Mary recovers from a locked account with Email OTP
+    When she clicks the 'unlock-account' button
+    Then she is redirected to the "Unlock Account" page
+    When she clicks the 'signup' button
+    Then she sees a page to input her user name and select Email, Phone, or Okta Verify to unlock her account
+    When she inputs her email
+     And she selects Email
+    Then she should see a screen telling her to "Verify with your email"
+     And she should see an input box for a code to enter from the email
+    When she enters the OTP from her email in the original tab
+     And submits the form
+    Then she should see a terminal page that says "Account Successfully Unlocked!"
+     And she should see a link on the page to go back to the Basic Login View

--- a/samples/test/features/account-unlock.feature
+++ b/samples/test/features/account-unlock.feature
@@ -9,27 +9,24 @@ Feature: Account Unlock with Single factor (Email, Phone, Okta Verify Push)
     And a user named "Mary"
      And she has an account with "active" state in the org
 
-
-#  Background:
-#    GIVEN a SPA, WEB APP or MOBILE Sign On Policy that defines Password as required
-#    AND Password Policy is set to Lock out user after 1 unsuccessful attempt
-#    AND the Password Policy Rule "Users can perform self-service" has "Unlock Account" checked
-#    AND the Password Policy Rule "Users can initiate Recovery with" has "Phone (SMS / Voice Call)" and "Email" checked
-#    AND the Password Policy Rule "Additional Verification is" has "Not Required" checked
-#    AND a User named "Mary" exists, and this user has already setup email and password factors
-#    AND Mary has entered an incorrect password to trigger an account lockout
-
-
   Scenario: Mary recovers from a locked account with Email OTP
-    When she clicks the 'unlock-account' button
+    ## Mary has entered an incorrect password to trigger an account lockout
+    When she clicks the "login" button
+    Then she is redirected to the "Login" page
+    When she fills in her "username"
+     And she fills in an incorrect "password"
+     And she submits the form
+    Then she should see the message "Authentication failed"
+    When she clicks the "Home" link
+    ## Perform account lockout
+     And she clicks the "Unlock Account" button
     Then she is redirected to the "Unlock Account" page
-    When she clicks the 'signup' button
+    When she submits the form
     Then she sees a page to input her user name and select Email, Phone, or Okta Verify to unlock her account
-    When she inputs her email
-     And she selects Email
-    Then she should see a screen telling her to "Verify with your email"
-     And she should see an input box for a code to enter from the email
-    When she enters the OTP from her email in the original tab
-     And submits the form
-    Then she should see a terminal page that says "Account Successfully Unlocked!"
-     And she should see a link on the page to go back to the Basic Login View
+    When she inputs her recovery email
+     And she selects the "Email" factor
+     And she submits the form
+    Then she sees a page to challenge her email authenticator
+    When she inputs the correct code from her "Email"
+     And she submits the form
+    Then she should see a message "Your account is now unlocked!"

--- a/samples/test/features/account-unlock.feature
+++ b/samples/test/features/account-unlock.feature
@@ -6,19 +6,24 @@ Feature: Account Unlock with Single factor (Email, Phone, Okta Verify Push)
      And with a Policy Rule that defines "Password as the only factor"
     And a Policy that defines "Account Recovery"
      And with a Policy Rule that defines "Account Unlock with Email or SMS"
+     # Defined rules are:
+     # - Lock out user after 1 unsuccessful attempt
+     # - Users can perform self-service Unlock Account
+     # - Users can initiate Recovery with Phone (SMS / Voice Call) and Email
+     # - Additional Verification is Not Required
     And a user named "Mary"
      And she has an account with "active" state in the org
 
   Scenario: Mary recovers from a locked account with Email OTP
-    ## Mary has entered an incorrect password to trigger an account lockout
+    # Mary has entered an incorrect password to trigger an account lockout
     When she clicks the "login" button
     Then she is redirected to the "Login" page
     When she fills in her "username"
      And she fills in an incorrect "password"
      And she submits the form
     Then she should see the message "Authentication failed"
+    # Mary performs account lockout
     When she clicks the "Home" link
-    ## Perform account lockout
      And she clicks the "Unlock Account" button
     Then she is redirected to the "Unlock Account" page
     When she submits the form
@@ -33,15 +38,15 @@ Feature: Account Unlock with Single factor (Email, Phone, Okta Verify Push)
 
   Scenario: Mary recovers from a locked account with Phone SMS OTP
     Given she has enrolled in the "SMS" factor
-    ## Mary has entered an incorrect password to trigger an account lockout
+    # Mary has entered an incorrect password to trigger an account lockout
     When she clicks the "login" button
     Then she is redirected to the "Login" page
     When she fills in her "username"
      And she fills in an incorrect "password"
      And she submits the form
     Then she should see the message "Authentication failed"
+    # Mary performs account lockout
     When she clicks the "Home" link
-    ## Perform account lockout
      And she clicks the "Unlock Account" button
     Then she is redirected to the "Unlock Account" page
     When she submits the form

--- a/samples/test/features/account-unlock.feature
+++ b/samples/test/features/account-unlock.feature
@@ -13,8 +13,7 @@ Feature: Account Unlock with Single factor (Email, Phone, Okta Verify Push)
 
   Scenario: Mary recovers from a locked account with Email OTP
     Given Mary has entered an incorrect password to trigger an account lockout
-    When she clicks the "Home" link
-     And she clicks the "Unlock Account" button
+    When she clicks the "Unlock Account" button
     Then she is redirected to the "Unlock Account" page
     When she submits the form
     Then she sees a page to input her user name and select Email, Phone, or Okta Verify to unlock her account
@@ -29,8 +28,7 @@ Feature: Account Unlock with Single factor (Email, Phone, Okta Verify Push)
   Scenario: Mary recovers from a locked account with Phone SMS OTP
     Given she has enrolled in the "SMS" factor
      And Mary has entered an incorrect password to trigger an account lockout
-    When she clicks the "Home" link
-     And she clicks the "Unlock Account" button
+    When she clicks the "Unlock Account" button
     Then she is redirected to the "Unlock Account" page
     When she submits the form
     Then she sees a page to input her user name and select Email, Phone, or Okta Verify to unlock her account

--- a/samples/test/package.json
+++ b/samples/test/package.json
@@ -21,6 +21,7 @@
     "@okta/okta-sdk-nodejs": "^6.4.0",
     "cross-fetch": "^3.1.5",
     "cross-spawn-with-kill": "^1.0.0",
+    "deepmerge": "^4.2.2",
     "regenerator-runtime": "^0.13.3",
     "totp-generator": "0.0.12",
     "pngjs": "6.0.0",

--- a/samples/test/steps/given.ts
+++ b/samples/test/steps/given.ts
@@ -24,6 +24,7 @@ import enrollFactor from '../support/management-api/enrollFactor';
 import grantConsentToScope from '../support/management-api/grantConsentToScope';
 import updateAppOAuthClient from '../support/management-api/updateAppOAuthClient';
 import clickButton from '../support/action/clickButton';
+import clickLink from '../support/action/clickLink';
 import checkIsOnPage from '../support/check/checkIsOnPage';
 import checkFormMessage from '../support/check/checkFormMessage';
 import loginDirect from '../support/action/loginDirect';
@@ -351,5 +352,6 @@ Given(
       password: '!incorrect!'
     });
     await checkFormMessage('Authentication failed');
+    await clickLink('Home');
   }
 );

--- a/samples/test/steps/given.ts
+++ b/samples/test/steps/given.ts
@@ -185,6 +185,40 @@ Given(
 );
 
 Given(
+  'a Password Policy is set to Lock out user after {int} unsuccessful attempt',
+  { timeout },
+  async function(this: ActionContext, maxAttempts: number) {
+    this.policies = this.policies || [];
+    const policy = await createPolicy(this.config, { 
+      policyDescription: 'Password',
+      groupId: this.group?.id,
+      maxAttempts
+    });
+    this.policies.push(policy);
+    try {
+      await addAppToPolicy(this.config, { 
+        policyId: policy.id, 
+        appId: this.app.id
+      });
+    } catch(err) {/* do nothing */}
+  }
+);
+
+Given(
+  /^the Password Policy Rule (?<policyRuleDescription>.+?)$/,
+  { timeout },
+  async function(this: ActionContext, policyRuleDescription: string) {
+    const lastPolicy = this.policies[this.policies.length - 1];
+    await upsertPolicyRule(this.config, { 
+      policyId: lastPolicy.id, 
+      policyType: lastPolicy.type,
+      policyRuleDescription,
+      groupId: this.group?.id
+    });
+  }
+);
+
+Given(
   'with a Policy Rule that defines {string}',
   { timeout },
   async function(this: ActionContext, policyRuleDescription: string) {

--- a/samples/test/steps/given.ts
+++ b/samples/test/steps/given.ts
@@ -25,6 +25,7 @@ import grantConsentToScope from '../support/management-api/grantConsentToScope';
 import updateAppOAuthClient from '../support/management-api/updateAppOAuthClient';
 import clickButton from '../support/action/clickButton';
 import checkIsOnPage from '../support/check/checkIsOnPage';
+import checkFormMessage from '../support/check/checkFormMessage';
 import loginDirect from '../support/action/loginDirect';
 import addUserProfileSchemaToApp from '../support/management-api/addUserProfileSchemaToApp';
 import openRegisterWithActivationToken from '../support/action/openRegisterWithActivationToken';
@@ -305,3 +306,16 @@ Given('she does not have account in the org', noop);
 Given('she is on the Root View in an UNAUTHENTICATED state', noop);
 
 Given('she is not enrolled in any authenticators', noop);
+
+Given(
+  'Mary has entered an incorrect password to trigger an account lockout', 
+  async function(this: ActionContext) {
+    await clickButton('login');
+    await checkIsOnPage('Login');
+    await loginDirect({
+      username: this.credentials.emailAddress,
+      password: '!incorrect!'
+    });
+    await checkFormMessage('Authentication failed');
+  }
+);

--- a/samples/test/steps/then.ts
+++ b/samples/test/steps/then.ts
@@ -206,6 +206,11 @@ Then(
 );
 
 Then(
+  'she sees a page to input her user name and select Email, Phone, or Okta Verify to unlock her account',
+  () => checkIsOnPage('Select Authenticator Unlock Account')
+);
+
+Then(
   /^she sees the set new password form$/,
   () => checkIsOnPage('Set up Password')
 );

--- a/samples/test/steps/when.ts
+++ b/samples/test/steps/when.ts
@@ -18,6 +18,7 @@ import enterCredential from '../support/action/context-enabled/enterCredential';
 import enterValidPassword from '../support/action/enterValidPassword';
 import enterCode from '../support/action/enterCode';
 import enterLiveUserEmail from '../support/action/context-enabled/live-user/enterEmail';
+import enterRecoveryEmail from '../support/action/context-enabled/live-user/enterRecoveyEmail';
 import submitForm from '../support/action/submitForm';
 import selectAuthenticator from '../support/action/selectAuthenticator';
 import inputInvalidEmail from '../support/action/inputInvalidEmail';
@@ -296,4 +297,9 @@ When(
 When(
   /^She selects Security Question from the list$/,
   selectSecurityQuestionAuthenticator
+);
+
+When(
+  /^she inputs her recovery email$/,
+  enterRecoveryEmail
 );

--- a/samples/test/support/action/context-enabled/live-user/enterRecoveyEmail.ts
+++ b/samples/test/support/action/context-enabled/live-user/enterRecoveyEmail.ts
@@ -10,21 +10,10 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { PageWithTitle } from './Page';
 
-const unlockForm = '#select-authenticator-form';
-const username = `${unlockForm} #username`;
-const submit = `${unlockForm} button[type=submit]`;
-const options = `#authenticator-options`;
+import SelectAuthenticatorUnlockAccount from '../../../selectors/SelectAuthenticatorUnlockAccount';
+import ActionContext from '../../../context';
 
-class SelectAuthenticatorUnlockAccount extends PageWithTitle {
-  title = 'Select authenticator';
-
-  get pageTitle() {return '#select-authenticator-page-title-header';}
-
-  get options() { return options; }
-  get username() { return username; }
-  get submit() { return submit; }
+export default async function(this: ActionContext) {
+  await (await $(SelectAuthenticatorUnlockAccount.username)).setValue(this.user.profile.email);
 }
-
-export default new SelectAuthenticatorUnlockAccount(); 

--- a/samples/test/support/management-api/createPolicy.ts
+++ b/samples/test/support/management-api/createPolicy.ts
@@ -57,6 +57,7 @@ const getGlobalSessionPolicy = (options: Options) => {
 
 const getPasswordPolicy = (options: Options) => {
   return {
+    priority: 0,
     type: 'PASSWORD',
     conditions: {
       people: {
@@ -90,7 +91,7 @@ const getPasswordPolicy = (options: Options) => {
           maxAttempts: 1, // important to lock user after incorrect passwod
           autoUnlockMinutes: 0,
           userLockoutNotificationChannels: [],
-          showLockoutFailures: true
+          showLockoutFailures: false
         }
       },
       recovery: {

--- a/samples/test/support/management-api/createPolicy.ts
+++ b/samples/test/support/management-api/createPolicy.ts
@@ -7,6 +7,7 @@ type Options = {
   dataTable?: {
     rawTable: string[][];
   }; 
+  maxAttempts?: number;
 }
 
 const getAuthenticationPolicy = () => {
@@ -88,7 +89,7 @@ const getPasswordPolicy = (options: Options) => {
           historyCount: 4
         },
         lockout:  {
-          maxAttempts: 1, // important to lock user after incorrect passwod
+          maxAttempts: options.maxAttempts || 1,
           autoUnlockMinutes: 0,
           userLockoutNotificationChannels: [],
           showLockoutFailures: false
@@ -129,7 +130,7 @@ export default async function(config: OktaClientConfig, options: Options) {
     policyObject = getProfileEnrollmentPolicy();
   } else if (policyDescription === 'Global Session') {
     policyObject = getGlobalSessionPolicy(options);
-  } else if (policyDescription === 'Account Recovery') {
+  } else if (policyDescription === 'Password') {
     policyObject = getPasswordPolicy(options);
   } else {
     throw new Error(`Unknow policy ${policyDescription}`);

--- a/samples/test/support/management-api/upsertPolicyRule.ts
+++ b/samples/test/support/management-api/upsertPolicyRule.ts
@@ -184,7 +184,7 @@ const getPasswordPolicyActions = (description: string) => {
       },
       'actions': {
         'passwordChange': {
-          'access': 'DENY'
+          'access': 'ACTIVE'
         },
         'selfServicePasswordReset': {
           'access': 'ALLOW',

--- a/samples/test/support/management-api/upsertPolicyRule.ts
+++ b/samples/test/support/management-api/upsertPolicyRule.ts
@@ -173,6 +173,42 @@ const getGlobalSessionPolicyActions = (description: string) => {
   } as any)[description];
 };
 
+const getPasswordPolicyActions = (description: string) => {
+  return ({
+    'Account Unlock with Email or SMS': {
+      'type': 'PASSWORD',
+      'status': 'ACTIVE',
+      'conditions': {
+        'people': { 'users': { 'exclude': [] } },
+        'network': { 'connection': 'ANYWHERE' }
+      },
+      'actions': {
+        'passwordChange': {
+          'access': 'DENY'
+        },
+        'selfServicePasswordReset': {
+          'access': 'ALLOW',
+          'requirement': {
+            'primary': {
+              'methods': [
+                'email',
+                'sms'
+              ]
+            },
+            'stepUp': { 
+              'required': false
+            }
+          }
+        },
+        'selfServiceUnlock': {
+          'access': 'ALLOW',
+        }
+      }
+    }
+  } as any)[description];
+};
+
+/* eslint-disable complexity */
 export default async function (config: OktaClientConfig, {
   policyId,
   policyType,
@@ -197,6 +233,9 @@ export default async function (config: OktaClientConfig, {
       break;
     case 'OKTA_SIGN_ON':
       actions = getGlobalSessionPolicyActions(policyRuleDescription);
+      break;
+    case 'PASSWORD':
+      actions = getPasswordPolicyActions(policyRuleDescription);
       break;
     default:
       throw new Error(`No actions is found with ${policyType} ${policyRuleDescription}`);

--- a/samples/test/support/management-api/upsertPolicyRule.ts
+++ b/samples/test/support/management-api/upsertPolicyRule.ts
@@ -184,7 +184,7 @@ const getPasswordPolicyActions = (description: string) => {
       },
       'actions': {
         'passwordChange': {
-          'access': 'ACTIVE'
+          'access': 'ALLOW'
         },
         'selfServicePasswordReset': {
           'access': 'ALLOW',

--- a/samples/test/support/selectors/SelectAuthenticatorUnlockAccount.ts
+++ b/samples/test/support/selectors/SelectAuthenticatorUnlockAccount.ts
@@ -1,0 +1,25 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { PageWithTitle } from './Page';
+
+
+class SelectAuthenticatorUnlockAccount extends PageWithTitle {
+  title = 'Select authenticator';
+
+  get pageTitle() {return '#select-authenticator-page-title-header';}
+
+  get options() { return '#authenticator-options';  }
+  get submit() { return '#select-authenticator-form button[type=submit]';}
+}
+
+export default new SelectAuthenticatorUnlockAccount(); 

--- a/samples/test/support/selectors/UnlockAccount.ts
+++ b/samples/test/support/selectors/UnlockAccount.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { Page } from './Page';
+
+const unlockAccountForm = '#unlock-account-form';
+const submit = `${unlockAccountForm} #submit-button`;
+
+class UnlockAccount implements Page {
+  get isDisplayedElementSelector() { return this.submit; }
+
+  get submit() { return submit; }
+}
+
+export default new UnlockAccount();

--- a/samples/test/support/selectors/index.ts
+++ b/samples/test/support/selectors/index.ts
@@ -38,6 +38,8 @@ import PasswordSetup from './PasswordSetup';
 import Registration from './Registration';
 import OktaSignInOIEFacebookIdp from './OktaSignInOIEFacebookIdp';
 import OktaSignInOIEOktaIdp from './OktaSignInOIEOktaIdp';
+import UnlockAccount from './UnlockAccount';
+import SelectAuthenticatorUnlockAccount from './SelectAuthenticatorUnlockAccount';
 
 const pages: { [key: string]: Page } = {
   'Login': LoginForm,
@@ -67,6 +69,8 @@ const pages: { [key: string]: Page } = {
   'Challenge Security Question': ChallengeSecurityQuestion,
   'Enroll Google Authenticator':  EnrollGoogleAuthenticator,
   'Challenge Google Authenticator':  ChallengeGoogleAuthenticator,
+  'Unlock Account': UnlockAccount,
+  'Select Authenticator Unlock Account': SelectAuthenticatorUnlockAccount,
   // SIW form
   'Embedded Widget': OktaSignInOIE,
   'Login with Social IDP': OktaSignInOIEFacebookIdp,


### PR DESCRIPTION
Added e2e tests [scenarios](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2046692364/OIE+SDK+-+Cucumber+Features+and+Scenarios#11.-Account-Unlock):
- 11.1.3 - Recovers from a locked account with Email OTP
- 11.1.4 - Recovers from a locked account with Phone SMS OTP

Internal ref: [OKTA-456302](https://oktainc.atlassian.net/browse/OKTA-456302)  [OKTA-456303](https://oktainc.atlassian.net/browse/OKTA-456303) 