### PR TITLE
fix: Don't check for 'identify' remediation if 'activationToken' is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#1335](https://github.com/okta/okta-auth-js/pull/1335) IDX: adds `uiDisplay` property to `IdxContext` type
 - [#1336](https://github.com/okta/okta-auth-js/pull/1319) IDX: adds `deviceKnown` property to `IdxAuthenticator` type
+- [#1337](https://github.com/okta/okta-auth-js/pull/1337) IDX: fixes account activation flow by removing check for `identify` remediation
 
 ## 7.0.1
 

--- a/lib/idx/register.ts
+++ b/lib/idx/register.ts
@@ -28,7 +28,7 @@ export async function register(
 
   // Only check at the beginning of the transaction
   if (!hasSavedInteractionHandle(authClient)) {
-    const { enabledFeatures, availableSteps } = await startTransaction(authClient, {
+    const { enabledFeatures } = await startTransaction(authClient, {
       ...options,
       flow: 'register',
       autoRemediate: false

--- a/lib/idx/register.ts
+++ b/lib/idx/register.ts
@@ -36,9 +36,6 @@ export async function register(
     if (!options.activationToken && enabledFeatures && !enabledFeatures.includes(IdxFeature.REGISTRATION)) {
       throw new AuthSdkError('Registration is not supported based on your current org configuration.');
     }
-    if (options.activationToken && availableSteps?.some(({ name }) => name === 'identify')) {
-      throw new AuthSdkError('activationToken is not supported based on your current org configuration.');
-    }
   }
 
   return run(authClient, {

--- a/test/spec/idx/register.ts
+++ b/test/spec/idx/register.ts
@@ -321,27 +321,6 @@ describe('idx/register', () => {
       expect(didThrow).toBe(true);
       expect(mocked.startTransaction.startTransaction).toHaveBeenCalledWith(authClient, { flow: 'register', autoRemediate: false });
     });
-    it('presence of identify remediation means activationToken is not supported', async () => {
-      const { authClient, transactionMeta } = testContext;
-      jest.spyOn(authClient.transactionManager, 'exists').mockReturnValue(false);
-      authClient.token.prepareTokenParams = jest.fn().mockResolvedValue(transactionMeta);
-      const identifyResponse = IdxResponseFactory.build({
-        neededToProceed: [
-          IdentifyRemediationFactory.build()
-        ]
-      });
-      jest.spyOn(mocked.introspect, 'introspect').mockResolvedValue(identifyResponse);
-            
-      let didThrow = false;
-      try {
-        await register(authClient, { activationToken: 'fn-activationToken' });
-      } catch (error) {
-        didThrow = true;
-        expect(error).toBeInstanceOf(AuthSdkError);
-        expect((error as any).errorSummary).toBe('activationToken is not supported based on your current org configuration.');
-      }
-      expect(didThrow).toBe(true);
-    });
     it('with activationToken should not check select-enroll-profile remediation', async () => {
       const { authClient, transactionMeta } = testContext;
       jest.spyOn(authClient.transactionManager, 'exists').mockReturnValue(false);


### PR DESCRIPTION
Issue: https://oktainc.atlassian.net/browse/OKTA-548934
