### PR TITLE
Add `react-native` to `package.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 - [#1395](https://github.com/okta/okta-auth-js/pull/1395) Changes resolve value of `closeSession()` and `signOut()` to boolean
+- [#1398](https://github.com/okta/okta-auth-js/pull/1398) Fixes race condition in `LeaderElectionService` start
+- [#1404](https://github.com/okta/okta-auth-js/pull/1404) Adds `react-native` to `package.json`
 
 ## 7.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Changelog
 
-## 7.2.1
+## 7.3.0
+
+### Features
+
+- [#1404](https://github.com/okta/okta-auth-js/pull/1404) Adds `react-native` to `package.json`
+- [#1395](https://github.com/okta/okta-auth-js/pull/1395) Changes resolve value of `closeSession()` and `signOut()` to boolean
 
 ### Fixes
 
-- [#1395](https://github.com/okta/okta-auth-js/pull/1395) Changes resolve value of `closeSession()` and `signOut()` to boolean
 - [#1398](https://github.com/okta/okta-auth-js/pull/1398) Fixes race condition in `LeaderElectionService` start
-- [#1404](https://github.com/okta/okta-auth-js/pull/1404) Adds `react-native` to `package.json`
 
 ## 7.2.0
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "build/cjs/exports/default.js",
   "module": "build/esm/node/exports/exports/default.js",
   "browser": "build/umd/default.js",
+  "react-native": "build/esm/browser/exports/exports/default.js",
   "types": "build/types/lib/exports/default.d.ts",
   "exports": {
     ".": {

--- a/scripts/buildtools/build.js
+++ b/scripts/buildtools/build.js
@@ -92,7 +92,7 @@ function removeBuildDir(val) {
 }
 
 // Remove "build/" from the entrypoint paths.
-['main', 'module', 'browser', 'types', 'exports'].forEach(function(key) {
+['main', 'module', 'browser', 'types', 'exports', 'react-native'].forEach(function(key) {
   packageJSON[key] = removeBuildDir(packageJSON[key]);
 });
 


### PR DESCRIPTION
This resolves issue https://github.com/okta/okta-auth-js/issues/1393 when `fetch` does not work with `@okta//okta-react-native` (Error `fetch is not a function`)

By default React Native uses `browser` key in `package.json` of okta-auth-js which is `UMD` build made with Webpack.
Adding special `react-native` key in `package.json` helps resolving okta-auth-js with `ESM` browser build which has no fetch polyfill and works correctly.

Internal ref: https://oktainc.atlassian.net/browse/OKTA-592572