### PR TITLE
Faster type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "@rollup/plugin-alias": "^3.1.8",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-replace": "^3.0.0",
-    "@tsd/typescript": "^4.6.4",
+    "@tsd/typescript": "^4.8.2",
     "@types/jest": "^27.5.1",
     "@types/node": "^14.0.3",
     "@typescript-eslint/eslint-plugin": "^5.18.0",

--- a/test/types/jest.config.js
+++ b/test/types/jest.config.js
@@ -1,7 +1,5 @@
 const REPORT_DIR = '../../build2/reports/tsd';
 
-let counts = {};
-
 module.exports = {
   runner: 'jest-runner-tsd',
   testMatch: ['**/*.test-d.ts'],
@@ -9,14 +7,8 @@ module.exports = {
     'default',
     ['jest-junit', {
       outputDirectory: REPORT_DIR,
-      suiteNameTemplate: (vars) => `${vars.filename}`,
-      classNameTemplate: (vars) => {
-        if (!counts[vars.filename]) {
-          counts[vars.filename] = 0;
-        }
-        counts[vars.filename] = counts[vars.filename] + 1;
-        return `${vars.filename} ${counts[vars.filename]}`;
-      }
+      suiteNameTemplate: '{filename}',
+      classNameTemplate: '{title}',
     }]
   ]
 };

--- a/test/types/package.json
+++ b/test/types/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "description": "test type declarations",
   "scripts": {
-    "test": "jest --runInBand"
+    "test": "jest"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1987,10 +1987,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
-"@tsd/typescript@^4.6.4":
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/@tsd/typescript/-/typescript-4.6.4.tgz#2d49c111c32d15651c9ebe0e6f19a5df04d53f5f"
-  integrity sha512-+9o716aWbcjKLbV4bCrGlJKJbS0UZNogfVk9U7ffooYSf/9GOJ6wwahTSrRjW7mWQdywQ/sIg9xxbuPLnkmhwg==
+"@tsd/typescript@^4.8.2":
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/@tsd/typescript/-/typescript-4.8.2.tgz#2523eb4c4e33e1b352e290b70711d4646f156de9"
+  integrity sha512-Guwrz4D/ATCZnWGxf8pejvxEnR2xLXwxFXr0wQh6xuRkyEmEtqJ/wj2y2Z+JTjN5wVilG/Lw7Lks5HZMo9kyXw==
 
 "@tsd/typescript@~4.3.2":
   version "4.3.5"


### PR DESCRIPTION
Noticed that on dev-7 `yarn test:types` runs too long.
Improved from 129s to 34s. in Bacon.

- Removed `--runInBand` and fixed `suiteNameTemplate / classNameTemplate` (should be template string, not function for parallel tests)
- Updating `@tsd/typescript` also makes a difference in speed.