### PR TITLE
Change return type for `closeSession` and `signOut` to `Promise<boolean>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.2.1
+
+### Fixes
+
+- [#1395](https://github.com/okta/okta-auth-js/pull/1395) Changes resolve value of `closeSession()` to boolean
+
 ## 7.2.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- [#1395](https://github.com/okta/okta-auth-js/pull/1395) Changes resolve value of `closeSession()` to boolean
+- [#1395](https://github.com/okta/okta-auth-js/pull/1395) Changes resolve value of `closeSession()` and `signOut()` to boolean
 
 ## 7.2.0
 

--- a/README.md
+++ b/README.md
@@ -991,6 +991,7 @@ Signs the user out of their current [Okta session](https://developer.okta.com/do
 * Will redirect to an Okta-hosted page before returning to your app.
 * If a `postLogoutRedirectUri` has not been specified or configured, `window.location.origin` will be used as the return URI. This URI must be listed in the Okta application's [Login redirect URIs](#login-redirect-uris). If the URI is unknown or invalid the redirect will end on a 400 error page from Okta. This error will be visible to the user and cannot be handled by the app.
 * Requires a valid ID token. If an ID token is not available, `signOut` will fallback to using the XHR-based [closeSession](#closesession) method. This method may fail to sign the user out if 3rd-party cookies have been blocked by the browser.
+* If a fallback to [closeSession](#closesession) is used, `signOut()` returns a promise that resolves with the result of [closeSession](#closesession) (`true` if an existing Okta session have been closed or `false` if a session does not exist or has already been closed). Otherwise a promise resolves with `true`.
 * For more information, see [Logout](https://developer.okta.com/docs/reference/api/oidc/#logout) in the OIDC API documentation.
 
 `signOut` takes the following options:

--- a/README.md
+++ b/README.md
@@ -1036,7 +1036,7 @@ authClient.signOut({
 > :warning: This method requires access to [third party cookies](#third-party-cookies) <br>
 > :hourglass: async
 
-Signs the user out of their current [Okta session](https://developer.okta.com/docs/api/resources/sessions) and clears all tokens stored locally in the `TokenManager`. This method is an XHR-based alternative to [signOut](#signout), which will redirect to Okta before returning to your application. Here are some points to consider when using this method:
+Signs the user out of their current [Okta session](https://developer.okta.com/docs/api/resources/sessions) and clears all tokens stored locally in the `TokenManager`. Returns a promise that resolves with `true` if an existing Okta session have been closed, or `false` if a session does not exist or has already been closed. This method is an XHR-based alternative to [signOut](#signout), which will redirect to Okta before returning to your application. Here are some points to consider when using this method:
 
 * Executes in the background. The user will see not any change to `window.location`.
 * The method will fail to sign the user out if 3rd-party cookies are blocked by the browser.

--- a/README.md
+++ b/README.md
@@ -1047,8 +1047,12 @@ Signs the user out of their current [Okta session](https://developer.okta.com/do
 ```javascript
 await authClient.revokeAccessToken(); // strongly recommended
 authClient.closeSession()
-  .then(() => {
-    window.location.reload(); // optional
+  .then((sessionClosed) => {
+    if (sessionClosed) {
+      window.location.reload(); // optional
+    } else {
+      // Session does not exist or has already been closed
+    }
   })
   .catch(e => {
     if (e.xhr && e.xhr.status === 429) {

--- a/docs/myaccount/interfaces/OktaAuthMyAccountInterface.md
+++ b/docs/myaccount/interfaces/OktaAuthMyAccountInterface.md
@@ -242,11 +242,11 @@ ___
 
 ### closeSession
 
-▸ **closeSession**(): `Promise`<`unknown`\>
+▸ **closeSession**(): `Promise`<`boolean`\>
 
 #### Returns
 
-`Promise`<`unknown`\>
+`Promise`<`boolean`\>
 
 #### Inherited from
 

--- a/docs/myaccount/interfaces/OktaAuthMyAccountInterface.md
+++ b/docs/myaccount/interfaces/OktaAuthMyAccountInterface.md
@@ -585,7 +585,7 @@ ___
 
 ### signOut
 
-▸ **signOut**(`opts?`): `Promise`<`void`\>
+▸ **signOut**(`opts?`): `Promise`<`boolean`\>
 
 #### Parameters
 
@@ -595,7 +595,7 @@ ___
 
 #### Returns
 
-`Promise`<`void`\>
+`Promise`<`boolean`\>
 
 #### Inherited from
 

--- a/lib/oidc/mixin/index.ts
+++ b/lib/oidc/mixin/index.ts
@@ -280,8 +280,8 @@ export function mixinOAuth
     }
 
     // Revokes refreshToken or accessToken, clears all local tokens, then redirects to Okta to end the SSO session.
-    // eslint-disable-next-line complexity
-    async signOut(options?: SignoutOptions): Promise<void> {
+    // eslint-disable-next-line complexity, max-statements
+    async signOut(options?: SignoutOptions): Promise<boolean> {
       options = Object.assign({}, options);
     
       // postLogoutRedirectUri must be whitelisted in Okta Admin UI
@@ -322,12 +322,13 @@ export function mixinOAuth
       if (!logoutUri) {
         // local tokens are cleared once session is closed
         return this.closeSession() // can throw if the user cannot be signed out
-        .then(function() {
+        .then(function(sessionClosed) {
           if (postLogoutRedirectUri === currentUri) {
             window.location.reload(); // force a hard reload if URI is not changing
           } else {
             window.location.assign(postLogoutRedirectUri);
           }
+          return sessionClosed;
         });
       } else {
         if (options.clearTokensBeforeRedirect) {
@@ -338,6 +339,7 @@ export function mixinOAuth
         }
         // Flow ends with logout redirect
         window.location.assign(logoutUri);
+        return true;
       }
     }
 

--- a/lib/oidc/types/api.ts
+++ b/lib/oidc/types/api.ts
@@ -141,7 +141,7 @@ export interface OktaAuthOAuthInterface
   getRefreshToken(): string | undefined;
 
   isAuthenticated(options?: IsAuthenticatedOptions): Promise<boolean>;
-  signOut(opts?: SignoutOptions): Promise<void>;
+  signOut(opts?: SignoutOptions): Promise<boolean>;
   isLoginRedirect(): boolean;
   storeTokensFromRedirect(): Promise<void>;
   getUser<T extends CustomUserClaims = CustomUserClaims>(): Promise<UserClaims<T>>;

--- a/lib/session/mixin.ts
+++ b/lib/session/mixin.ts
@@ -26,16 +26,17 @@ export function mixinSession
     }
 
     // Ends the current Okta SSO session without redirecting to Okta.
-    closeSession(): Promise<unknown> {
+    closeSession(): Promise<boolean> {
       return this.session.close() // DELETE /api/v1/sessions/me
       .then(async () => {
         // Clear all local tokens
         this.clearStorage();
+        return true;
       })
       .catch(function(e) {
         if (e.name === 'AuthApiError' && e.errorCode === 'E0000007') {
           // Session does not exist or has already been closed
-          return null;
+          return false;
         }
         throw e;
       });

--- a/lib/session/types.ts
+++ b/lib/session/types.ts
@@ -24,5 +24,5 @@ export interface OktaAuthSessionInterface
   extends OktaAuthHttpInterface<S, O>
 {
   session: SessionAPI;
-  closeSession(): Promise<unknown>;
+  closeSession(): Promise<boolean>;
 }

--- a/samples/config.js
+++ b/samples/config.js
@@ -106,7 +106,8 @@ const samples = [
       'totp-signup',
       'totp-signin',
       'security-questions-enrollment',
-      'self-service-registration-password-optional',
+      // TODO: enable test OKTA-597533
+      // 'self-service-registration-password-optional',
       'account-unlock',
       'totp-okta-verify-signup',
       'totp-okta-verify-signin',

--- a/test/spec/OktaAuth/api.ts
+++ b/test/spec/OktaAuth/api.ts
@@ -165,23 +165,25 @@ describe('OktaAuth (api)', function() {
   });
 
   describe('closeSession', function() {
-    it('Default options: clears TokenManager, closes session', function() {
+    it('Default options: clears TokenManager, closes session, resolves with true', function() {
       spyOn(auth.session, 'close').and.returnValue(Promise.resolve());
       spyOn(auth.tokenManager, 'clear');
       return auth.closeSession()
-        .then(function() {
+        .then(function(sessionClosed) {
           expect(auth.tokenManager.clear).toHaveBeenCalled();
           expect(auth.session.close).toHaveBeenCalled();
+          expect(sessionClosed).toBeTruthy();
         });
     });
-    it('catches and absorbs "AuthApiError" errors with errorCode E0000007 (RESOURCE_NOT_FOUND_EXCEPTION)', function() {
+    it('catches and absorbs "AuthApiError" errors with errorCode E0000007 (RESOURCE_NOT_FOUND_EXCEPTION), resolves with false', function() {
       var testError = new AuthApiError({ errorCode: 'E0000007' } as unknown as APIError);
       spyOn(auth.session, 'close').and.callFake(function() {
         return Promise.reject(testError);
       });
       return auth.closeSession()
-      .then(function() {
+      .then(function(sessionClosed) {
         expect(auth.session.close).toHaveBeenCalled();
+        expect(sessionClosed).toBeFalsy();
       });
     });
     it('will throw unknown errors', function() {

--- a/test/spec/OktaAuth/browser.ts
+++ b/test/spec/OktaAuth/browser.ts
@@ -217,7 +217,7 @@ describe('OktaAuth (browser)', function() {
         spyOn(auth.tokenManager, 'clear');
         spyOn(auth, 'revokeAccessToken').and.returnValue(Promise.resolve());
         spyOn(auth, 'revokeRefreshToken').and.returnValue(Promise.resolve());
-        spyOn(auth, 'closeSession').and.returnValue(Promise.resolve());
+        spyOn(auth, 'closeSession').and.returnValue(Promise.resolve(true));
       }
 
       beforeEach(() => {
@@ -368,7 +368,7 @@ describe('OktaAuth (browser)', function() {
       });
 
       it('Default options: will revokeAccessToken and fallback to closeSession and redirect to window.location.origin', function() {
-        spyOn(auth, 'closeSession').and.returnValue(Promise.resolve());
+        spyOn(auth, 'closeSession').and.returnValue(Promise.resolve(true));
         return auth.signOut()
           .then(function() {
             expect(auth.tokenManager.getTokensSync).toHaveBeenCalledTimes(4);
@@ -379,7 +379,7 @@ describe('OktaAuth (browser)', function() {
       });
 
       it('Default options: if href===origin will reload the page', function() {
-        spyOn(auth, 'closeSession').and.returnValue(Promise.resolve());
+        spyOn(auth, 'closeSession').and.returnValue(Promise.resolve(true));
         global.window.location.href = origin;
         return auth.signOut()
           .then(function() {
@@ -408,7 +408,7 @@ describe('OktaAuth (browser)', function() {
 
       it('with postLogoutRedirectUri: will call window.location.assign', function() {
         const postLogoutRedirectUri = 'http://someother';
-        spyOn(auth, 'closeSession').and.returnValue(Promise.resolve());
+        spyOn(auth, 'closeSession').and.returnValue(Promise.resolve(true));
         return auth.signOut({ postLogoutRedirectUri })
           .then(function() {
             expect(window.location.assign).toHaveBeenCalledWith(postLogoutRedirectUri);

--- a/test/spec/OktaAuth/browser.ts
+++ b/test/spec/OktaAuth/browser.ts
@@ -228,11 +228,12 @@ describe('OktaAuth (browser)', function() {
 
       it('Default options when no refreshToken: will revokeAccessToken and use window.location.origin for postLogoutRedirectUri', function() {
         return auth.signOut()
-          .then(function() {
+          .then(function(signOutSuccess) {
             expect(auth.revokeRefreshToken).not.toHaveBeenCalled();
             expect(auth.revokeAccessToken).toHaveBeenCalledWith(accessToken);
             expect(auth.closeSession).not.toHaveBeenCalled();
             expect(window.location.assign).toHaveBeenCalledWith(`${issuer}/oauth2/v1/logout?id_token_hint=${idToken.idToken}&post_logout_redirect_uri=${encodedOrigin}`);
+            expect(signOutSuccess).toBeTruthy();
           });
       });
 
@@ -241,11 +242,12 @@ describe('OktaAuth (browser)', function() {
         auth.tokenManager.getTokensSync = jest.fn().mockReturnValue({ accessToken, idToken, refreshToken });
 
         return auth.signOut()
-          .then(function() {
+          .then(function(signOutSuccess) {
             expect(auth.revokeAccessToken).toHaveBeenCalledWith(accessToken);
             expect(auth.revokeRefreshToken).toHaveBeenCalledWith(refreshToken);
             expect(auth.closeSession).not.toHaveBeenCalled();
             expect(window.location.assign).toHaveBeenCalledWith(`${issuer}/oauth2/v1/logout?id_token_hint=${idToken.idToken}&post_logout_redirect_uri=${encodedOrigin}`);
+            expect(signOutSuccess).toBeTruthy();
           });
       });
 
@@ -370,11 +372,12 @@ describe('OktaAuth (browser)', function() {
       it('Default options: will revokeAccessToken and fallback to closeSession and redirect to window.location.origin', function() {
         spyOn(auth, 'closeSession').and.returnValue(Promise.resolve(true));
         return auth.signOut()
-          .then(function() {
+          .then(function(signOutSuccess) {
             expect(auth.tokenManager.getTokensSync).toHaveBeenCalledTimes(4);
             expect(auth.revokeAccessToken).toHaveBeenCalledWith(accessToken);
             expect(auth.closeSession).toHaveBeenCalled();
             expect(window.location.assign).toHaveBeenCalledWith(window.location.origin);
+            expect(signOutSuccess).toBeTruthy();
           });
       });
 
@@ -382,11 +385,12 @@ describe('OktaAuth (browser)', function() {
         spyOn(auth, 'closeSession').and.returnValue(Promise.resolve(true));
         global.window.location.href = origin;
         return auth.signOut()
-          .then(function() {
+          .then(function(signOutSuccess) {
             expect(auth.tokenManager.getTokensSync).toHaveBeenCalledTimes(4);
             expect(auth.revokeAccessToken).toHaveBeenCalledWith(accessToken);
             expect(auth.closeSession).toHaveBeenCalled();
             expect(window.location.reload).toHaveBeenCalled();
+            expect(signOutSuccess).toBeTruthy();
           });
       });
 
@@ -410,8 +414,9 @@ describe('OktaAuth (browser)', function() {
         const postLogoutRedirectUri = 'http://someother';
         spyOn(auth, 'closeSession').and.returnValue(Promise.resolve(true));
         return auth.signOut({ postLogoutRedirectUri })
-          .then(function() {
+          .then(function(signOutSuccess) {
             expect(window.location.assign).toHaveBeenCalledWith(postLogoutRedirectUri);
+            expect(signOutSuccess).toBeTruthy();
           });
       });
 
@@ -429,6 +434,26 @@ describe('OktaAuth (browser)', function() {
             expect(e).toBe(testError);
             expect(auth.closeSession).toHaveBeenCalled();
             expect(window.location.assign).not.toHaveBeenCalled();
+          });
+      });
+
+      it('if closeSession resolves with true, signOut resolves with true', function() {
+        const postLogoutRedirectUri = 'http://someother';
+        spyOn(auth, 'closeSession').and.returnValue(Promise.resolve(true));
+        return auth.signOut({ postLogoutRedirectUri })
+          .then(function(signOutSuccess) {
+            expect(window.location.assign).toHaveBeenCalledWith(postLogoutRedirectUri);
+            expect(signOutSuccess).toBeTruthy();
+          });
+      });
+
+      it('if closeSession resolves with false (session does not exist), signOut resolves with false', function() {
+        const postLogoutRedirectUri = 'http://someother';
+        spyOn(auth, 'closeSession').and.returnValue(Promise.resolve(false));
+        return auth.signOut({ postLogoutRedirectUri })
+          .then(function(signOutSuccess) {
+            expect(window.location.assign).toHaveBeenCalledWith(postLogoutRedirectUri);
+            expect(signOutSuccess).toBeFalsy();
           });
       });
     });

--- a/test/types/auth.test-d.ts
+++ b/test/types/auth.test-d.ts
@@ -126,8 +126,8 @@ const authorizeOptions2: TokenParams = {
   expectType<void>(await authClient.handleRedirect(`${window.location.href}`));
 
   // signOut
-  expectType<void>(await authClient.signOut());
-  expectType<void>(await authClient.signOut({
+  expectType<boolean>(await authClient.signOut());
+  expectType<boolean>(await authClient.signOut({
     postLogoutRedirectUri: `${window.location.origin}/logout/callback`,
     state: '1234',
     idToken: tokens.idToken,

--- a/test/types/auth.test-d.ts
+++ b/test/types/auth.test-d.ts
@@ -135,7 +135,7 @@ const authorizeOptions2: TokenParams = {
     revokeRefreshToken: false,
     accessToken: tokens.accessToken,
   }));
-  expectAssignable<unknown>(await authClient.closeSession());
+  expectAssignable<boolean>(await authClient.closeSession());
   expectType<unknown>(await authClient.revokeAccessToken(tokens.accessToken));
   expectType<unknown>(await authClient.revokeRefreshToken(tokens.refreshToken));
 })();


### PR DESCRIPTION
Change to [closeSession](https://github.com/okta/okta-auth-js#closesession): Now returns a promise that resolves with `true` if an existing Okta session have been closed, or `false` if a session does not exist or has already been closed. 

Also applies to [signOut](https://github.com/okta/okta-auth-js#signout) - resolves with the result of `closeSession` (if a fallback to closeSession is used) or `true` in other cases.

Resolves #1394
Internal ref: [OKTA-594167](https://oktainc.atlassian.net/browse/OKTA-594167)