### PR TITLE
Move `insufficient_authentication_context` error handling logic to core http

### DIFF
--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -19,11 +19,10 @@ import {
   OktaAuthHttpInterface,
   RequestOptions,
   FetchOptions,
-  RequestData
+  RequestData,
+  HttpResponse
 } from './types';
-import { AuthApiError, OAuthError, AuthSdkError } from '../errors';
-import { HttpResponse } from './types';
-import { APIError } from '../errors/types';
+import { AuthApiError, OAuthError, AuthSdkError, APIError } from '../errors';
 
 type InsufficientAuthenticationError = {
   error: string;

--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -21,7 +21,95 @@ import {
   FetchOptions,
   RequestData
 } from './types';
-import { AuthApiError, OAuthError } from '../errors';
+import { AuthApiError, OAuthError, AuthSdkError } from '../errors';
+import { HttpResponse } from './types';
+import { APIError } from '../errors/types';
+
+type InsufficientAuthenticationError = {
+  error: string;
+  // eslint-disable-next-line camelcase
+  error_description: string;
+  // eslint-disable-next-line camelcase
+  max_age: string;
+  // eslint-disable-next-line camelcase
+  acr_values: string;
+};
+
+const parseInsufficientAuthenticationError = (
+  header: string
+): InsufficientAuthenticationError => {
+  if (!header) {
+    throw new AuthSdkError('Missing header string');
+  }
+
+  return header
+    .split(',')
+    .map(part => part.trim())
+    .map(part => part.split('='))
+    .reduce((acc, curr) => {
+      // unwrap quotes from value
+      acc[curr[0]] = curr[1].replace(/^"(.*)"$/, '$1');
+      return acc;
+    }, {}) as InsufficientAuthenticationError;
+};
+
+const formatError = (sdk: OktaAuthHttpInterface, resp: HttpResponse): AuthApiError | OAuthError => {
+  let err: AuthApiError | OAuthError;
+  let serverErr: Record<string, any> = {};
+  if (resp.responseText && isString(resp.responseText)) {
+    try {
+      serverErr = JSON.parse(resp.responseText);
+    } catch (e) {
+      serverErr = {
+        errorSummary: 'Unknown error'
+      };
+    }
+  }
+
+  if (resp.status >= 500) {
+    serverErr.errorSummary = 'Unknown error';
+  }
+
+  if (sdk.options.transformErrorXHR) {
+    resp = sdk.options.transformErrorXHR(clone(resp));
+  }
+
+  if (serverErr.error && serverErr.error_description) {
+    err = new OAuthError(serverErr.error, serverErr.error_description);
+  } else {
+    err = new AuthApiError(serverErr as APIError, resp);
+  }
+
+  if (resp?.status === 403 && !!resp?.headers?.['www-authenticate']) {
+    const { 
+      error, 
+      // eslint-disable-next-line camelcase
+      error_description,
+      // eslint-disable-next-line camelcase
+      max_age,
+      // eslint-disable-next-line camelcase
+      acr_values 
+    } = parseInsufficientAuthenticationError(resp?.headers?.['www-authenticate']);
+    if (error === 'insufficient_authentication_context') {
+      err = new AuthApiError(
+        { 
+          errorSummary: error,
+          // eslint-disable-next-line camelcase
+          errorCauses: [{ errorSummary: error_description }]
+        }, 
+        resp, 
+        {
+          // eslint-disable-next-line camelcase
+          max_age: +max_age,
+          // eslint-disable-next-line camelcase
+          ...(acr_values && { acr_values })
+        }
+      );
+    }
+  }
+
+  return err;
+};
 
 export function httpRequest(sdk: OktaAuthHttpInterface, options: RequestOptions): Promise<any> {
   options = options || {};
@@ -106,30 +194,7 @@ export function httpRequest(sdk: OktaAuthHttpInterface, options: RequestOptions)
       return res;
     })
     .catch(function(resp) {
-      var serverErr = resp.responseText || {};
-      if (isString(serverErr)) {
-        try {
-          serverErr = JSON.parse(serverErr);
-        } catch (e) {
-          serverErr = {
-            errorSummary: 'Unknown error'
-          };
-        }
-      }
-
-      if (resp.status >= 500) {
-        serverErr.errorSummary = 'Unknown error';
-      }
-
-      if (sdk.options.transformErrorXHR) {
-        resp = sdk.options.transformErrorXHR(clone(resp));
-      }
-
-      if (serverErr.error && serverErr.error_description) {
-        err = new OAuthError(serverErr.error, serverErr.error_description);
-      } else {
-        err = new AuthApiError(serverErr, resp);
-      }
+      err = formatError(sdk, resp);
 
       if (err.errorCode === 'E0000011') {
         storage.delete(STATE_TOKEN_KEY_NAME);

--- a/lib/myaccount/request.ts
+++ b/lib/myaccount/request.ts
@@ -8,7 +8,7 @@ import {
   PhoneTransaction
 } from './transactions';
 import { httpRequest } from '../http';
-import { AuthApiError, AuthSdkError } from '../errors';
+import { AuthSdkError } from '../errors';
 import { MyAccountRequestOptions as RequestOptions } from './types';
 import { OktaAuthOAuthInterface } from '../oidc/types';
 
@@ -30,45 +30,15 @@ type SendRequestOptions = RequestOptions & {
   transactionClassName?: string;
 }
 
-type InsufficientAuthenticationError = {
-  error: string;
-  // eslint-disable-next-line camelcase
-  error_description: string;
-  // eslint-disable-next-line camelcase
-  max_age: string;
-  // eslint-disable-next-line camelcase
-  acr_values: string;
-}
-
-const parseInsufficientAuthenticationError = (
-  header: string
-): InsufficientAuthenticationError => {
-  if (!header) {
-    throw new AuthSdkError('Missing header string');
-  }
-
-  return header
-    .split(',')
-    .map(part => part.trim())
-    .map(part => part.split('='))
-    .reduce((acc, curr) => {
-      // unwrap quotes from value
-      acc[curr[0]] = curr[1].replace(/^"(.*)"$/, '$1');
-      return acc;
-    }, {}) as InsufficientAuthenticationError;
-};
-
 /* eslint-disable complexity */
 export async function sendRequest<T extends BaseTransaction> (
   oktaAuth: OktaAuthOAuthInterface, 
   options: SendRequestOptions
 ): Promise<T | T[]> {
   const { 
-    accessToken: accessTokenObj,
-    idToken: idTokenObj 
+    accessToken: accessTokenObj
   } = oktaAuth.tokenManager.getTokensSync();
   
-  const idToken = idTokenObj?.idToken;
   const accessToken = options.accessToken || accessTokenObj?.accessToken;
   const { issuer } = oktaAuth.options;
   const { url, method, payload } = options;
@@ -78,50 +48,13 @@ export async function sendRequest<T extends BaseTransaction> (
     throw new AuthSdkError('AccessToken is required to request MyAccount API endpoints.');
   }
   
-  let res;
-  try {
-    res = await httpRequest(oktaAuth, {
-      headers: { 'Accept': '*/*;okta-version=1.0.0' },
-      accessToken,
-      url: requestUrl,
-      method,
-      ...(payload && { args: payload })
-    });
-  } catch (err) {
-    const errorResp = (err as AuthApiError).xhr;
-    if (idToken && errorResp?.status === 403 && !!errorResp?.headers?.['www-authenticate']) {
-      const { 
-        error, 
-        // eslint-disable-next-line camelcase
-        error_description,
-        // eslint-disable-next-line camelcase
-        max_age,
-        // eslint-disable-next-line camelcase
-        acr_values 
-      } = parseInsufficientAuthenticationError(errorResp?.headers?.['www-authenticate']);
-      if (error === 'insufficient_authentication_context') {
-        const insufficientAuthenticationError = new AuthApiError(
-          { 
-            errorSummary: error,
-            // eslint-disable-next-line camelcase
-            errorCauses: [{ errorSummary: error_description }]
-          }, 
-          errorResp, 
-          {
-            // eslint-disable-next-line camelcase
-            max_age: +max_age,
-            // eslint-disable-next-line camelcase
-            ...(acr_values && { acr_values })
-          }
-        );
-        throw insufficientAuthenticationError;
-      } else {
-        throw err;
-      }
-    } else {
-      throw err;
-    }
-  }
+  const res = await httpRequest(oktaAuth, {
+    headers: { 'Accept': '*/*;okta-version=1.0.0' },
+    accessToken,
+    url: requestUrl,
+    method,
+    ...(payload && { args: payload })
+  });
 
   const map = {
     EmailTransaction,

--- a/test/spec/myaccount/request.ts
+++ b/test/spec/myaccount/request.ts
@@ -48,36 +48,6 @@ describe('sendRequest', () => {
     });
   });
 
-  it('throws insufficient_authentication error when has "insufficient_authentication_context" in www-authenticate header', async () => {
-    jest.spyOn(mocked.oidc, 'decodeToken').mockReturnValue({
-      payload: {
-        scp: ['openid', 'okta.myaccount.*']
-      }
-    });
-    jest.spyOn(mocked.oidc, 'getWithRedirect');
-    jest.spyOn(mocked.http, 'httpRequest').mockRejectedValue({
-      xhr: {
-        status: 403,
-        headers: {
-          'www-authenticate': 'Bearer realm="IdpMyAccountAPI", error="insufficient_authentication_context", error_description="The access token requires additional assurance to access the resource", max_age=900, acr_values="urn:okta:loa:2fa:any:ifpossible"'
-        }
-      }
-    });
-    try {
-      await sendRequest(auth, {
-        url: 'https://fake-url.com',
-        method: 'GET',
-        accessToken: 'fake-token'
-      });
-    } catch (err) {
-      expect(err).toBeInstanceOf(AuthApiError);
-      expect((err as any).errorSummary).toEqual('insufficient_authentication_context');
-      expect((err as any).errorCauses).toEqual([{ errorSummary: 'The access token requires additional assurance to access the resource' }]);
-      expect((err as any).meta.max_age).toEqual(900);
-      expect((err as any).meta.acr_values).toEqual('urn:okta:loa:2fa:any:ifpossible');
-    }
-  });
-
   it('throws AuthApiError', async () => {
     const error = new AuthApiError({
       errorSummary: 'fake-error'


### PR DESCRIPTION
Move `insufficient_authentication_context` error handling logic from myaccount http level to core http level

Internal ref: https://oktainc.atlassian.net/browse/OKTA-535363 