### PR TITLE
Updates account unlock error message

### DIFF
--- a/samples/test/features/account-unlock.feature
+++ b/samples/test/features/account-unlock.feature
@@ -23,7 +23,7 @@ Feature: Account Unlock with Single factor (Email, Phone, Okta Verify Push)
     Then she sees a page to challenge her email authenticator
     When she inputs the correct code from her "Email"
      And she submits the form
-    Then she should see a message "Your account is now unlocked!"
+    Then she should see a message containing "unlocked!"
 
   Scenario: Mary recovers from a locked account with Phone SMS OTP
     Given she has enrolled in the "SMS" factor
@@ -38,4 +38,4 @@ Feature: Account Unlock with Single factor (Email, Phone, Okta Verify Push)
     Then the screen changes to receive an input for a code to verify
     When she inputs the correct code from her "SMS"
      And she submits the form
-    Then she should see a message "Your account is now unlocked!"
+    Then she should see a message containing "unlocked!"

--- a/samples/test/steps/then.ts
+++ b/samples/test/steps/then.ts
@@ -188,6 +188,11 @@ Then(
 );
 
 Then(
+  /^she should see (?:a message on the Login form|the message|a message|an error message) containing "(?<message>.+?)"$/,
+  checkFormContainsMessage
+);
+
+Then(
   /^the sample shows an error message "(?<message>.+?)" on the Sample App$/,
   checkFormMessage
 );


### PR DESCRIPTION
- Account unlock test failing on trex due to message change in backend
- Updates the test to check if message contains `unlocked` instead of specific error message