### PR TITLE
fix(idx): expose field level messages - OKTA-503627

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.6.2
+
+### Fixes
+
+- [#1231](https://github.com/okta/okta-auth-js/pull/1231) IDX: exposes field level error messages
+
 ## 6.6.1
 
 ### Fixes

--- a/lib/idx/remediate.ts
+++ b/lib/idx/remediate.ts
@@ -101,7 +101,7 @@ export async function remediate(
           idxResponse = await idxResponse.actions[action](params);
           idxResponse = { ...idxResponse, requestDidSucceed: true };
         } catch (e) {
-          return handleIdxError(authClient, e, remediator);
+          return handleIdxError(authClient, e, options);
         }
         if (action === 'cancel') {
           return { idxResponse, canceled: true };
@@ -122,7 +122,7 @@ export async function remediate(
           idxResponse = { ...idxResponse, requestDidSucceed: true };
         }
         catch (e) {
-          return handleIdxError(authClient, e, remediator);
+          return handleIdxError(authClient, e, options);
         }
 
         return remediate(authClient, idxResponse, values, optionsWithoutExecutedAction); // recursive call
@@ -144,7 +144,7 @@ export async function remediate(
         idxResponse = { ...idxResponse, requestDidSucceed: true };
         return { idxResponse };
       } catch(e) {
-        return handleIdxError(authClient, e);
+        return handleIdxError(authClient, e, options);
       }
     }
     if (flow === 'default') {
@@ -189,6 +189,6 @@ export async function remediate(
     
     return remediate(authClient, idxResponse, values, options); // recursive call
   } catch (e) {
-    return handleIdxError(authClient, e, remediator);
+    return handleIdxError(authClient, e, options);
   }
 }

--- a/lib/idx/remediate.ts
+++ b/lib/idx/remediate.ts
@@ -21,7 +21,6 @@ import {
   IdxActionParams, 
 } from './types/idx-js';
 import {
-  getMessagesFromResponse,
   isTerminalResponse,
   filterValuesForRemediation,
   getRemediator,
@@ -133,9 +132,8 @@ export async function remediate(
 
   // Do not attempt to remediate if response is in terminal state
   const terminal = isTerminalResponse(idxResponse);
-  const messages = getMessagesFromResponse(idxResponse);
   if (terminal) {
-    return { idxResponse, terminal, messages };
+    return { idxResponse, terminal };
   }
 
   if (!remediator) {
@@ -164,7 +162,6 @@ export async function remediate(
     return {
       idxResponse,
       nextStep,
-      messages: messages.length ? messages: undefined
     };
   }
 
@@ -187,7 +184,6 @@ export async function remediate(
       return {
         idxResponse,
         nextStep,
-        messages: messages.length ? messages: undefined
       };
     }
     

--- a/lib/idx/run.ts
+++ b/lib/idx/run.ts
@@ -245,7 +245,7 @@ async function finalizeData(authClient, data: RunData): Promise<RunData> {
     shouldSaveResponse = !!(idxResponse.requestDidSucceed || idxResponse.stepUp);
     enabledFeatures = getEnabledFeatures(idxResponse);
     availableSteps = getAvailableSteps(authClient, idxResponse, options.useGenericRemediator);
-    messages = getMessagesFromResponse(idxResponse);
+    messages = getMessagesFromResponse(idxResponse, options);
     terminal = isTerminalResponse(idxResponse);
   }
 

--- a/lib/idx/util.ts
+++ b/lib/idx/util.ts
@@ -254,7 +254,7 @@ export function getNextStep(
   };
 }
 
-export function handleIdxError(authClient: OktaAuthIdxInterface, e, remediator?): RemediationResponse {
+export function handleIdxError(authClient: OktaAuthIdxInterface, e, options = {}): RemediationResponse {
   // Handle idx messages
   let idxResponse = isIdxResponse(e) ? e : null;
   if (!idxResponse) {
@@ -266,6 +266,7 @@ export function handleIdxError(authClient: OktaAuthIdxInterface, e, remediator?)
     requestDidSucceed: false
   };
   const terminal = isTerminalResponse(idxResponse);
+  const remediator = getRemediator(idxResponse.neededToProceed, {}, options);
   const nextStep = remediator && getNextStep(authClient, remediator, idxResponse);
   return {
     idxResponse,

--- a/lib/idx/util.ts
+++ b/lib/idx/util.ts
@@ -262,15 +262,10 @@ export function handleIdxError(authClient: OktaAuthIdxInterface, e, remediator?)
     requestDidSucceed: false
   };
   const terminal = isTerminalResponse(idxResponse);
-  const messages = getMessagesFromResponse(idxResponse);
-  if (terminal) {
-    return { idxResponse, terminal, messages };
-  } else {
-    const nextStep = remediator && getNextStep(authClient, remediator, idxResponse);
-    return { 
-      idxResponse,
-      messages, 
-      ...(nextStep && { nextStep }) 
-    };
-  }
+  const nextStep = remediator && getNextStep(authClient, remediator, idxResponse);
+  return {
+    idxResponse,
+    ...(terminal && { terminal }),
+    ...(!terminal && nextStep && { nextStep }) 
+  };
 }

--- a/lib/idx/util.ts
+++ b/lib/idx/util.ts
@@ -2,7 +2,7 @@ import { warn } from '../util';
 import * as remediators from './remediators';
 import { RemediationValues, Remediator, RemediatorConstructor } from './remediators';
 import { GenericRemediator } from './remediators/GenericRemediator';
-import { IdxFeature, NextStep, RemediateOptions, RemediationResponse } from './types';
+import { IdxFeature, NextStep, RemediateOptions, RemediationResponse, RunOptions } from './types';
 import { IdxMessage, IdxRemediation, IdxRemediationValue, IdxResponse, isIdxResponse } from './types/idx-js';
 import { OktaAuthIdxInterface } from '../types';
 
@@ -48,7 +48,7 @@ export function getMessagesFromIdxRemediationValue(
   }, []);
 }
 
-export function getMessagesFromResponse(idxResponse: IdxResponse): IdxMessage[] {
+export function getMessagesFromResponse(idxResponse: IdxResponse, options: RunOptions): IdxMessage[] {
   let messages: IdxMessage[] = [];
   const { rawIdxState, neededToProceed } = idxResponse;
 
@@ -59,10 +59,14 @@ export function getMessagesFromResponse(idxResponse: IdxResponse): IdxMessage[] 
   }
 
   // Handle field messages for current flow
-  for (let remediation of neededToProceed) {
-    const fieldMessages = getMessagesFromIdxRemediationValue(remediation.value);
-    if (fieldMessages) {
-      messages = [...messages, ...fieldMessages] as never;
+  // Preserve existing logic for general cases, remove in the next major version
+  // Follow ion response format for top level messages when useGenericRemediator is true
+  if (!options.useGenericRemediator) {
+    for (let remediation of neededToProceed) {
+      const fieldMessages = getMessagesFromIdxRemediationValue(remediation.value);
+      if (fieldMessages) {
+        messages = [...messages, ...fieldMessages] as never;
+      }
     }
   }
 

--- a/test/spec/idx/authenticate.ts
+++ b/test/spec/idx/authenticate.ts
@@ -38,6 +38,7 @@ import {
   GoogleAuthenticatorOptionFactory,
   SelectAuthenticatorEnrollRemediationFactory,
   ChallengeAuthenticatorRemediationFactory,
+  EnrollAuthenticatorRemediationFactory,
   CredentialsValueFactory,
   PasscodeValueFactory,
   IdxErrorPasscodeInvalidFactory,
@@ -648,7 +649,7 @@ describe('idx/authenticate', () => {
             ]
           });
 
-          const challengeAuthenticatorRemediation = ChallengeAuthenticatorRemediationFactory.build({
+          const challengeAuthenticatorRemediation = EnrollAuthenticatorRemediationFactory.build({
             relatesTo: {
               type: 'object',
               value: PhoneAuthenticatorFactory.build()
@@ -857,18 +858,9 @@ describe('idx/authenticate', () => {
               EnrollPhoneAuthenticatorRemediationFactory.build()
             ]
           });
-          const selectAuthenticatorRemediation = SelectAuthenticatorEnrollRemediationFactory.build({
-            value: [
-              AuthenticatorValueFactory.build({
-                options: [
-                  PhoneAuthenticatorOptionFactory.build(),
-                ]
-              })
-            ]
-          });
           const errorInvalidPhoneResponse = IdxResponseFactory.build({
             neededToProceed: [
-              selectAuthenticatorRemediation,
+              PhoneAuthenticatorEnrollmentDataRemediationFactory.build()
             ],
             rawIdxState: RawIdxResponseFactory.build({
               messages: IdxMessagesFactory.build({
@@ -879,7 +871,7 @@ describe('idx/authenticate', () => {
               remediation: {
                 type: 'array',
                 value: [
-                  selectAuthenticatorRemediation
+                  PhoneAuthenticatorEnrollmentDataRemediationFactory.build()
                 ]
               }
             })
@@ -1287,29 +1279,6 @@ describe('idx/authenticate', () => {
     });
 
     describe('google authenticator', () => {
-      let errorInvalidCodeResponse;
-      beforeEach(() => {
-        errorInvalidCodeResponse = IdxResponseFactory.build({
-          rawIdxState: RawIdxResponseFactory.build({
-            messages: IdxMessagesFactory.build({
-              value: [
-                IdxErrorGoogleAuthenticatorPasscodeInvalidFactory.build()
-              ]
-            })
-          }),
-          neededToProceed:[
-            SelectAuthenticatorEnrollRemediationFactory.build({
-              value: [
-                AuthenticatorValueFactory.build({
-                  options: [
-                    PhoneAuthenticatorOptionFactory.build(),
-                  ]
-                })
-              ]
-            })
-          ]
-        });
-      });
 
       describe('verification', () => {
         beforeEach(() => {
@@ -1328,6 +1297,18 @@ describe('idx/authenticate', () => {
           });
           const verifyAuthenticatorResponse = IdxResponseFactory.build({
             neededToProceed: [
+              VerifyGoogleAuthenticatorRemediationFactory.build()
+            ]
+          });
+          const errorInvalidCodeResponse = IdxResponseFactory.build({
+            rawIdxState: RawIdxResponseFactory.build({
+              messages: IdxMessagesFactory.build({
+                value: [
+                  IdxErrorGoogleAuthenticatorPasscodeInvalidFactory.build()
+                ]
+              })
+            }),
+            neededToProceed:[
               VerifyGoogleAuthenticatorRemediationFactory.build()
             ]
           });
@@ -1494,6 +1475,18 @@ describe('idx/authenticate', () => {
               EnrollGoogleAuthenticatorRemediationFactory.build()
             ]
           });
+          const errorInvalidCodeResponse = IdxResponseFactory.build({
+            rawIdxState: RawIdxResponseFactory.build({
+              messages: IdxMessagesFactory.build({
+                value: [
+                  IdxErrorGoogleAuthenticatorPasscodeInvalidFactory.build()
+                ]
+              })
+            }),
+            neededToProceed:[
+              EnrollGoogleAuthenticatorRemediationFactory.build()
+            ]
+          });
 
           Object.assign(testContext, {
             selectAuthenticatorResponse,
@@ -1619,29 +1612,6 @@ describe('idx/authenticate', () => {
     });
 
     describe('Okta Verify', () => {
-      let errorInvalidCodeResponse;
-      beforeEach(() => {
-        errorInvalidCodeResponse = IdxResponseFactory.build({
-          rawIdxState: RawIdxResponseFactory.build({
-            messages: IdxMessagesFactory.build({
-              value: [
-                IdxErrorOktaVerifyPasscodeInvalidFactory.build()
-              ]
-            })
-          }),
-          neededToProceed:[
-            SelectAuthenticatorEnrollRemediationFactory.build({
-              value: [
-                AuthenticatorValueFactory.build({
-                  options: [
-                    OktaVerifyAuthenticatorOptionFactory.build(),
-                  ]
-                })
-              ]
-            })
-          ]
-        });
-      });
 
       describe('verification', () => {
         beforeEach(() => {
@@ -1689,7 +1659,6 @@ describe('idx/authenticate', () => {
           Object.assign(testContext, {
             selectAuthenticatorResponse,
             verifyAuthenticatorResponse,
-            errorInvalidCodeResponse,
             verificationDataResponse,
             pollForPushResponse,
           });
@@ -1771,8 +1740,19 @@ describe('idx/authenticate', () => {
           const {
             authClient,
             verifyAuthenticatorResponse,
-            errorInvalidCodeResponse
           } = testContext;
+          const errorInvalidCodeResponse = IdxResponseFactory.build({
+            rawIdxState: RawIdxResponseFactory.build({
+              messages: IdxMessagesFactory.build({
+                value: [
+                  IdxErrorOktaVerifyPasscodeInvalidFactory.build()
+                ]
+              })
+            }),
+            neededToProceed:[
+              VerifyOktaVerifyAuthenticatorRemediationFactory.build(),
+            ]
+          });
           jest.spyOn(verifyAuthenticatorResponse, 'proceed').mockRejectedValue(errorInvalidCodeResponse);
           jest.spyOn(mocked.introspect, 'introspect').mockResolvedValue(verifyAuthenticatorResponse);
           const verificationCode = 'invalid-test-code';

--- a/test/spec/idx/register.ts
+++ b/test/spec/idx/register.ts
@@ -45,7 +45,6 @@ import {
   IdxErrorInvalidLoginEmailFactory,
   IdxErrorDoesNotMatchPattern,
   IdxErrorEnrollmentInvalidPhoneFactory,
-  SelectAuthenticatorAuthenticateRemediationFactory,
   EnrollGoogleAuthenticatorRemediationFactory,
   GoogleAuthenticatorOptionFactory,
   SecurityQuestionAuthenticatorOptionFactory,
@@ -1291,15 +1290,6 @@ describe('idx/register', () => {
         }),
         neededToProceed: [
           PhoneAuthenticatorEnrollmentDataRemediationFactory.build(),
-          SelectAuthenticatorAuthenticateRemediationFactory.build({
-            value: [
-              AuthenticatorValueFactory.build({
-                options: [
-                  PhoneAuthenticatorOptionFactory.build(),
-                ]
-              })
-            ]
-          })
         ]
       });
 

--- a/test/spec/idx/register.ts
+++ b/test/spec/idx/register.ts
@@ -1290,6 +1290,7 @@ describe('idx/register', () => {
           })
         }),
         neededToProceed: [
+          PhoneAuthenticatorEnrollmentDataRemediationFactory.build(),
           SelectAuthenticatorAuthenticateRemediationFactory.build({
             value: [
               AuthenticatorValueFactory.build({

--- a/test/spec/idx/remediate.ts
+++ b/test/spec/idx/remediate.ts
@@ -462,20 +462,6 @@ describe('idx/remediate', () => {
         idxResponse
       };
     });
-    // This behavior is being removed
-    // xit('if there are messages on the remediation, it returns early, without evaluation by the Remediator', async () => {
-    //   const { idxResponse, remediator } = testContext;
-    //   const messages = ['fake'];
-    //   jest.spyOn(util, 'getMessagesFromResponse').mockReturnValue(messages);
-    //   const res = await remediate(idxResponse, {}, {});
-    //   expect(res).toEqual({
-    //     idxResponse,
-    //     messages,
-    //     nextStep: {}
-    //   });
-    //   expect(util.getMessagesFromResponse).toHaveBeenCalledWith(idxResponse);
-    //   expect(remediator.canRemediate).not.toHaveBeenCalled();
-    // });
     it('if the Remediator cannot remediate, it returns early with nextStep information', async () => {
       const { authClient, idxResponse, remediator } = testContext;
       remediator.canRemediate.mockReturnValue(false);

--- a/test/spec/idx/remediate.ts
+++ b/test/spec/idx/remediate.ts
@@ -45,20 +45,16 @@ describe('idx/remediate', () => {
     expect(res).toEqual({ idxResponse });
   });
 
-  it('returns idxResponse, messages, terminal if the idxResponse is terminal', async () => {
+  it('returns idxResponse, terminal if the idxResponse is terminal', async () => {
     const { authClient } = testContext;
-    const messages = ['fake'];
     jest.spyOn(util, 'isTerminalResponse').mockReturnValue(true);
-    jest.spyOn(util, 'getMessagesFromResponse').mockReturnValue(messages);
     const idxResponse = { fake: true, actions: {} } as unknown as IdxResponse;
     const res = await remediate(authClient, idxResponse, {}, {});
     expect(res).toEqual({
       idxResponse,
       terminal: true,
-      messages
     });
     expect(util.isTerminalResponse).toHaveBeenCalledWith(idxResponse);
-    expect(util.getMessagesFromResponse).toHaveBeenCalledWith(idxResponse);
   });
 
   describe('actions', () => {
@@ -525,7 +521,6 @@ describe('idx/remediate', () => {
             ...responseFromProceed,
             requestDidSucceed: true
           },
-          messages: ['hello'],
           nextStep: {}
         });
         expect(idxResponse.proceed).toHaveBeenCalledWith(name, data);
@@ -606,7 +601,6 @@ describe('idx/remediate', () => {
           requestDidSucceed: true,
         },
         terminal: true,
-        messages: ['hello'],
       });
     });
   });

--- a/test/spec/idx/remediate.ts
+++ b/test/spec/idx/remediate.ts
@@ -94,7 +94,7 @@ describe('idx/remediate', () => {
         });
 
         it('will handle exceptions', async () => {
-          const { authClient, remediator, errorResponse } = testContext;
+          const { authClient, errorResponse } = testContext;
           const error = new Error('my test error');
           const idxResponse = {
             neededToProceed: [{
@@ -107,7 +107,7 @@ describe('idx/remediate', () => {
           } as unknown as IdxResponse;
           const res = await remediate(authClient, idxResponse, { resend: true }, {});
           expect(res).toBe(errorResponse);
-          expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, remediator);
+          expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, {});
         });
       });
 
@@ -146,7 +146,7 @@ describe('idx/remediate', () => {
           expect(util.getRemediator).toHaveBeenNthCalledWith(2, responseFromAction.neededToProceed, {}, { actions: [] });
         });
         it('will handle exceptions', async () => {
-          const { authClient, remediator, errorResponse } = testContext;
+          const { authClient, errorResponse } = testContext;
           const error = new Error('my test error');
           const idxResponse = {
             neededToProceed: [{
@@ -157,9 +157,10 @@ describe('idx/remediate', () => {
             },
             rawIdxState: {}
           } as unknown as IdxResponse;
-          const res = await remediate(authClient, idxResponse, { resend: true }, { actions: ['some-action'] });
+          const options = { actions: ['some-action'] };
+          const res = await remediate(authClient, idxResponse, { resend: true }, options);
           expect(res).toEqual(errorResponse);
-          expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, remediator);
+          expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, options);
         });
       });
 
@@ -193,7 +194,7 @@ describe('idx/remediate', () => {
         });
         it('will handle exceptions', async () => {
           let { authClient, idxResponse } = testContext;
-          const { remediator, errorResponse } = testContext;
+          const { errorResponse } = testContext;
           const error = new Error('my test error');
           idxResponse = {
             ...idxResponse,
@@ -202,9 +203,10 @@ describe('idx/remediate', () => {
               name: 'some-remediation'
             }],
           } as unknown as IdxResponse;
-          const res = await remediate(authClient, idxResponse, {}, { actions: ['some-remediation'] });
+          const options = { actions: ['some-remediation'] };
+          const res = await remediate(authClient, idxResponse, {}, options);
           expect(res).toBe(errorResponse);
-          expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, remediator);
+          expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, options);
         });
       });
 
@@ -275,7 +277,7 @@ describe('idx/remediate', () => {
         });
         it('will handle exceptions', async () => {
           let { authClient, idxResponse } = testContext;
-          const { remediator, errorResponse } = testContext;
+          const { errorResponse } = testContext;
           const error = new Error('my test error');
           const actionFn = jest.fn().mockRejectedValue(error);
           idxResponse = {
@@ -291,9 +293,10 @@ describe('idx/remediate', () => {
             name: 'some-action',
             params: { foo: 'bar' }
           };
-          const res = await remediate(authClient, idxResponse, {}, { actions: [action] });
+          const options = { actions: [action] };
+          const res = await remediate(authClient, idxResponse, {}, options);
           expect(res).toBe(errorResponse);
-          expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, remediator);
+          expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, options);
           expect(actionFn).toHaveBeenCalledWith({ foo: 'bar' });
         });
       });
@@ -331,7 +334,7 @@ describe('idx/remediate', () => {
         });
         it('will handle exceptions', async () => {
           let { authClient, idxResponse } = testContext;
-          const { remediator, errorResponse } = testContext;
+          const { errorResponse } = testContext;
           const error = new Error('my test error');
           idxResponse = {
             ...idxResponse,
@@ -343,9 +346,10 @@ describe('idx/remediate', () => {
           const action = {
             name: 'some-remediation'
           };
-          const res = await remediate(authClient, idxResponse, {}, { actions: [action] });
+          const options = { actions: [action] };
+          const res = await remediate(authClient, idxResponse, {}, options);
           expect(res).toBe(errorResponse);
-          expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, remediator);
+          expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, options);
         });
       });
 
@@ -433,9 +437,10 @@ describe('idx/remediate', () => {
             }]
           }],
         } as unknown as IdxResponse;
-        const res = await remediate(authClient, idxResponse, {}, { step: 'some-remediation' });
+        const options = { step: 'some-remediation' };
+        const res = await remediate(authClient, idxResponse, {}, options);
         expect(res).toBe(errorResponse);
-        expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error);
+        expect(util.handleIdxError).toHaveBeenCalledWith(authClient, error, options);
         expect(idxResponse.proceed).toHaveBeenCalledWith('some-remediation', {});
       });
     });

--- a/test/spec/idx/util.ts
+++ b/test/spec/idx/util.ts
@@ -439,7 +439,6 @@ describe('idx/util', () => {
           requestDidSucceed: false
         },
         terminal: true,
-        messages: []
       });
     });
     it('non-terminal IDX responses, no remediator: it augments the object with requestDidSucceed = false and returns it', () => {
@@ -453,7 +452,6 @@ describe('idx/util', () => {
           ...idxResponse,
           requestDidSucceed: false
         },
-        messages: []
       });
     });
     it('non-terminal IDX response and a remediator: it augments the object with requestDidSucceed = false and returns it along with next step info', () => {
@@ -473,7 +471,6 @@ describe('idx/util', () => {
           ...idxResponse,
           requestDidSucceed: false
         },
-        messages: [],
         nextStep
       });
       expect(remediator.getNextStep).toHaveBeenCalledWith(authClient, context);


### PR DESCRIPTION
Fixes issues:
* stale `nextStep` returned by `handleIdxError`
* only return top level error messages at idxTransaction.message with `useGenericRemediator` option
* incorrect response with messages mock in jest