### PR TITLE
docs: v5 is now retired

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This library uses semantic versioning and follows Okta's [library version policy
 | -------   | -------------------------------- |
 | `7.x`     | :heavy_check_mark: Stable        |
 | `6.x`     | :warning: Retiring on 2023-09-30 |
-| `5.x`     | :warning: Retiring on 2022-10-31 |
+| `5.x`     | :x: Retired                      |
 | `4.x`     | :x: Retired                      |
 | `3.x`     | :x: Retired                      |
 | `2.x`     | :x: Retired                      |


### PR DESCRIPTION
As with other versions, marked v5 as retired as the date has passed.