### PR TITLE
Allow custom scheme in `isAbsoluteUrl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Other
 
 - [#1243](https://github.com/okta/okta-auth-js/pull/1243) Adds export of `./polyfill` in package.json
+- [#1276](https://github.com/okta/okta-auth-js/pull/1276) Support custom URL scheme in `isAbsoluteUrl`
 
 ## 6.7.5
 

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -11,7 +11,7 @@
  */
 
 export function isAbsoluteUrl(url) {
-  return /^(?:[a-z]+:)?\/\//i.test(url);
+  return /^[a-z][a-z0-9+.-]*:/i.test(url);
 }
 
 export function toAbsoluteUrl(url = '', baseUrl) {

--- a/test/spec/util.js
+++ b/test/spec/util.js
@@ -202,9 +202,42 @@ describe('util', function() {
     });
   });
 
+  describe('isAbsoluteUrl', () => {
+    it('returns true if url has a scheme', () => {
+      expect(util.isAbsoluteUrl('https://acme.com/redirect')).toBe(true);
+    });
+
+    it('returns true if url has a custom scheme (RFC2396)', () => {
+      expect(util.isAbsoluteUrl('com.acme.app://redirect')).toBe(true);
+      expect(util.isAbsoluteUrl('com.acme.APP://redirect')).toBe(true);
+      expect(util.isAbsoluteUrl('com.acme.my-mobile-app+12://redirect')).toBe(true);
+      expect(util.isAbsoluteUrl('bad^scheme://redirect')).toBe(false);
+    });
+
+    it('returns true if url has a custom scheme without double slash', () => {
+      expect(util.isAbsoluteUrl('com.acme.app:redirect')).toBe(true);
+      expect(util.isAbsoluteUrl('com.acme.app:/redirect')).toBe(true);
+    });
+
+    it('returns false if url has no scheme', () => {
+      expect(util.isAbsoluteUrl('acme.com/redirect')).toBe(false);
+      expect(util.isAbsoluteUrl('/redirect')).toBe(false);
+      expect(util.isAbsoluteUrl('redirect')).toBe(false);
+    });
+
+    it('returns false if url is a network-path', () => {
+      expect(util.isAbsoluteUrl('//redirect')).toBe(false);
+    });
+  });
+  
   describe('toAbsoluteUrl', () => {
     it('should return same url if url is an absolute url', () => {
       const url = 'http://fake.com';
+      expect(util.toAbsoluteUrl(url)).toEqual(url);
+    });
+
+    it('should return same url if url is an absolute url with custom scheme', () => {
+      const url = 'com.acme.app://redirect';
       expect(util.toAbsoluteUrl(url)).toEqual(url);
     });
 


### PR DESCRIPTION
Changes to `isAbsoluteUrl` util according to [RFC2396](https://www.ietf.org/rfc/rfc2396.txt):
- Support custom URL scheme 
- Don't treat network-path (URL starts with '//') as absolute URL

Resolves https://github.com/okta/okta-auth-js/issues/1248 and https://github.com/okta/okta-oidc-android/issues/219
Internal ref: https://oktainc.atlassian.net/browse/OKTA-511508