### PR TITLE
feat: support acr_values for authorize endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,7 @@ The following configuration options can be included in `token.getWithoutPrompt`,
 | `display` | The display parameter to be passed to the Social Identity Provider when performing [Social Login][social-login]. |
 | `prompt` | Determines whether the Okta login will be displayed on failure. Use `none` to prevent this behavior. Valid values: `none`, `consent`, `login`, or `consent login`. See [Parameter details](https://developer.okta.com/docs/reference/api/oidc/#parameter-details) for more information. |
 | `maxAge` | Allowable elapsed time, in seconds, since the last time the end user was actively authenticated by Okta. |
+| `acrValues` | Optional parameter to increase the level of user assurance. Values supported: `urn:okta:loa:1fa:pwd`, `urn:okta:loa:1fa:any`, `urn:okta:loa:2fa:any`, `urn:okta:loa:2fa:any:ifpossible`, `phr`, `phrh`. See [Predefined ACR values](https://developer.okta.com/docs/guides/step-up-authentication/main/#predefined-parameter-values) for more information. |
 | `loginHint` | A username to prepopulate if prompting for authentication. |
 
 For more details, see Okta's [Authorize Request API](https://developer.okta.com/docs/api/resources/oidc#request-parameters).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [localStorage]: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
 [sessionStorage]: https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
 [cookie]: https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
+[early-access]: https://developer.okta.com/docs/reference/releases-at-okta/#early-access-ea
 
 [<img src="https://www.okta.com/sites/default/files/Dev_Logo-01_Large-thumbnail.png" align="right" width="256px"/>](https://devforum.okta.com/)
 
@@ -1316,7 +1317,7 @@ The following configuration options can be included in `token.getWithoutPrompt`,
 | `display` | The display parameter to be passed to the Social Identity Provider when performing [Social Login][social-login]. |
 | `prompt` | Determines whether the Okta login will be displayed on failure. Use `none` to prevent this behavior. Valid values: `none`, `consent`, `login`, or `consent login`. See [Parameter details](https://developer.okta.com/docs/reference/api/oidc/#parameter-details) for more information. |
 | `maxAge` | Allowable elapsed time, in seconds, since the last time the end user was actively authenticated by Okta. |
-| `acrValues` | Optional parameter to increase the level of user assurance. Values supported: `urn:okta:loa:1fa:pwd`, `urn:okta:loa:1fa:any`, `urn:okta:loa:2fa:any`, `urn:okta:loa:2fa:any:ifpossible`, `phr`, `phrh`. See [Predefined ACR values](https://developer.okta.com/docs/guides/step-up-authentication/main/#predefined-parameter-values) for more information. |
+| `acrValues` | [[EA][early-access]] Optional parameter to increase the level of user assurance. See [Predefined ACR values](https://developer.okta.com/docs/guides/step-up-authentication/main/#predefined-parameter-values) for more information. |
 | `loginHint` | A username to prepopulate if prompting for authentication. |
 
 For more details, see Okta's [Authorize Request API](https://developer.okta.com/docs/api/resources/oidc#request-parameters).

--- a/lib/oidc/endpoints/authorize.ts
+++ b/lib/oidc/endpoints/authorize.ts
@@ -43,6 +43,7 @@ export function convertTokenParamsToOAuthParams(tokenParams: TokenParams) {
     'response_type': tokenParams.responseType,
     'sessionToken': tokenParams.sessionToken,
     'state': tokenParams.state,
+    'acr_values': tokenParams.acrValues,
   };
   oauthParams = removeNils(oauthParams) as OAuthParams;
 

--- a/lib/oidc/exchangeCodeForTokens.ts
+++ b/lib/oidc/exchangeCodeForTokens.ts
@@ -32,7 +32,8 @@ export function exchangeCodeForTokens(sdk: OktaAuthOAuthInterface, tokenParams: 
     redirectUri,
     scopes,
     ignoreSignature,
-    state
+    state,
+    acrValues
   } = tokenParams;
 
   var getTokenOptions = {
@@ -59,6 +60,7 @@ export function exchangeCodeForTokens(sdk: OktaAuthOAuthInterface, tokenParams: 
         scopes,
         responseType,
         ignoreSignature,
+        acrValues
       };
       return handleOAuthResponse(sdk, handleResponseOptions, response, urls!)
         .then((response: TokenResponse) => {

--- a/lib/oidc/handleOAuthResponse.ts
+++ b/lib/oidc/handleOAuthResponse.ts
@@ -47,7 +47,7 @@ export async function handleOAuthResponse(
   res: OAuthResponse,
   urls?: CustomUrls
 ): Promise<TokenResponse> {
-  var pkce = sdk.options.pkce !== false;
+  const pkce = sdk.options.pkce !== false;
 
   // The result contains an authorization_code and PKCE is enabled 
   // `exchangeCodeForTokens` will call /token then call `handleOauthResponse` recursively with the result
@@ -61,32 +61,32 @@ export async function handleOAuthResponse(
   tokenParams = tokenParams || getDefaultTokenParams(sdk);
   urls = urls || getOAuthUrls(sdk, tokenParams);
 
-  var responseType = tokenParams.responseType || [];
+  let responseType = tokenParams.responseType || [];
   if (!Array.isArray(responseType)) {
     responseType = [responseType];
   }
 
-  var scopes;
+  let scopes;
   if (res.scope) {
     scopes = res.scope.split(' ');
   } else {
     scopes = clone(tokenParams.scopes);
   }
-  var clientId = tokenParams.clientId || sdk.options.clientId;
+  const clientId = tokenParams.clientId || sdk.options.clientId;
 
   // Handling the result from implicit flow or PKCE token exchange
   validateResponse(res, tokenParams);
 
-  var tokenDict = {} as Tokens;
-  var expiresIn = res.expires_in;
-  var tokenType = res.token_type;
-  var accessToken = res.access_token;
-  var idToken = res.id_token;
-  var refreshToken = res.refresh_token;
-  var now = Math.floor(Date.now()/1000);
+  const tokenDict = {} as Tokens;
+  const expiresIn = res.expires_in;
+  const tokenType = res.token_type;
+  const accessToken = res.access_token;
+  const idToken = res.id_token;
+  const refreshToken = res.refresh_token;
+  const now = Math.floor(Date.now()/1000);
 
   if (accessToken) {
-    var accessJwt = sdk.token.decode(accessToken);
+    const accessJwt = sdk.token.decode(accessToken);
     tokenDict.accessToken = {
       accessToken: accessToken,
       claims: accessJwt.payload,
@@ -112,8 +112,8 @@ export async function handleOAuthResponse(
   }
 
   if (idToken) {
-    var idJwt = sdk.token.decode(idToken);
-    var idTokenObj: IDToken = {
+    const idJwt = sdk.token.decode(idToken);
+    const idTokenObj: IDToken = {
       idToken: idToken,
       claims: idJwt.payload,
       expiresAt: idJwt.payload.exp! - idJwt.payload.iat! + now, // adjusting expiresAt to be in local time
@@ -123,11 +123,12 @@ export async function handleOAuthResponse(
       clientId: clientId!
     };
 
-    var validationParams: TokenVerifyParams = {
+    const validationParams: TokenVerifyParams = {
       clientId: clientId!,
       issuer: urls.issuer!,
       nonce: tokenParams.nonce,
-      accessToken: accessToken
+      accessToken: accessToken,
+      acrValues: tokenParams.acrValues
     };
 
     if (tokenParams.ignoreSignature !== undefined) {

--- a/lib/oidc/options/OAuthOptionsConstructor.ts
+++ b/lib/oidc/options/OAuthOptionsConstructor.ts
@@ -79,6 +79,8 @@ export function createOAuthOptionsConstructor() {
     ignoreSignature: boolean;
     codeChallenge: string;
     codeChallengeMethod: string;
+    acrValues: string;
+    maxAge: string | number;
 
     // Additional options
     tokenManager: TokenManagerOptions;
@@ -122,6 +124,8 @@ export function createOAuthOptionsConstructor() {
       this.ignoreSignature = !!options.ignoreSignature;
       this.codeChallenge = options.codeChallenge;
       this.codeChallengeMethod = options.codeChallengeMethod;
+      this.acrValues = options.acrValues;
+      this.maxAge = options.maxAge;
 
       this.tokenManager = options.tokenManager;
       this.postLogoutRedirectUri = options.postLogoutRedirectUri;

--- a/lib/oidc/types/UserClaims.ts
+++ b/lib/oidc/types/UserClaims.ts
@@ -42,4 +42,5 @@ export type UserClaims<T extends CustomUserClaims = CustomUserClaims> = T & {
   ver?: number;
   zoneinfo?: string;
   at_hash?: string;
+  acr?: string;
 }

--- a/lib/oidc/types/api.ts
+++ b/lib/oidc/types/api.ts
@@ -81,6 +81,7 @@ export interface TokenVerifyParams {
   ignoreSignature?: boolean;
   nonce?: string;
   accessToken?: string; // raw access token string
+  acrValues?: string;
 }
 
 export interface IDTokenAPI {

--- a/lib/oidc/types/meta.ts
+++ b/lib/oidc/types/meta.ts
@@ -24,7 +24,8 @@ export interface OAuthTransactionMeta extends
     'state' |
     'pkce' |
     'ignoreSignature' |
-    'nonce'
+    'nonce' |
+    'acrValues'
   >
 {
   urls: CustomUrls;

--- a/lib/oidc/types/options.ts
+++ b/lib/oidc/types/options.ts
@@ -35,6 +35,7 @@ export interface TokenParams extends CustomUrls {
   state?: string;
   nonce?: string;
   scopes?: string[];
+  acrValues?: string;
   display?: string;
   ignoreSignature?: boolean;
   codeVerifier?: string;
@@ -83,7 +84,9 @@ export interface OktaAuthOAuthOptions extends
     'pkce' |
     'ignoreSignature' |
     'codeChallenge' |
-    'codeChallengeMethod'
+    'codeChallengeMethod' |
+    'maxAge' |
+    'acrValues'
   >
 {
   ignoreLifetime?: boolean;

--- a/lib/oidc/types/proto.ts
+++ b/lib/oidc/types/proto.ts
@@ -31,6 +31,7 @@ export interface OAuthParams {
   grant_type?: string;
   code?: string;
   interaction_code?: string;
+  acr_values?: string;
 }
 
 export interface OAuthResponse {

--- a/lib/oidc/util/defaultTokenParams.ts
+++ b/lib/oidc/util/defaultTokenParams.ts
@@ -25,6 +25,7 @@ export function getDefaultTokenParams(sdk: OktaAuthOAuthInterface): TokenParams 
     responseType,
     responseMode,
     scopes,
+    acrValues,
     state,
     ignoreSignature
   } = sdk.options;
@@ -38,6 +39,7 @@ export function getDefaultTokenParams(sdk: OktaAuthOAuthInterface): TokenParams 
     state: state || generateState(),
     nonce: generateNonce(),
     scopes: scopes || ['openid', 'email'],
+    acrValues,
     ignoreSignature
   });
 }

--- a/lib/oidc/util/oauthMeta.ts
+++ b/lib/oidc/util/oauthMeta.ts
@@ -19,6 +19,7 @@ export function createOAuthMeta(
     state: tokenParams.state!,
     nonce: tokenParams.nonce!,
     ignoreSignature: tokenParams.ignoreSignature!,
+    acrValues: tokenParams.acrValues,
   };
 
   if (tokenParams.pkce === false) {

--- a/lib/oidc/util/validateClaims.ts
+++ b/lib/oidc/util/validateClaims.ts
@@ -42,7 +42,7 @@ export function validateClaims(sdk: OktaAuthOAuthInterface, claims: UserClaims, 
       'does not match [' + aud + ']');
   }
 
-  if (acr && claims.acr && claims.acr !== acr) {
+  if (acr && claims.acr !== acr) {
     throw new AuthSdkError('The acr [' + claims.acr + '] ' +
       'does not match acr_values [' + acr + ']');
   }

--- a/lib/oidc/util/validateClaims.ts
+++ b/lib/oidc/util/validateClaims.ts
@@ -17,9 +17,10 @@ import AuthSdkError from '../../errors/AuthSdkError';
 import { OktaAuthOAuthInterface, TokenVerifyParams, UserClaims } from '../../oidc/types';
 
 export function validateClaims(sdk: OktaAuthOAuthInterface, claims: UserClaims, validationParams: TokenVerifyParams) {
-  var aud = validationParams.clientId;
-  var iss = validationParams.issuer;
-  var nonce = validationParams.nonce;
+  const aud = validationParams.clientId;
+  const iss = validationParams.issuer;
+  const nonce = validationParams.nonce;
+  const acr = validationParams.acrValues;
 
   if (!claims || !iss || !aud) {
     throw new AuthSdkError('The jwt, iss, and aud arguments are all required');
@@ -29,7 +30,7 @@ export function validateClaims(sdk: OktaAuthOAuthInterface, claims: UserClaims, 
     throw new AuthSdkError('OAuth flow response nonce doesn\'t match request nonce');
   }
 
-  var now = Math.floor(Date.now()/1000);
+  const now = Math.floor(Date.now()/1000);
 
   if (claims.iss !== iss) {
     throw new AuthSdkError('The issuer [' + claims.iss + '] ' +
@@ -39,6 +40,11 @@ export function validateClaims(sdk: OktaAuthOAuthInterface, claims: UserClaims, 
   if (claims.aud !== aud) {
     throw new AuthSdkError('The audience [' + claims.aud + '] ' +
       'does not match [' + aud + ']');
+  }
+
+  if (acr && claims.acr && claims.acr !== acr) {
+    throw new AuthSdkError('The acr [' + claims.acr + '] ' +
+      'does not match acr_values [' + acr + ']');
   }
 
   if (claims.iat! > claims.exp!) {

--- a/lib/oidc/verifyToken.ts
+++ b/lib/oidc/verifyToken.ts
@@ -26,14 +26,14 @@ export async function verifyToken(sdk: OktaAuthOAuthInterface, token: IDToken, v
   }
 
   // Decode the Jwt object (may throw)
-  var jwt = decodeToken(token.idToken);
+  const jwt = decodeToken(token.idToken);
 
   // The configured issuer may point to a frontend proxy.
   // Get the "real" issuer from .well-known/openid-configuration
   const configuredIssuer = validationParams?.issuer || sdk.options.issuer;
   const { issuer } = await getWellKnown(sdk, configuredIssuer);
 
-  var validationOptions: TokenVerifyParams = Object.assign({
+  const validationOptions: TokenVerifyParams = Object.assign({
     // base options, can be overridden by params
     clientId: sdk.options.clientId,
     ignoreSignature: sdk.options.ignoreSignature

--- a/test/apps/app/src/config.ts
+++ b/test/apps/app/src/config.ts
@@ -85,7 +85,7 @@ export function getConfigFromUrl(): Config {
   const forceRedirect = url.searchParams.get('forceRedirect') === 'true'; // off by default
   const enableSharedStorage = url.searchParams.get('enableSharedStorage') !== 'false'; // on by default
   const syncStorage = url.searchParams.get('syncStorage') !== 'false'; // on by default
-  const acrValues = url.searchParams.get('acrValues');
+  const acrValues = url.searchParams.get('acrValues') || undefined;
   let crossTabsCount = parseInt(url.searchParams.get('crossTabsCount'));
   if (isNaN(crossTabsCount)) {
     crossTabsCount = DEFAULT_CROSS_TABS_COUNT;

--- a/test/apps/app/src/config.ts
+++ b/test/apps/app/src/config.ts
@@ -85,6 +85,7 @@ export function getConfigFromUrl(): Config {
   const forceRedirect = url.searchParams.get('forceRedirect') === 'true'; // off by default
   const enableSharedStorage = url.searchParams.get('enableSharedStorage') !== 'false'; // on by default
   const syncStorage = url.searchParams.get('syncStorage') !== 'false'; // on by default
+  const acrValues = url.searchParams.get('acrValues');
   let crossTabsCount = parseInt(url.searchParams.get('crossTabsCount'));
   if (isNaN(crossTabsCount)) {
     crossTabsCount = DEFAULT_CROSS_TABS_COUNT;
@@ -98,6 +99,7 @@ export function getConfigFromUrl(): Config {
     pkce,
     defaultScopes,
     scopes,
+    acrValues,
     responseType,
     responseMode,
     postLogoutRedirectUri,

--- a/test/apps/app/src/form.ts
+++ b/test/apps/app/src/form.ts
@@ -52,6 +52,9 @@ const Form = `
   <label for="scopes">Scopes (comma separated)</label><input id="f_scopes" name="scopes" type="text" />
   </div>
   <div class="pure-control-group">
+  <label for="acrValues">acr_values (space separated)</label><input id="f_acrValues" name="acrValues" type="text" />
+  </div>
+  <div class="pure-control-group">
   <label for="postLogoutRedirectUri">Post Logout Redirect URI</label><input id="f_postLogoutRedirectUri" name="postLogoutRedirectUri" type="text" />
   </div>
   <div class="pure-control-group">
@@ -140,6 +143,7 @@ export function updateForm(origConfig: Config): void {
   (document.getElementById('f_redirectUri') as HTMLInputElement).value = config.redirectUri;
   (document.getElementById('f_responseType') as HTMLInputElement).value = config.responseType.join(',');
   (document.getElementById('f_scopes') as HTMLInputElement).value = config.scopes.join(',');
+  (document.getElementById('f_acrValues') as HTMLInputElement).value = config.acrValues;
   (document.getElementById('f_postLogoutRedirectUri') as HTMLInputElement).value = config.postLogoutRedirectUri;
   (document.getElementById('f_clientId') as HTMLInputElement).value = config.clientId;
   (document.getElementById('f_clientSecret') as HTMLInputElement).value = config.clientSecret;

--- a/test/apps/app/src/form.ts
+++ b/test/apps/app/src/form.ts
@@ -52,7 +52,16 @@ const Form = `
   <label for="scopes">Scopes (comma separated)</label><input id="f_scopes" name="scopes" type="text" />
   </div>
   <div class="pure-control-group">
-  <label for="acrValues">acr_values (space separated)</label><input id="f_acrValues" name="acrValues" type="text" />
+  <label for="acrValues"><a href="https://developer.okta.com/docs/guides/step-up-authentication/main/">acr_values</a></label>
+  <select id="f_acrValues" name="acrValues">
+    <option value="" selected>None</option>
+    <option value="urn:okta:loa:1fa:pwd">urn:okta:loa:1fa:pwd</option>
+    <option value="urn:okta:loa:1fa:any">urn:okta:loa:1fa:any</option>
+    <option value="urn:okta:loa:2fa:any">urn:okta:loa:2fa:any</option>
+    <option value="urn:okta:loa:2fa:any:ifpossible">urn:okta:loa:2fa:any:ifpossible</option>
+    <option value="phr">phr</option>
+    <option value="phrh">phrh</option>
+  </select>
   </div>
   <div class="pure-control-group">
   <label for="postLogoutRedirectUri">Post Logout Redirect URI</label><input id="f_postLogoutRedirectUri" name="postLogoutRedirectUri" type="text" />

--- a/test/apps/app/src/form.ts
+++ b/test/apps/app/src/form.ts
@@ -143,7 +143,7 @@ export function updateForm(origConfig: Config): void {
   (document.getElementById('f_redirectUri') as HTMLInputElement).value = config.redirectUri;
   (document.getElementById('f_responseType') as HTMLInputElement).value = config.responseType.join(',');
   (document.getElementById('f_scopes') as HTMLInputElement).value = config.scopes.join(',');
-  (document.getElementById('f_acrValues') as HTMLInputElement).value = config.acrValues;
+  (document.getElementById('f_acrValues') as HTMLInputElement).value = config.acrValues || '';
   (document.getElementById('f_postLogoutRedirectUri') as HTMLInputElement).value = config.postLogoutRedirectUri;
   (document.getElementById('f_clientId') as HTMLInputElement).value = config.clientId;
   (document.getElementById('f_clientSecret') as HTMLInputElement).value = config.clientSecret;

--- a/test/apps/app/src/testApp.ts
+++ b/test/apps/app/src/testApp.ts
@@ -654,7 +654,8 @@ class TestApp {
     options = Object.assign({}, {
       responseType: this.config.responseType,
       scopes: this.config.defaultScopes ? [] : this.config.scopes,
-      state: this.config.state
+      acrValues: this.config.acrValues,
+      state: this.config.state,
     }, options);
     return this.oktaAuth.token.getWithRedirect(options)
       .catch(e => {

--- a/test/e2e/specs/login.js
+++ b/test/e2e/specs/login.js
@@ -69,6 +69,17 @@ describe('E2E login', () => {
         await TestApp.logoutRedirect();
       });
 
+      it('can specify acr_values', async () => {
+        const acrValues = 'urn:okta:loa:2fa:any:ifpossible';
+        await bootstrap({ acrValues });
+        await loginRedirect(flow);
+        await TestApp.getUserInfo();
+        await TestApp.assertUserInfo();
+        const idToken = await TestApp.getIdToken();
+        assert(idToken.claims.acr === acrValues);
+        await TestApp.logoutRedirect();
+      });
+
       it('can login using a popup window', async() => {
         await bootstrap();
         await loginPopup();

--- a/test/spec/oidc/endpoints/authorize.ts
+++ b/test/spec/oidc/endpoints/authorize.ts
@@ -69,5 +69,15 @@ describe('authorize endpoint', () => {
         }
       })).toBe('?client_id=fakeClientId&code_challenge=fakeCodeChallenge&response_type=id_token%20token&scope=openid%20email&launch=launch');
     });
+
+    it('respects acr_values', () => {
+      expect(buildAuthorizeParams({
+        clientId: 'fakeClientId',
+        codeChallenge: 'fakeCodeChallenge',
+        scopes: ['openid'],
+        responseType: 'code',
+        acrValues: 'urn:okta:loa:1fa:any'
+      })).toBe('?client_id=fakeClientId&code_challenge=fakeCodeChallenge&response_type=code&acr_values=urn%3Aokta%3Aloa%3A1fa%3Aany&scope=openid');
+    });
   });
 });

--- a/test/spec/oidc/exchangeCodeForTokens.ts
+++ b/test/spec/oidc/exchangeCodeForTokens.ts
@@ -43,16 +43,19 @@ describe('exchangeCodeForTokens', () => {
     const codeVerifier = 'y';
     const interactionCode = 'b';
     const redirectUri = 'http://localhost';
-    const tokenParams = { authorizationCode, clientId, codeVerifier, interactionCode, redirectUri };
+    const acrValues = 'foo';
+    const getTokenOptions = { authorizationCode, clientId, codeVerifier, interactionCode, redirectUri };
+    const tokenParams = { ...getTokenOptions, acrValues };
     const urls = getOAuthUrls(sdk);
     await exchangeCodeForTokens(sdk, tokenParams);
-    expect(postToTokenEndpoint).toHaveBeenCalledWith(sdk, tokenParams, urls);
+    expect(postToTokenEndpoint).toHaveBeenCalledWith(sdk, getTokenOptions, urls);
     expect(handleOAuthResponse).toHaveBeenCalledWith(sdk, {
       clientId,
       ignoreSignature: undefined,
       redirectUri,
       responseType: ['token', 'id_token'],
-      scopes: ['openid', 'email']
+      scopes: ['openid', 'email'],
+      acrValues
     }, oauthResponse, urls);
   });
 

--- a/test/spec/oidc/util/defaultTokenParams.ts
+++ b/test/spec/oidc/util/defaultTokenParams.ts
@@ -90,4 +90,9 @@ describe('getDefaultTokenParams', () => {
   it('`nonce`: generates a default value', () => {
     expect(getDefaultTokenParams({ options: {} } as OktaAuthOAuthInterface).nonce).toBeTruthy();
   });
+  
+  it('`acrValues`: uses value from sdk.options', () => {
+    const sdk = { options: { acrValues: 'foo' } } as OktaAuthOAuthInterface;
+    expect(getDefaultTokenParams(sdk).acrValues).toBe('foo');
+  });
 });

--- a/test/spec/oidc/util/oauthMeta.ts
+++ b/test/spec/oidc/util/oauthMeta.ts
@@ -71,6 +71,7 @@ describe('oauthMeta', () => {
       codeVerifier: 'abcd',
       codeChallenge: 'efgh',
       codeChallengeMethod: 'fake',
+      acrValues: 'foo',
     });
 
     const meta = createOAuthMeta(sdk, tokenParams);
@@ -86,6 +87,7 @@ describe('oauthMeta', () => {
       codeVerifier: 'abcd',
       codeChallenge: 'efgh',
       codeChallengeMethod: 'fake',
+      acrValues: 'foo',
     });
   });
 });

--- a/test/spec/oidc/util/validateClaims.ts
+++ b/test/spec/oidc/util/validateClaims.ts
@@ -222,4 +222,29 @@ describe('validateClaims', function () {
     };
     expect(fn).not.toThrowError();
   });
+
+  it('validates acr, if acr_values is provided', function() {
+    validationOptions.acrValues = 'urn:okta:loa:2fa:any:ifpossible';
+    const claims = {
+      iss: validationOptions.issuer,
+      aud: validationOptions.clientId,
+      acr: 'foo'
+    } as unknown as UserClaims;
+    var fn = function () {
+      validateClaims(sdk, claims, validationOptions);
+    };
+    expect(fn).toThrowError('The acr [foo] does not match acr_values [urn:okta:loa:2fa:any:ifpossible]');  
+  });
+
+  it('does not throw error on missing acr, because unknown acr_values can be ignored', function() {
+    validationOptions.acrValues = 'foo';
+    const claims = {
+      iss: validationOptions.issuer,
+      aud: validationOptions.clientId,
+    } as unknown as UserClaims;
+    var fn = function () {
+      validateClaims(sdk, claims, validationOptions);
+    };
+    expect(fn).not.toThrowError();
+  });
 });

--- a/test/spec/oidc/util/validateClaims.ts
+++ b/test/spec/oidc/util/validateClaims.ts
@@ -236,7 +236,7 @@ describe('validateClaims', function () {
     expect(fn).toThrowError('The acr [foo] does not match acr_values [urn:okta:loa:2fa:any:ifpossible]');  
   });
 
-  it('does not throw error on missing acr, because unknown acr_values can be ignored', function() {
+  it('does not throw error on missing acr, if unknown acr_values is provided', function() {
     validationOptions.acrValues = 'foo';
     const claims = {
       iss: validationOptions.issuer,
@@ -246,5 +246,17 @@ describe('validateClaims', function () {
       validateClaims(sdk, claims, validationOptions);
     };
     expect(fn).not.toThrowError();
+  });
+
+  it('does throw an error on missing acr, if supported acr_values is provided', function() {
+    validationOptions.acrValues = 'urn:okta:loa:2fa:any:ifpossible';
+    const claims = {
+      iss: validationOptions.issuer,
+      aud: validationOptions.clientId,
+    } as unknown as UserClaims;
+    var fn = function () {
+      validateClaims(sdk, claims, validationOptions);
+    };
+    expect(fn).toThrowError('The acr [undefined] does not match acr_values [urn:okta:loa:2fa:any:ifpossible]');  
   });
 });

--- a/test/spec/oidc/util/validateClaims.ts
+++ b/test/spec/oidc/util/validateClaims.ts
@@ -230,31 +230,19 @@ describe('validateClaims', function () {
       aud: validationOptions.clientId,
       acr: 'foo'
     } as unknown as UserClaims;
-    var fn = function () {
+    const fn = function () {
       validateClaims(sdk, claims, validationOptions);
     };
     expect(fn).toThrowError('The acr [foo] does not match acr_values [urn:okta:loa:2fa:any:ifpossible]');  
   });
 
-  it('does not throw error on missing acr, if unknown acr_values is provided', function() {
-    validationOptions.acrValues = 'foo';
-    const claims = {
-      iss: validationOptions.issuer,
-      aud: validationOptions.clientId,
-    } as unknown as UserClaims;
-    var fn = function () {
-      validateClaims(sdk, claims, validationOptions);
-    };
-    expect(fn).not.toThrowError();
-  });
-
-  it('does throw an error on missing acr, if supported acr_values is provided', function() {
+  it('does throw an error on missing acr, if acr_values is provided', function() {
     validationOptions.acrValues = 'urn:okta:loa:2fa:any:ifpossible';
     const claims = {
       iss: validationOptions.issuer,
       aud: validationOptions.clientId,
     } as unknown as UserClaims;
-    var fn = function () {
+    const fn = function () {
       validateClaims(sdk, claims, validationOptions);
     };
     expect(fn).toThrowError('The acr [undefined] does not match acr_values [urn:okta:loa:2fa:any:ifpossible]');  


### PR DESCRIPTION
- Adds support of `acr_values` in `authorize` endpoint
- Validate token claim `acr` against `acr_values`
- Added unit tests
- Added support of `acr_values` in test app

Internal ref: [OKTA-535359](https://oktainc.atlassian.net/browse/OKTA-535359)

[Docs](https://developer.okta.com/docs/guides/step-up-authentication/main/)