### PR TITLE
Upgrade minimal node support version to 14

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -16,7 +16,7 @@ test_suites:
     - name: unit
       script_path: ../okta-auth-js/scripts
       sort_order: '2'
-      timeout: '10'
+      timeout: '20'
       script_name: unit
       criteria: MERGE
       queue_name: small

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -118,8 +118,8 @@ module.exports = {
           'devDependencies': false
         }],
         'node/no-unsupported-features/es-builtins': ['error', {
-          // features that are not supported before v12 are transformed in babel.cjs.js for commonjs output
-          version: '>=12.0.0'
+          // features that are not supported before v14 are transformed in babel.cjs.js for commonjs output
+          version: '>=14.0.0'
         }],
         'import/no-commonjs': 'error',
         "jsdoc/check-tag-names": 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - '12'
+  - '14'
 
 install:
   - yarn install --frozen-lockfile

--- a/babel.cjs.js
+++ b/babel.cjs.js
@@ -6,7 +6,7 @@ module.exports = {
     [
       '@babel/preset-env', {
       'targets': {
-        'node': 14
+        'node': true
       },
       'modules': 'commonjs'
     }
@@ -16,7 +16,7 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     // https://babeljs.io/docs/en/babel-plugin-transform-runtime#corejs
     ['@babel/plugin-transform-runtime', {
-      corejs: 3
+      corejs: false
     }],
     ['@babel/plugin-transform-modules-commonjs', {
       'strict': true,

--- a/babel.cjs.js
+++ b/babel.cjs.js
@@ -6,7 +6,7 @@ module.exports = {
     [
       '@babel/preset-env', {
       'targets': {
-        'node': 11
+        'node': 14
       },
       'modules': 'commonjs'
     }

--- a/babel.cjs.js
+++ b/babel.cjs.js
@@ -15,9 +15,7 @@ module.exports = {
     '@babel/plugin-transform-typescript',
     '@babel/plugin-proposal-class-properties',
     // https://babeljs.io/docs/en/babel-plugin-transform-runtime#corejs
-    ['@babel/plugin-transform-runtime', {
-      corejs: false
-    }],
+    '@babel/plugin-transform-runtime',
     ['@babel/plugin-transform-modules-commonjs', {
       'strict': true,
       'noInterop': false

--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@babel/runtime-corejs3": "^7.17.0",
     "@peculiar/webcrypto": "^1.4.0",
     "Base64": "1.1.0",
     "atob": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "@peculiar/webcrypto": "^1.4.0",
     "Base64": "1.1.0",
     "atob": "^2.1.2",
-    "broadcast-channel": "^4.14.0",
+    "broadcast-channel": "~4.14.0",
     "btoa": "^1.2.1",
     "core-js": "^3.6.5",
     "cross-fetch": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "not IE_Mob 11"
   ],
   "engines": {
-    "node": ">=11.0",
+    "node": ">=14.0",
     "yarn": "^1.7.0"
   },
   "dependencies": {
@@ -155,7 +155,7 @@
     "@peculiar/webcrypto": "^1.4.0",
     "Base64": "1.1.0",
     "atob": "^2.1.2",
-    "broadcast-channel": "4.13.0",
+    "broadcast-channel": "^4.14.0",
     "btoa": "^1.2.1",
     "core-js": "^3.6.5",
     "cross-fetch": "^3.1.5",

--- a/samples/generated/express-embedded-auth-with-sdk/package.json
+++ b/samples/generated/express-embedded-auth-with-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "start": "node ./web-server/server.js",

--- a/samples/generated/express-embedded-sign-in-widget/package.json
+++ b/samples/generated/express-embedded-sign-in-widget/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "start": "SIW_VERSION=${SIW_VERSION-6.4.2} node ./web-server/server.js",

--- a/samples/templates/express-embedded-sign-in-widget/package.json
+++ b/samples/templates/express-embedded-sign-in-widget/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "start": "SIW_VERSION=${SIW_VERSION-{{ siwVersion }}{{append '}'}} node ./web-server/server.js",

--- a/samples/test/package.json
+++ b/samples/test/package.json
@@ -13,7 +13,7 @@
     "test:features": "RUN_CUCUMBER_TESTS=1 node ./runner"
   },
   "engines": {
-    "node": ">=11.0",
+    "node": ">=14.0",
     "yarn": "^1.7.0"
   },
   "dependencies": {

--- a/samples/test/steps/when.ts
+++ b/samples/test/steps/when.ts
@@ -85,6 +85,9 @@ When(
 
 When(
   'she inputs the correct code from her {string}',
+  {
+    timeout: 30000,
+  },
   async function(this: ActionContext, type: string) {
     let code = '';
     if (type === 'SMS') {

--- a/samples/test/support/management-api/createCredentials.ts
+++ b/samples/test/support/management-api/createCredentials.ts
@@ -30,7 +30,7 @@ export default async function (
   return Object.assign({}, a18nProfile, {
     firstName,
     lastName: lastName || `Mc${firstName}face`,
-    password: crypto.randomBytes(16).toString('base64'),
+    password: crypto.randomBytes(16).toString('base64') + 'Aa1',
     username: a18nProfile.emailAddress,
     email: a18nProfile.emailAddress,
   });

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -29,11 +29,17 @@ if [ ! -z "$WIDGET_VERSION" ]; then
   echo "WIDGET_VERSION installed: ${WIDGET_VERSION}"
 fi
 
-# Install dependences
-if ! yarn install --frozen-lockfile; then
+# Install dependences. --ignore-scripts will prevent chromedriver from attempting to install
+if ! yarn install --frozen-lockfile --ignore-scripts; then
   echo "yarn install failed! Exiting..."
   exit ${FAILED_SETUP}
 fi
+
+# microtime was not built due to `--ignore-scripts` flag, build it manually
+cd ./node_modules/microtime
+yum install -y python3
+yarn
+cd ../..
 
 # Build
 if ! yarn build; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -29,17 +29,11 @@ if [ ! -z "$WIDGET_VERSION" ]; then
   echo "WIDGET_VERSION installed: ${WIDGET_VERSION}"
 fi
 
-# Install dependences. --ignore-scripts will prevent chromedriver from attempting to install
-if ! yarn install --frozen-lockfile --ignore-scripts; then
+# Install dependences
+if ! yarn install --frozen-lockfile; then
   echo "yarn install failed! Exiting..."
   exit ${FAILED_SETUP}
 fi
-
-# microtime was not built due to `--ignore-scripts` flag, build it manually
-cd ./node_modules/microtime
-yum install -y python3
-yarn
-cd ../..
 
 # Build
 if ! yarn build; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -35,8 +35,9 @@ if ! yarn install --frozen-lockfile --ignore-scripts; then
   exit ${FAILED_SETUP}
 fi
 
-# Prebuild of microtime requires a version of gcc with support for CXXABI_1.3.8
-# Amazon Linux 2 used in Bacon has old version of gcc, so don't use prebuild, build instead
+# Prebuild of `microtime` requires a version of GCC with support for CXXABI_1.3.8
+# Bacon uses Amazon Linux 2 with old version of GCC which causes error
+# To fix this, don't use prebuild of `microtime`, build instead
 cd ./node_modules/microtime
 rm -rf ./prebuilds
 yum install -y python3

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -35,11 +35,8 @@ if ! yarn install --frozen-lockfile --ignore-scripts; then
   exit ${FAILED_SETUP}
 fi
 
-# Prebuild of `microtime` requires a version of GCC with support for CXXABI_1.3.8
-# Bacon uses Amazon Linux 2 with old version of GCC which causes error
-# To fix this, don't use prebuild of `microtime`, build instead
+# microtime was not built due to `--ignore-scripts` flag, build it manually
 cd ./node_modules/microtime
-rm -rf ./prebuilds
 yum install -y python3
 yarn
 cd ../..

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,7 +10,7 @@ export PATH="${PATH}:$(yarn global bin)"
 
 # Install required node version
 export NVM_DIR="/root/.nvm"
-NODE_VERSION="${1:-v12.22.0}"
+NODE_VERSION="${1:-v14.18.0}"
 setup_service node $NODE_VERSION
 # Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
 setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
@@ -34,6 +34,14 @@ if ! yarn install --frozen-lockfile --ignore-scripts; then
   echo "yarn install failed! Exiting..."
   exit ${FAILED_SETUP}
 fi
+
+# Prebuild of microtime requires a version of gcc with support for CXXABI_1.3.8
+# Amazon Linux 2 used in Bacon has old version of gcc, so don't use prebuild, build instead
+cd ./node_modules/microtime
+rm -rf ./prebuilds
+yum install -y python3
+yarn
+cd ../..
 
 # Build
 if ! yarn build; then

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -2,5 +2,5 @@ set -e
 
 # run the validate and unit tests
 # validate will run lint and typescript build
-#yarn validate
+yarn validate
 yarn test:unit

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -2,5 +2,5 @@ set -e
 
 # run the validate and unit tests
 # validate will run lint and typescript build
-yarn validate
+#yarn validate
 yarn test:unit

--- a/test/support/package.json
+++ b/test/support/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint ."
   },
   "engines": {
-    "node": ">=10.3",
+    "node": ">=14.0",
     "yarn": "^1.7.0"
   },
   "dependencies": {

--- a/test/types/authStateManager.test-d.ts
+++ b/test/types/authStateManager.test-d.ts
@@ -25,11 +25,12 @@ const authClient = new OktaAuth({});
 (async () => {
   const authStateManager = authClient.authStateManager;
 
-  authStateManager.subscribe((authState: AuthState) => {});
-  authStateManager.unsubscribe((authState: AuthState) => {});
+  const handler = (authState: AuthState) => {};
+  authStateManager.subscribe(handler);
+  authStateManager.unsubscribe(handler);
   authStateManager.unsubscribe();
 
-  authStateManager.updateAuthState();
+  await authStateManager.updateAuthState();
 
   const authState = authStateManager.getAuthState()!;
   expectType<AuthState>(authState);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3859,7 +3859,7 @@ broadcast-channel@^4.10.0:
     rimraf "3.0.2"
     unload "2.3.1"
 
-broadcast-channel@^4.14.0:
+broadcast-channel@~4.14.0:
   version "4.14.0"
   resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.14.0.tgz#cd2ce466128130ec3a93f7c1f1ed01d658575e35"
   integrity sha512-uNzxOgBQ+boWCRDESLNg3zZWQ3iz/X7j/uD8pAfr4/S7wQerXVvJI/SBKd9J6ckaPt2jil0gq+7l+3b+kuxJYw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3846,7 +3846,7 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-broadcast-channel@4.13.0, broadcast-channel@^4.10.0:
+broadcast-channel@^4.10.0:
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.13.0.tgz#21387b2602b9e9ec3b97b03bd8a8d2c198352ff6"
   integrity sha512-fcDr8QNJ4SOb6jyjUNZatVNmcHtSWfW4PFcs4xIEFZAtorKCIFoEYtjIjaQ4c0jrbr/Bl8NIwOWiLSyspoAnEQ==
@@ -3854,6 +3854,19 @@ broadcast-channel@4.13.0, broadcast-channel@^4.10.0:
     "@babel/runtime" "^7.16.0"
     detect-node "^2.1.0"
     microtime "3.0.0"
+    oblivious-set "1.1.1"
+    p-queue "6.6.2"
+    rimraf "3.0.2"
+    unload "2.3.1"
+
+broadcast-channel@^4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.14.0.tgz#cd2ce466128130ec3a93f7c1f1ed01d658575e35"
+  integrity sha512-uNzxOgBQ+boWCRDESLNg3zZWQ3iz/X7j/uD8pAfr4/S7wQerXVvJI/SBKd9J6ckaPt2jil0gq+7l+3b+kuxJYw==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    detect-node "^2.1.0"
+    microtime "3.1.0"
     oblivious-set "1.1.1"
     p-queue "6.6.2"
     rimraf "3.0.2"
@@ -9568,6 +9581,14 @@ microtime@3.0.0:
     node-addon-api "^1.2.0"
     node-gyp-build "^3.8.0"
 
+microtime@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/microtime/-/microtime-3.1.0.tgz#599a71250e3116c59f0fe5271dae4cc44321869c"
+  integrity sha512-GcjhfC2y/DF2znac8IRwri7+YUIy34QRHz/iZK3bHrh74qrNNOpAJQwiOMnIG+v1J0K4eiqd+RiGzN3F1eofTQ==
+  dependencies:
+    node-addon-api "^5.0.0"
+    node-gyp-build "^4.4.0"
+
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2", mime-db@^1.28.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -9835,6 +9856,11 @@ node-addon-api@^1.2.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
+node-addon-api@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.0.0.tgz#7d7e6f9ef89043befdb20c1989c905ebde18c501"
+  integrity sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==
+
 node-cache@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
@@ -9858,6 +9884,11 @@ node-gyp-build@^3.8.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.9.0.tgz#53a350187dd4d5276750da21605d1cb681d09e25"
   integrity sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==
+
+node-gyp-build@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.5.0.tgz#7a64eefa0b21112f89f58379da128ac177f20e40"
+  integrity sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
- Set min supported Node version to 14
- Update `broadcast-channel` to `^4.14.0` (latest version depends on `microtime 3.1.0` which requires Node 14)
- Don't use `corejs: 3` in `@babel/plugin-transform-runtime` (was needed for `Object.fromEntries` which requires Node 12)
- `microtime` is a native module, needs to be built manually in Bacon setup script because of `--ignore-scripts` flag

Internal ref: [OKTA-504784](https://oktainc.atlassian.net/browse/OKTA-504784)

Fixes https://github.com/okta/okta-auth-js/issues/1256
