### PR TITLE
Fix race condition in LeaderElectionService start

### DIFF
--- a/lib/services/AutoRenewService.ts
+++ b/lib/services/AutoRenewService.ts
@@ -75,7 +75,6 @@ export class AutoRenewService implements ServiceInterface {
   }
 
   async start() {
-    await this.stop();
     if (this.canStart()) {
       this.tokenManager.on(EVENT_EXPIRED, this.onTokenExpiredHandler);
       if (this.tokenManager.isStarted()) {

--- a/lib/services/AutoRenewService.ts
+++ b/lib/services/AutoRenewService.ts
@@ -71,12 +71,12 @@ export class AutoRenewService implements ServiceInterface {
   }
 
   canStart() {
-    return (!!this.options.autoRenew || !!this.options.autoRemove);
+    return (!!this.options.autoRenew || !!this.options.autoRemove) && !this.started;
   }
 
   async start() {
+    await this.stop();
     if (this.canStart()) {
-      await this.stop();
       this.tokenManager.on(EVENT_EXPIRED, this.onTokenExpiredHandler);
       if (this.tokenManager.isStarted()) {
         // If token manager has been already started, we could miss token expire events,

--- a/lib/services/LeaderElectionService.ts
+++ b/lib/services/LeaderElectionService.ts
@@ -55,10 +55,14 @@ export class LeaderElectionService implements ServiceInterface {
     await this.stop();
     if (this.canStart()) {
       const { electionChannelName } = this.options;
-      this.channel = new BroadcastChannel(electionChannelName as string);
-      this.elector = createLeaderElection(this.channel);
-      this.elector.onduplicate = this.onLeaderDuplicate;
-      this.elector.awaitLeadership().then(this.onLeader);
+      if (!this.channel) {
+        this.channel = new BroadcastChannel(electionChannelName as string);
+      }
+      if (!this.elector) {
+        this.elector = createLeaderElection(this.channel);
+        this.elector.onduplicate = this.onLeaderDuplicate;
+        this.elector.awaitLeadership().then(this.onLeader);
+      }
       this.started = true;
     }
   }

--- a/lib/services/LeaderElectionService.ts
+++ b/lib/services/LeaderElectionService.ts
@@ -53,7 +53,7 @@ export class LeaderElectionService implements ServiceInterface {
 
   async start() {
     await this.stop();
-    if (this.canStart() && !this.started) {
+    if (this.canStart()) {
       const { electionChannelName } = this.options;
       this.channel = new BroadcastChannel(electionChannelName as string);
       this.elector = createLeaderElection(this.channel);
@@ -88,7 +88,7 @@ export class LeaderElectionService implements ServiceInterface {
   }
 
   canStart() {
-    return isBrowser();
+    return isBrowser() && !this.started;
   }
 
 }

--- a/lib/services/LeaderElectionService.ts
+++ b/lib/services/LeaderElectionService.ts
@@ -53,16 +53,12 @@ export class LeaderElectionService implements ServiceInterface {
 
   async start() {
     await this.stop();
-    if (this.canStart()) {
+    if (this.canStart() && !this.started) {
       const { electionChannelName } = this.options;
-      if (!this.channel) {
-        this.channel = new BroadcastChannel(electionChannelName as string);
-      }
-      if (!this.elector) {
-        this.elector = createLeaderElection(this.channel);
-        this.elector.onduplicate = this.onLeaderDuplicate;
-        this.elector.awaitLeadership().then(this.onLeader);
-      }
+      this.channel = new BroadcastChannel(electionChannelName as string);
+      this.elector = createLeaderElection(this.channel);
+      this.elector.onduplicate = this.onLeaderDuplicate;
+      this.elector.awaitLeadership().then(this.onLeader);
       this.started = true;
     }
   }

--- a/lib/services/LeaderElectionService.ts
+++ b/lib/services/LeaderElectionService.ts
@@ -52,7 +52,6 @@ export class LeaderElectionService implements ServiceInterface {
   }
 
   async start() {
-    await this.stop();
     if (this.canStart()) {
       const { electionChannelName } = this.options;
       this.channel = new BroadcastChannel(electionChannelName as string);

--- a/lib/services/SyncStorageService.ts
+++ b/lib/services/SyncStorageService.ts
@@ -58,7 +58,6 @@ export class SyncStorageService implements ServiceInterface {
   }
 
   async start() {
-    await this.stop();
     if (!this.canStart()) {
       return;
     }

--- a/lib/services/SyncStorageService.ts
+++ b/lib/services/SyncStorageService.ts
@@ -54,15 +54,14 @@ export class SyncStorageService implements ServiceInterface {
   }
 
   canStart() {
-    return !!this.options.syncStorage && isBrowser();
+    return !!this.options.syncStorage && isBrowser() && !this.started;
   }
 
   async start() {
+    await this.stop();
     if (!this.canStart()) {
       return;
     }
-
-    await this.stop();
     
     const { syncChannelName } = this.options;
     try {

--- a/samples/test/features/embedded-widget-basic-auth.feature
+++ b/samples/test/features/embedded-widget-basic-auth.feature
@@ -5,7 +5,8 @@ Feature: Basic Login with Embedded Sign In Widget
       And the app is assigned to "Everyone" group
       And a Policy that defines "Authentication"
       And with a Policy Rule that defines "Password as the only factor"
-      And a predefined user named Mary with an account in the org
+      And a user named "Mary"
+      And she has an account with "active" state in the org
 
   Scenario: Mary logs in with a Password
 	  When she clicks the "login" button

--- a/test/spec/services/AutoRenewService.ts
+++ b/test/spec/services/AutoRenewService.ts
@@ -90,6 +90,17 @@ describe('AutoRenewService', function() {
       expect(Emitter.prototype.off).toHaveBeenCalledWith('expired', expect.any(Function));
     });
 
+    it('calling start twice should register listener for "expired" event once', async () => {
+      await setup({ tokenManager: { autoRenew: true } }, false);
+      jest.spyOn(client.tokenManager, 'on');
+      await Promise.all([
+        service.start(),
+        service.start()
+      ]);
+      expect(client.tokenManager.on).toHaveBeenCalledWith('expired', expect.any(Function));
+      expect(client.tokenManager.on).toHaveBeenCalledTimes(1);
+    });
+
     it('should renew token if expired after service start', async function() {
       await setup({
         tokenManager: { autoRenew: true }

--- a/test/spec/services/LeaderElectionService.ts
+++ b/test/spec/services/LeaderElectionService.ts
@@ -84,14 +84,14 @@ describe('LeaderElectionService', () => {
       expect(elector.awaitLeadership).toHaveBeenCalledTimes(1);
     });
 
-    it('stops service if already started', async () => {
+    it('does not stop service if already started', async () => {
       const elector = createElectorWithLeadership();
       jest.spyOn(mocked.broadcastChannel, 'createLeaderElection').mockReturnValue(elector);
       const service = createService();
       await service.start();
-      await service.start();
+      await service.start(); // start again
       expect(service.isStarted()).toBeTruthy();
-      expect(elector.die).toHaveBeenCalledTimes(1);
+      expect(elector.die).toHaveBeenCalledTimes(0);
     });
 
     it('calling start twice creates only 1 elector', async () => {

--- a/test/spec/services/LeaderElectionService.ts
+++ b/test/spec/services/LeaderElectionService.ts
@@ -49,9 +49,9 @@ describe('LeaderElectionService', () => {
     return service;
   }
 
-  function createElectorWithLeadership() {
+  function createElectorWithLeadership(isLeader = true) {
     return {
-      isLeader: true,
+      isLeader,
       awaitLeadership: jest.fn().mockReturnValue(new Promise(() => {})),
       die: jest.fn(),
     };
@@ -92,6 +92,22 @@ describe('LeaderElectionService', () => {
       await service.start();
       expect(service.isStarted()).toBeTruthy();
       expect(elector.die).toHaveBeenCalledTimes(1);
+    });
+
+    it('calling start twice creates only 1 elector', async () => {
+      let electors: any[] = [];
+      jest.spyOn(mocked.broadcastChannel, 'createLeaderElection').mockImplementation(() => {
+        const elector = createElectorWithLeadership(electors.length === 0);
+        electors.push(elector);
+        return elector;
+      });
+      const service = createService();
+      await Promise.all([
+        service.start(),
+        service.start()
+      ]);
+      expect(service.isLeader()).toBeTruthy();
+      expect(electors.length).toBe(1);
     });
   });
 


### PR DESCRIPTION
Resolves issue https://github.com/okta/okta-auth-js/issues/1164
Internal ref: OKTA-597615

### Issue description:
If `start` is called 2 times concurrently for single `OktaAuth` instance (and thus for `LeaderElectionService`), 2 instances of `LeaderElector` can be created:
https://github.com/okta/okta-auth-js/blob/master/lib/services/LeaderElectionService.ts#L59
One 1 of 2 electors can become leader.
But only last one will be assigned to `this.elector` an used in method [`isLeader()`](https://github.com/okta/okta-auth-js/blob/master/lib/services/LeaderElectionService.ts#L47)
If an "orphan" elector (not assigned to `this.elector`) becomes a leader, it causes the issue #1164 because `isLeader()` will return false