### PR TITLE
feat: Handle acr_values from insufficient_authentication_context error

### DIFF
--- a/docs/myaccount/README.md
+++ b/docs/myaccount/README.md
@@ -85,7 +85,7 @@ import { getEmail } from '@okta/okta-auth-js';
 
 ## Handling `insufficient_authentication_context` error
 
-For additional security, the MyAccount API requires a higher assurance level to protect the end user's account from being manipulated by malicious actors. If the `access token` provided does not meet the required assurance level, an error will be thrown to prompt the user to re-authenticate. Applications consuming the MyAccount API will need to handle this error condition. When this occurs, `myaccount` methods will throw an `AuthApiError` with `insufficient_authentication_context` in `errorSummary` and `max_age` in `meta` field, like so:
+For additional security, the MyAccount API requires a higher assurance level to protect the end user's account from being manipulated by malicious actors. If the `access token` provided does not meet the required assurance level, an error will be thrown to prompt the user to re-authenticate. Applications consuming the MyAccount API will need to handle this error condition. When this occurs, `myaccount` methods will throw an `AuthApiError` with `insufficient_authentication_context` in `errorSummary` having `max_age` and `acr_values` in `meta` field, like so:
 
 ```js
 {
@@ -95,7 +95,8 @@ For additional security, the MyAccount API requires a higher assurance level to 
     errorSummary: 'The access token requires additional assurance to access the resource'
   }],
   meta: {
-    max_age: 900
+    max_age: 900,
+    acr_values: 'phr'
   }
 }
 ```
@@ -104,7 +105,7 @@ For additional security, the MyAccount API requires a higher assurance level to 
 
 ### Re-Authenticate with Okta Hosted Login flow
 
-Bootstrap re-authentication flow by calling `getWithRedirect` with `maxAge`.
+Bootstrap re-authentication flow by calling `getWithRedirect` with `maxAge` and `acrValues`.
 
 ```js
 await getWithRedirect(
@@ -112,6 +113,7 @@ await getWithRedirect(
   {
     prompt: 'login',
     maxAge,
+    acrValues,
     scopes,
     extraParams: {
       id_token_hint: idToken
@@ -122,16 +124,16 @@ await getWithRedirect(
 
 ### Re-Authenticate with Embedded SDK
 
-Bootstrap re-authentication flow by calling `oktaAuth.idx.authenticate` with `maxAge`.
+Bootstrap re-authentication flow by calling `oktaAuth.idx.authenticate` with `maxAge` and `acrValues`.
 
 ```js
-const transaction = await oktaAuth.idx.authenticate({ maxAge });
+const transaction = await oktaAuth.idx.authenticate({ maxAge, acrValues });
 // then render form based on new transaction
 ```
 
 ### Re-Authenticate with Embedded Widget
 
-Bootstrap embedded widget by passing `max_age` in `authParams`. Then start authentication flow from there.
+Bootstrap embedded widget by passing `max_age` and `acr_values` in `authParams`. Then start authentication flow from there.
 
 ```js
 const { issuer, clientId, redirectUri, scopes } = oidcConfig;
@@ -142,6 +144,7 @@ const widget = new OktaSignIn({
   authParams: {
     scopes,
     ...(maxAge && { maxAge }),
+    ...(acrValues && { acrValues }),
   },
   useInteractionCodeFlow: true,
 });

--- a/lib/myaccount/README.md
+++ b/lib/myaccount/README.md
@@ -83,7 +83,7 @@ import { getEmail } from '@okta/okta-auth-js';
 
 ## Handling `insufficient_authentication_context` error
 
-For additional security, the MyAccount API requires a higher assurance level to protect the end user's account from being manipulated by malicious actors. If the `access token` provided does not meet the required assurance level, an error will be thrown to prompt the user to re-authenticate. Applications consuming the MyAccount API will need to handle this error condition. When this occurs, `myaccount` methods will throw an `AuthApiError` with `insufficient_authentication_context` in `errorSummary` and `max_age` in `meta` field, like so:
+For additional security, the MyAccount API requires a higher assurance level to protect the end user's account from being manipulated by malicious actors. If the `access token` provided does not meet the required assurance level, an error will be thrown to prompt the user to re-authenticate. Applications consuming the MyAccount API will need to handle this error condition. When this occurs, `myaccount` methods will throw an `AuthApiError` with `insufficient_authentication_context` in `errorSummary` having `max_age` and `acr_values` in `meta` field, like so:
 
 
 ```js
@@ -94,7 +94,8 @@ For additional security, the MyAccount API requires a higher assurance level to 
     errorSummary: 'The access token requires additional assurance to access the resource'
   }],
   meta: {
-    max_age: 900
+    max_age: 900,
+    acr_values: 'phr'
   }
 }
 ```
@@ -121,16 +122,16 @@ await getWithRedirect(
 
 ### Re-Authenticate with Embedded SDK
 
-Bootstrap re-authentication flow by calling `oktaAuth.idx.authenticate` with `maxAge`.
+Bootstrap re-authentication flow by calling `oktaAuth.idx.authenticate` with `maxAge` and `acrValues`.
 
 ```js
-const transaction = await oktaAuth.idx.authenticate({ maxAge });
+const transaction = await oktaAuth.idx.authenticate({ maxAge, acrValues });
 // then render form based on new transaction
 ```
 
 ### Re-Authenticate with Embedded Widget
 
-Bootstrap embedded widget by passing `max_age` in `authParams`. Then start authentication flow from there.
+Bootstrap embedded widget by passing `max_age` and `acr_values` in `authParams`. Then start authentication flow from there.
 
 
 ```js
@@ -142,6 +143,7 @@ const widget = new OktaSignIn({
   authParams: {
     scopes,
     ...(maxAge && { maxAge }),
+    ...(acrValues && { acrValues }),
   },
   useInteractionCodeFlow: true,
 });

--- a/lib/myaccount/README.md
+++ b/lib/myaccount/README.md
@@ -104,7 +104,7 @@ For additional security, the MyAccount API requires a higher assurance level to 
 
 ### Re-Authenticate with Okta Hosted Login flow
 
-Bootstrap re-authentication flow by calling `getWithRedirect` with `maxAge`.
+Bootstrap re-authentication flow by calling `getWithRedirect` with `maxAge` and `acrValues`.
 
 ```js
 await getWithRedirect(
@@ -112,6 +112,7 @@ await getWithRedirect(
   {
     prompt: 'login',
     maxAge,
+    acrValues,
     scopes,
     extraParams: {
       id_token_hint: idToken

--- a/lib/myaccount/request.ts
+++ b/lib/myaccount/request.ts
@@ -36,6 +36,8 @@ type InsufficientAuthenticationError = {
   error_description: string;
   // eslint-disable-next-line camelcase
   max_age: string;
+  // eslint-disable-next-line camelcase
+  acr_values: string;
 }
 
 const parseInsufficientAuthenticationError = (
@@ -93,7 +95,9 @@ export async function sendRequest<T extends BaseTransaction> (
         // eslint-disable-next-line camelcase
         error_description,
         // eslint-disable-next-line camelcase
-        max_age 
+        max_age,
+        // eslint-disable-next-line camelcase
+        acr_values 
       } = parseInsufficientAuthenticationError(errorResp?.headers?.['www-authenticate']);
       if (error === 'insufficient_authentication_context') {
         const insufficientAuthenticationError = new AuthApiError(
@@ -103,8 +107,12 @@ export async function sendRequest<T extends BaseTransaction> (
             errorCauses: [{ errorSummary: error_description }]
           }, 
           errorResp, 
-          // eslint-disable-next-line camelcase
-          { max_age: +max_age }
+          {
+            // eslint-disable-next-line camelcase
+            max_age: +max_age,
+            // eslint-disable-next-line camelcase
+            ...(acr_values && { acr_values })
+          }
         );
         throw insufficientAuthenticationError;
       } else {

--- a/samples/generated/react-embedded-auth-with-sdk/src/components/WidgetPage.jsx
+++ b/samples/generated/react-embedded-auth-with-sdk/src/components/WidgetPage.jsx
@@ -15,6 +15,7 @@ const WidgetPage = () => {
   const otp = queryParams.get('otp');
   const state = queryParams.get('state');
   const maxAge = queryParams.get('maxAge');
+  const acrValues = queryParams.get('acrValues');
 
   useEffect(() => {
     if (!widgetRef.current) {
@@ -35,7 +36,9 @@ const WidgetPage = () => {
         // To avoid redirect do not set "pkce" or "display" here. OKTA-335945
         issuer,
         scopes,
-        ...(maxAge && { maxAge }), // config to bootstrap re-authentication for insufficient authentication scenario 
+        // config to bootstrap re-authentication for insufficient authentication scenario
+        ...(maxAge && { maxAge }),
+        ...(acrValues && { acrValues }),
       },
       useInteractionCodeFlow: true,
       ...(state && { state }),
@@ -54,7 +57,7 @@ const WidgetPage = () => {
     );
 
     return () => widget.remove();
-  }, [oktaAuth, history, maxAge, otp, state]);
+  }, [oktaAuth, history, maxAge, acrValues, otp, state]);
 
   return (
     <div>

--- a/test/spec/myaccount/request.ts
+++ b/test/spec/myaccount/request.ts
@@ -59,7 +59,7 @@ describe('sendRequest', () => {
       xhr: {
         status: 403,
         headers: {
-          'www-authenticate': 'Bearer realm="IdpMyAccountAPI", error="insufficient_authentication_context", error_description="The access token requires additional assurance to access the resource", max_age=900'
+          'www-authenticate': 'Bearer realm="IdpMyAccountAPI", error="insufficient_authentication_context", error_description="The access token requires additional assurance to access the resource", max_age=900, acr_values="urn:okta:loa:2fa:any:ifpossible"'
         }
       }
     });
@@ -74,6 +74,7 @@ describe('sendRequest', () => {
       expect((err as any).errorSummary).toEqual('insufficient_authentication_context');
       expect((err as any).errorCauses).toEqual([{ errorSummary: 'The access token requires additional assurance to access the resource' }]);
       expect((err as any).meta.max_age).toEqual(900);
+      expect((err as any).meta.acr_values).toEqual('urn:okta:loa:2fa:any:ifpossible');
     }
   });
 


### PR DESCRIPTION
- Handle `acr_values` in `insufficient_authentication_context` error (same as `max_age`), added unit test
- Support `acrValues` in MyAccount React sample app

TODO: wait for feature availability on backend and check sample app

Internal ref: https://oktainc.atlassian.net/browse/OKTA-535363