### PR TITLE
fix: generic remediator error handling issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 6.7.6
+
+### Fixes
+
+- [#1277](https://github.com/okta/okta-auth-js/pull/1277) IDX GenericRemediator patches (beta):
+  - fixes error handling issue
+
 ## 6.7.5
 
 ### Fixes

--- a/lib/idx/util.ts
+++ b/lib/idx/util.ts
@@ -287,11 +287,17 @@ export function handleIdxError(authClient: OktaAuthIdxInterface, e, options = {}
     requestDidSucceed: false
   };
   const terminal = isTerminalResponse(idxResponse);
-  const remediator = getRemediator(idxResponse.neededToProceed, {}, options);
-  const nextStep = remediator && getNextStep(authClient, remediator, idxResponse);
-  return {
-    idxResponse,
-    ...(terminal && { terminal }),
-    ...(!terminal && nextStep && { nextStep }) 
-  };
+  const messages = getMessagesFromResponse(idxResponse, options);
+  if (terminal) {
+    return { idxResponse, terminal, messages };
+  } else {
+    const remediator = getRemediator(idxResponse.neededToProceed, {}, options);
+    const nextStep = remediator && getNextStep(authClient, remediator, idxResponse);
+    return {
+      idxResponse,
+      messages,
+      ...(nextStep && { nextStep }),
+    };
+  }
+  
 }

--- a/test/spec/idx/util.ts
+++ b/test/spec/idx/util.ts
@@ -449,6 +449,7 @@ describe('idx/util', () => {
           ...idxResponse,
           requestDidSucceed: false
         },
+        messages: [],
         terminal: true,
       });
     });
@@ -468,6 +469,7 @@ describe('idx/util', () => {
           ...idxResponse,
           requestDidSucceed: false
         },
+        messages: [],
       });
     });
     it('non-terminal IDX response and a remediator: it augments the object with requestDidSucceed = false and returns it along with next step info', () => {
@@ -495,6 +497,7 @@ describe('idx/util', () => {
           ...idxResponse,
           requestDidSucceed: false
         },
+        messages: [],
         nextStep
       });
       expect(mockGetNextStep).toHaveBeenCalledWith(authClient, context);


### PR DESCRIPTION
Issue:

The following error happens when `idx.session.expired` error happen. It's because generic remediator will always be available and it runs `getNextStep` fn even it's a terminal error.

```
message: "Cannot read properties of undefined (reading 'name')"
stack: "TypeError: Cannot read properties of undefined (reading 'name')
    at GenericRemediator.getName (http://localhost:3000/okta-sign-in.next.js:218334:31)
    at GenericRemediator.getNextStep (http://localhost:3000/okta-sign-in.next.js:219412:23)
    at getNextStep (http://localhost:3000/okta-sign-in.next.js:221990:29)
    at handleIdxError (http://localhost:3000/okta-sign-in.next.js:222013:32)
    at _loop$ (http://localhost:3000/okta-sign-in.next.js:217624:53)
    at tryCatch (http://localhost:3000/okta-sign-in.next.js:268845:17)
    at Generator.invoke [as _invoke] (http://localhost:3000/okta-sign-in.next.js:269065:22)
    at prototype.<computed> [as throw] (http://localhost:3000/okta-sign-in.next.js:268898:21)
    at tryCatch (http://localhost:3000/okta-sign-in.next.js:268845:17)
    at maybeInvokeDelegate (http://localhost:3000/okta-sign-in.next.js:269126:18)"
```

Fix: 

Change back to original `if...else...` logic
