### PR TITLE
fix(idx:useGenericRemediator): decide canRemediate based on step in options (beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-# 6.7.2
+## 6.7.3
+
+- [#1264](https://github.com/okta/okta-auth-js/pull/1264) IDX GenericRemediator patches (beta):
+  - allows proceeding when `options.step` is available
+
+## 6.7.2
 
 ### Fixes
 

--- a/lib/idx/remediators/GenericRemediator/GenericRemediator.ts
+++ b/lib/idx/remediators/GenericRemediator/GenericRemediator.ts
@@ -20,16 +20,13 @@ export class GenericRemediator extends Remediator {
     if (this.remediation.name === 'poll' || this.remediation.name.endsWith('-poll')) {
       return true;
     }
-    
-    const inputKeys = this.getInputs().map(({ name }) => name);
 
-    if (!inputKeys.length) {
+    if (this.options.step) {
       return true;
     }
-
-    return Object.keys(this.values).reduce((acc: boolean, curr) => {
-      return acc || inputKeys.includes(curr);
-    }, false);
+    
+    // disable auto proceed for unknown remediations
+    return false;
   }
 
   getData() {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "6.7.2",
+  "version": "6.7.3",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "build/cjs/index.js",

--- a/samples/test/features/self-service-registration.feature
+++ b/samples/test/features/self-service-registration.feature
@@ -69,8 +69,8 @@ Scenario: Mary signs up with an invalid Email
   And she fills out her Last Name
   And she fills out her Email with an invalid email format
   And she submits the form
-  Then she sees an error message "'Email' must be in the form of an email address"
-  And she sees an error message "Provided value for property 'Email' does not match required pattern"
+  Then she sees an error message "must be in the form of an email address"
+  And she sees an error message "does not match required pattern"
 
 Scenario: Mary signs up for an account with Password, sets up required Email factor, And sets up optional SMS with an invalid phone number
   When she clicks the 'signup' button

--- a/samples/test/support/management-api/upsertPolicyRule.ts
+++ b/samples/test/support/management-api/upsertPolicyRule.ts
@@ -65,8 +65,15 @@ const getAccessPolicyActions = (description: string) => {
           'verificationMethod': {
             'factorMode': '1FA',
             'type': 'ASSURANCE',
-            'reauthenticateIn': 'PT1M',
-            'constraints': []
+            'reauthenticateIn': 'PT2H',
+            'constraints': [
+              {
+                'possession':{}
+             },
+             {
+                'knowledge':{}
+             }
+            ]
           }
         }
       },

--- a/scripts/e2e-express-embedded-sign-in-widget.sh
+++ b/scripts/e2e-express-embedded-sign-in-widget.sh
@@ -19,8 +19,6 @@ export ORG_OIE_ENABLED=true
 export USERNAME=mary@acme.com
 get_secret prod/okta-sdk-vars/password PASSWORD
 get_vault_secret_key devex/auth-js-sdk-vars a18n_api_key A18N_API_KEY
-export FB_USERNAME=js_ekdtypn_user@tfbnw.net
-get_secret prod/okta-sdk-vars/fb_password FB_PASSWORD
 
 # If this script is run as a bacon task, run against trexcloud environment
 if [[ "${BACON_TASK}" == true ]]; then
@@ -29,22 +27,12 @@ if [[ "${BACON_TASK}" == true ]]; then
   export CLIENT_ID=0oa3r1keeeFFb7VMG0g7
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_client_secret CLIENT_SECRET
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_idx_sdk_org_api_key OKTA_API_KEY
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_id MFA_CLIENT_ID
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_secret MFA_CLIENT_SECRET
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_id CUSTOM_CLIENT_ID
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_secret CUSTOM_CLIENT_SECRET
 else
   echo "Running tests against production (ok12) org"
   export ISSUER=https://javascript-idx-sdk.okta.com/oauth2/default
   export CLIENT_ID=0oav2oxnlYjULp0Cy5d6
   get_vault_secret_key devex/prod-js-idx-sdk-vars prod_client_secret CLIENT_SECRET
   get_vault_secret_key devex/prod-js-idx-sdk-vars prod_idx_sdk_org_api_key OKTA_API_KEY
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_mfa_client_id MFA_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_mfa_client_secret MFA_CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_custom_client_id CUSTOM_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_custom_client_secret CUSTOM_CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_totp_client_id TOTP_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_totp_client_secret TOTP_CLIENT_SECRET
 fi
 
 # Run the tests

--- a/scripts/e2e-express-web-no-oidc.sh
+++ b/scripts/e2e-express-web-no-oidc.sh
@@ -19,8 +19,6 @@ export ORG_OIE_ENABLED=true
 export USERNAME=mary@acme.com
 get_secret prod/okta-sdk-vars/password PASSWORD
 get_vault_secret_key devex/auth-js-sdk-vars a18n_api_key A18N_API_KEY
-export FB_USERNAME=js_ekdtypn_user@tfbnw.net
-get_secret prod/okta-sdk-vars/fb_password FB_PASSWORD
 
 # If this script is run as a bacon task, run against trexcloud environment
 if [[ "${BACON_TASK}" == true ]]; then
@@ -29,22 +27,12 @@ if [[ "${BACON_TASK}" == true ]]; then
   export CLIENT_ID=0oa3r1keeeFFb7VMG0g7
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_client_secret CLIENT_SECRET
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_idx_sdk_org_api_key OKTA_API_KEY
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_id MFA_CLIENT_ID
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_secret MFA_CLIENT_SECRET
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_id CUSTOM_CLIENT_ID
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_secret CUSTOM_CLIENT_SECRET
 else
   echo "Running tests against production (ok12) org"
   export ISSUER=https://javascript-idx-sdk.okta.com
   export CLIENT_ID=0oav2oxnlYjULp0Cy5d6
   get_vault_secret_key devex/prod-js-idx-sdk-vars prod_client_secret CLIENT_SECRET
   get_vault_secret_key devex/prod-js-idx-sdk-vars prod_idx_sdk_org_api_key OKTA_API_KEY
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_mfa_client_id MFA_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_mfa_client_secret MFA_CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_custom_client_id CUSTOM_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_custom_client_secret CUSTOM_CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_totp_client_id TOTP_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_totp_client_secret TOTP_CLIENT_SECRET
 fi
 
 # Run the tests

--- a/scripts/e2e-express-web-with-oidc.sh
+++ b/scripts/e2e-express-web-with-oidc.sh
@@ -18,8 +18,6 @@ export ORG_OIE_ENABLED=true
 export USERNAME=mary@acme.com
 get_secret prod/okta-sdk-vars/password PASSWORD
 get_vault_secret_key devex/auth-js-sdk-vars a18n_api_key A18N_API_KEY
-export FB_USERNAME=js_ekdtypn_user@tfbnw.net
-get_secret prod/okta-sdk-vars/fb_password FB_PASSWORD
 
 # If this script is run as a bacon task, run against trexcloud environment
 if [[ "${BACON_TASK}" == true ]]; then
@@ -28,22 +26,12 @@ if [[ "${BACON_TASK}" == true ]]; then
   export CLIENT_ID=0oa3r1keeeFFb7VMG0g7
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_client_secret CLIENT_SECRET
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_idx_sdk_org_api_key OKTA_API_KEY
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_id MFA_CLIENT_ID
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_secret MFA_CLIENT_SECRET
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_id CUSTOM_CLIENT_ID
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_secret CUSTOM_CLIENT_SECRET
 else
   echo "Running tests against production (ok12) org"
   export ISSUER=https://javascript-idx-sdk.okta.com
   export CLIENT_ID=0oav2oxnlYjULp0Cy5d6
   get_vault_secret_key devex/prod-js-idx-sdk-vars prod_client_secret CLIENT_SECRET
   get_vault_secret_key devex/prod-js-idx-sdk-vars prod_idx_sdk_org_api_key OKTA_API_KEY
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_mfa_client_id MFA_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_mfa_client_secret MFA_CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_custom_client_id CUSTOM_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_custom_client_secret CUSTOM_CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_totp_client_id TOTP_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_totp_client_secret TOTP_CLIENT_SECRET
 fi
 
 # Run the tests

--- a/scripts/e2e-react-embedded-auth-with-sdk.sh
+++ b/scripts/e2e-react-embedded-auth-with-sdk.sh
@@ -19,8 +19,6 @@ export ORG_OIE_ENABLED=true
 export USERNAME=mary@acme.com
 get_secret prod/okta-sdk-vars/password PASSWORD
 get_vault_secret_key devex/auth-js-sdk-vars a18n_api_key A18N_API_KEY
-export FB_USERNAME=js_ekdtypn_user@tfbnw.net
-get_secret prod/okta-sdk-vars/fb_password FB_PASSWORD
 
 # If this script is run as a bacon task, run against trexcloud environment
 if [[ "${BACON_TASK}" == true ]]; then
@@ -29,22 +27,12 @@ if [[ "${BACON_TASK}" == true ]]; then
   export SPA_CLIENT_ID=0oa3r92jj01DWBeWC0g7
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_client_secret CLIENT_SECRET
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_idx_sdk_org_api_key OKTA_API_KEY
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_id MFA_CLIENT_ID
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_secret MFA_CLIENT_SECRET
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_id CUSTOM_CLIENT_ID
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_secret CUSTOM_CLIENT_SECRET
 else
   echo "Running tests against production (ok12) org"
   export ISSUER=https://javascript-idx-sdk.okta.com
   export SPA_CLIENT_ID=0oa17suj5x9khaVH75d7
   get_vault_secret_key devex/prod-js-idx-sdk-vars prod_client_secret CLIENT_SECRET
   get_vault_secret_key devex/prod-js-idx-sdk-vars prod_idx_sdk_org_api_key OKTA_API_KEY
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_mfa_client_id MFA_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_mfa_client_secret MFA_CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_custom_client_id CUSTOM_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_custom_client_secret CUSTOM_CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_totp_client_id TOTP_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_totp_client_secret TOTP_CLIENT_SECRET
 fi
 
 # Run the tests

--- a/scripts/e2e-static-spa.sh
+++ b/scripts/e2e-static-spa.sh
@@ -19,8 +19,6 @@ export ORG_OIE_ENABLED=true
 export USERNAME=mary@acme.com
 get_secret prod/okta-sdk-vars/password PASSWORD
 get_vault_secret_key devex/auth-js-sdk-vars a18n_api_key A18N_API_KEY
-export FB_USERNAME=js_ekdtypn_user@tfbnw.net
-get_secret prod/okta-sdk-vars/fb_password FB_PASSWORD
 
 # If this script is run as a bacon task, run against trexcloud environment
 if [[ "${BACON_TASK}" == true ]]; then
@@ -29,22 +27,12 @@ if [[ "${BACON_TASK}" == true ]]; then
   export SPA_CLIENT_ID=0oa3r92jj01DWBeWC0g7
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_client_secret CLIENT_SECRET
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_idx_sdk_org_api_key OKTA_API_KEY
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_id MFA_CLIENT_ID
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_secret MFA_CLIENT_SECRET
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_id CUSTOM_CLIENT_ID
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_secret CUSTOM_CLIENT_SECRET
 else
   echo "Running tests against production (ok12) org"
   export ISSUER=https://javascript-idx-sdk.okta.com
   export SPA_CLIENT_ID=0oa17suj5x9khaVH75d7
   get_vault_secret_key devex/prod-js-idx-sdk-vars prod_client_secret CLIENT_SECRET
   get_vault_secret_key devex/prod-js-idx-sdk-vars prod_idx_sdk_org_api_key OKTA_API_KEY
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_mfa_client_id MFA_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_mfa_client_secret MFA_CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_custom_client_id CUSTOM_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_custom_client_secret CUSTOM_CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_totp_client_id TOTP_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_totp_client_secret TOTP_CLIENT_SECRET
 fi
 
 # Run the tests

--- a/scripts/e2e-webpack-spa.sh
+++ b/scripts/e2e-webpack-spa.sh
@@ -19,8 +19,6 @@ export ORG_OIE_ENABLED=true
 export USERNAME=mary@acme.com
 get_secret prod/okta-sdk-vars/password PASSWORD
 get_vault_secret_key devex/auth-js-sdk-vars a18n_api_key A18N_API_KEY
-export FB_USERNAME=js_ekdtypn_user@tfbnw.net
-get_secret prod/okta-sdk-vars/fb_password FB_PASSWORD
 
 # If this script is run as a bacon task, run against trexcloud environment
 if [[ "${BACON_TASK}" == true ]]; then
@@ -29,22 +27,12 @@ if [[ "${BACON_TASK}" == true ]]; then
   export SPA_CLIENT_ID=0oa3r92jj01DWBeWC0g7
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_client_secret CLIENT_SECRET
   get_vault_secret_key devex/trex-js-idx-sdk-vars trex_idx_sdk_org_api_key OKTA_API_KEY
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_id MFA_CLIENT_ID
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_secret MFA_CLIENT_SECRET
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_id CUSTOM_CLIENT_ID
-  get_vault_secret_key devex/trex-js-idx-sdk-vars trex_mfa_client_secret CUSTOM_CLIENT_SECRET
 else
   echo "Running tests against production (ok12) org"
   export ISSUER=https://javascript-idx-sdk.okta.com
   export SPA_CLIENT_ID=0oa17suj5x9khaVH75d7
   get_vault_secret_key devex/prod-js-idx-sdk-vars prod_client_secret CLIENT_SECRET
   get_vault_secret_key devex/prod-js-idx-sdk-vars prod_idx_sdk_org_api_key OKTA_API_KEY
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_mfa_client_id MFA_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_mfa_client_secret MFA_CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_custom_client_id CUSTOM_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_custom_client_secret CUSTOM_CLIENT_SECRET
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_totp_client_id TOTP_CLIENT_ID
-  get_vault_secret_key devex/prod-js-idx-sdk-vars prod_totp_client_secret TOTP_CLIENT_SECRET
 fi
 
 # Run the tests

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -22,9 +22,6 @@ export ORG_OIE_ENABLED=true
 export CLIENT_ID=0oa8lrg7ojTsbJgRQ696
 export REFRESH_TOKEN=true
 
-export FB_USERNAME=ycfjikukbl_1613767309@tfbnw.net 
-get_secret prod/okta-sdk-vars/fb_password FB_PASSWORD
-
 # Run the tests
 if ! yarn test:e2e; then
   echo "OIE e2e tests failed! Exiting..."

--- a/test/spec/idx/remediators/GenericRemediator.ts
+++ b/test/spec/idx/remediators/GenericRemediator.ts
@@ -22,14 +22,14 @@ describe('remediators/GenericRemediator', () => {
 
   describe('Override canRemediate', () => {
     describe('server side validation', () => {
-      it('returns true when no inputs', () => {
+      it('returns true when step is specified in options', () => {
         const remediation = IdxRemediationFactory.build({
           name: 'foo',
           value: [],
           action: jest.fn()
         });
         const values = {} as RemediationValues;
-        const remediator = new GenericRemediator(remediation, values);
+        const remediator = new GenericRemediator(remediation, values, { step: 'foo' });
         expect(remediator.canRemediate()).toBe(true);
       });
 
@@ -43,22 +43,7 @@ describe('remediators/GenericRemediator', () => {
         expect(remediator.canRemediate()).toBe(true);
       });
 
-      it('returns true when any input key can be found in values', () => {
-        const remediation = IdxRemediationFactory.build({
-          name: 'foo',
-          value: [
-            UsernameValueFactory.build(),
-          ],
-          action: jest.fn()
-        });
-        const values = {
-          identifier: 'fake-identifier',
-        } as RemediationValues;
-        const remediator = new GenericRemediator(remediation, values);
-        expect(remediator.canRemediate()).toBe(true);
-      });
-
-      it('returns false when no input key can be found in values', () => {
+      it('returns false by default', () => {
         const remediation = IdxRemediationFactory.build({
           name: 'foo',
           value: [


### PR DESCRIPTION
Only allow to proceed when options.step is specifically provided from downstream clients, so unneeded auto proceeding can be avoid.