### PR TITLE
Fixing README Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,7 +812,7 @@ const config = {
 };
 
 const authClient = new OktaAuth(config);
-const tokens = await authClient.token.getWithoutPrompt();
+const { tokens } = await authClient.token.getWithoutPrompt();
 authClient.tokenManager.setTokens(tokens); // storageProvider.setItem
 
 ```


### PR DESCRIPTION
Minor type in the README where the TokenResponse contains the `tokens` key that needs to be sent along.