### PR TITLE
feat: adds oauth introspect method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 7.4.0
 
+### Features
+
+- [#1412](https://github.com/okta/okta-auth-js/pull/1412)
+  * Adds oauth2 introspect method, exposed as `authClient.token.introspect`
+  * Adds optional `tokens` param to `renewTokens`
+
 ### Fixes
 
 - [#1421](https://github.com/okta/okta-auth-js/pull/1421) Throw error if there is incorrect `relatesTo` in IDX response

--- a/lib/oidc/factory/api.ts
+++ b/lib/oidc/factory/api.ts
@@ -23,6 +23,7 @@ import { renewToken } from '../renewToken';
 import { renewTokens } from '../renewTokens';
 import { renewTokensWithRefresh } from '../renewTokensWithRefresh';
 import { revokeToken } from '../revokeToken';
+import { oidcIntrospect } from '../introspect';
 import {
   AccessToken,
   CustomUserClaims,
@@ -84,7 +85,8 @@ export function createTokenAPI(sdk: OktaAuthOAuthInterface, queue: PromiseQueue)
       return getUserInfo(sdk, accessTokenObject, idTokenObject);
     },
     verify: verifyToken.bind(null, sdk),
-    isLoginRedirect: isLoginRedirect.bind(null, sdk)
+    isLoginRedirect: isLoginRedirect.bind(null, sdk),
+    introspect: oidcIntrospect.bind(null, sdk),
   };
 
   // Wrap certain async token API methods using PromiseQueue to avoid issues with concurrency

--- a/lib/oidc/index.ts
+++ b/lib/oidc/index.ts
@@ -34,3 +34,4 @@ export { getWithoutPrompt } from './getWithoutPrompt';
 export { getWithPopup } from './getWithPopup';
 export { getWithRedirect } from './getWithRedirect';
 export { parseFromUrl } from './parseFromUrl';
+export { oidcIntrospect } from './introspect';

--- a/lib/oidc/introspect.ts
+++ b/lib/oidc/introspect.ts
@@ -1,0 +1,69 @@
+/*!
+ * Copyright (c) 2015-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+import { AuthSdkError } from '../errors';
+import { getWellKnown } from './endpoints/well-known';
+import { post } from '../http';
+import { toQueryString } from '../util';
+import { btoa } from '../crypto';
+import { AccessToken, Token, TokenKind } from './types';
+
+const hintMap = {
+  accessToken: 'access_token',
+  idToken: 'id_token',
+  refreshToken: 'refresh_token'
+};
+
+export async function oidcIntrospect (sdk, kind: TokenKind, token?: Token) {
+  let issuer: string;
+  let clientId: string = sdk.options.clientId;
+  let clientSecret: string | undefined = sdk.options.clientSecret;
+
+  if (!token) {
+    token = sdk.tokenManager.getTokens()[kind];
+  }
+
+  if (kind !== TokenKind.ACCESS) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    issuer = (token! as any).issuer;
+  }
+  else {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    issuer = (token as AccessToken).claims.iss!;
+  }
+  issuer ??= sdk.options.issuer;
+
+  if (!clientId) {
+    throw new AuthSdkError('A clientId must be specified in the OktaAuth constructor to introspect a token');
+  }
+  if (!issuer) {
+    return Promise.reject(new AuthSdkError('Unable to find issuer'));
+  }
+  if (!kind || !token) {
+    return Promise.reject(new AuthSdkError(`${kind} token not found`));
+  }
+
+  const { introspect_endpoint: introspectUrl } = await getWellKnown(sdk, issuer);
+  const authHeader = clientSecret ? btoa(`${clientId}:${clientSecret}`) : btoa(clientId);
+  const args = toQueryString({
+    // eslint-disable-next-line camelcase
+    token_type_hint: hintMap[kind],
+    token: token[kind]    // extract raw token string from token object
+  }).slice(1);
+  return post(sdk, introspectUrl, args, {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Authorization': 'Basic ' + authHeader
+    }
+  });
+}

--- a/lib/oidc/renewTokens.ts
+++ b/lib/oidc/renewTokens.ts
@@ -11,15 +11,15 @@
  *
  */
 import { AuthSdkError } from '../errors';
-import { TokenParams, Tokens } from './types';
+import { RenewTokensParams, Tokens } from './types';
 import { getWithoutPrompt } from './getWithoutPrompt';
 import { renewTokensWithRefresh } from './renewTokensWithRefresh';
 import { getDefaultTokenParams } from './util';
 
 // If we have a refresh token, renew using that, otherwise getWithoutPrompt
 // eslint-disable-next-line complexity
-export async function renewTokens(sdk, options?: TokenParams): Promise<Tokens> {
-  const tokens = sdk.tokenManager.getTokensSync();
+export async function renewTokens(sdk, options?: RenewTokensParams): Promise<Tokens> {
+  const tokens = options?.tokens ?? sdk.tokenManager.getTokensSync();
   if (tokens.refreshToken) {
     return renewTokensWithRefresh(sdk, options || {}, tokens.refreshToken);
   }

--- a/lib/oidc/types/Token.ts
+++ b/lib/oidc/types/Token.ts
@@ -47,7 +47,7 @@ export enum TokenKind {
   ACCESS = 'accessToken',
   ID = 'idToken',
   REFRESH = 'refreshToken',
-};
+}
 
 export function isToken(obj: any): obj is Token {
   if (obj &&

--- a/lib/oidc/types/Token.ts
+++ b/lib/oidc/types/Token.ts
@@ -43,6 +43,11 @@ export type Token = AccessToken | IDToken | RefreshToken;
 export type RevocableToken = AccessToken | RefreshToken;
 
 export type TokenType = 'accessToken' | 'idToken' | 'refreshToken';
+export enum TokenKind {
+  ACCESS = 'accessToken',
+  ID = 'idToken',
+  REFRESH = 'refreshToken',
+};
 
 export function isToken(obj: any): obj is Token {
   if (obj &&

--- a/lib/oidc/types/api.ts
+++ b/lib/oidc/types/api.ts
@@ -12,10 +12,10 @@
 
 import { JWTObject } from './JWT';
 import { OAuthTransactionMeta, PKCETransactionMeta } from './meta';
-import { CustomUrls, OktaAuthOAuthOptions, SigninWithRedirectOptions, TokenParams } from './options';
+import { CustomUrls, OktaAuthOAuthOptions, SigninWithRedirectOptions, TokenParams, RenewTokensParams } from './options';
 import { OAuthResponseType } from './proto';
 import { OAuthStorageManagerInterface } from './storage';
-import { AccessToken, IDToken, RefreshToken, RevocableToken, Token, Tokens } from './Token';
+import { AccessToken, IDToken, RefreshToken, RevocableToken, Token, Tokens, TokenKind } from './Token';
 import { TokenManagerInterface } from './TokenManager';
 import { CustomUserClaims, UserClaims } from './UserClaims';
 import { TransactionManagerInterface } from './TransactionManager';
@@ -68,10 +68,11 @@ export interface TokenAPI extends BaseTokenAPI {
   getWithPopup(params?: TokenParams): Promise<TokenResponse>;
   revoke(token: RevocableToken): Promise<object>;
   renew(token: Token): Promise<Token | undefined>;
-  renewTokens(options?: TokenParams): Promise<Tokens>;
+  renewTokens(options?: RenewTokensParams): Promise<Tokens>;
   renewTokensWithRefresh(tokenParams: TokenParams, refreshTokenObject: RefreshToken): Promise<Tokens>;
   verify(token: IDToken, params?: object): Promise<IDToken>;
   isLoginRedirect(): boolean;
+  introspect(kind: TokenKind, token?: Token): any;  // TODO: make real return type
 }
 
 export interface TokenVerifyParams {

--- a/lib/oidc/types/options.ts
+++ b/lib/oidc/types/options.ts
@@ -15,6 +15,7 @@ import { OktaAuthHttpOptions } from '../../http/types';
 import { SimpleStorage } from '../../storage/types';
 import { OktaAuthOAuthInterface, SetLocationFunction } from './api';
 import { OAuthResponseMode, OAuthResponseType } from './proto';
+import { Tokens } from './Token';
 import { TransactionManagerOptions } from './Transaction';
 
 export interface CustomUrls {
@@ -74,6 +75,10 @@ export interface EnrollAuthenticatorOptions extends TokenParams {
 
 export interface SigninWithRedirectOptions extends TokenParams {
   originalUri?: string;
+}
+
+export interface RenewTokensParams extends TokenParams {
+  tokens?: Tokens
 }
 
 export interface OktaAuthOAuthOptions extends

--- a/lib/oidc/types/proto.ts
+++ b/lib/oidc/types/proto.ts
@@ -61,7 +61,7 @@ export interface WellKnownResponse {
   id_token_signing_alg_values_supported: string[];
   scopes_supported: string[];
   claims_supported: string[];
-  introspect_endpoint: string;
+  introspection_endpoint: string;
 }
 
 

--- a/lib/oidc/types/proto.ts
+++ b/lib/oidc/types/proto.ts
@@ -61,6 +61,7 @@ export interface WellKnownResponse {
   id_token_signing_alg_values_supported: string[];
   scopes_supported: string[];
   claims_supported: string[];
+  introspect_endpoint: string;
 }
 
 

--- a/test/spec/oidc/introspect.ts
+++ b/test/spec/oidc/introspect.ts
@@ -1,0 +1,188 @@
+import { oidcIntrospect as introspect } from '../../../lib/oidc/introspect';
+import { AuthSdkError } from '../../../lib/errors';
+import { TokenKind } from '../../../lib/oidc/types';
+
+const mockIntrospectUrl = 'test url';
+
+const mocked = {
+  getWellKnown: jest.fn().mockResolvedValue({introspection_endpoint: mockIntrospectUrl}),
+  post: jest.fn().mockResolvedValue(true),
+  getTokens: jest.fn()
+};
+jest.mock('../../../lib/oidc/endpoints/well-known', () => {
+  return {
+    getWellKnown: (...args) => mocked.getWellKnown(...args)
+  };
+});
+jest.mock('../../../lib/http', () => {
+  return {
+    post: (...args) => mocked.post(...args)
+  };
+});
+
+describe('introspect', () => {
+  const testContext: any = {};
+
+  beforeEach(() => {
+    testContext.accessToken = {
+      accessToken: 'accessToken'
+    };
+    testContext.idToken = {
+      idToken: 'idToken'
+    };
+    testContext.refreshToken = {
+      refreshToken: 'refreshToken'
+    };
+
+    testContext.sdk = {
+      tokenManager: {
+        getTokens: mocked.getTokens
+      },
+      options: {
+        clientId: 'clientId',
+        issuer: 'sdk.options.issuer'
+      }
+    };
+  });
+
+  describe('errors', () => {
+    it('throws when no clientId is provided', async () => {
+      const { sdk, accessToken } = testContext;
+      sdk.options.clientId = undefined;
+      let err;
+      try {
+        await introspect(sdk, TokenKind.ACCESS, accessToken);
+      }
+      catch(e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(AuthSdkError);
+      expect(err.message).toEqual('A clientId must be specified in the OktaAuth constructor to introspect a token');
+    });
+
+    it('throws when no issuer is provided', async () => {
+      const { sdk, accessToken } = testContext;
+      sdk.options.issuer = undefined;
+      let err;
+      try {
+        await introspect(sdk, TokenKind.ACCESS, accessToken);
+      }
+      catch(e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(AuthSdkError);
+      expect(err.message).toEqual('Unable to find issuer');
+    });
+
+    it('throws when tokens are not passed and cannot be found in storage', async () => {
+      const { sdk } = testContext;
+      mocked.getTokens.mockReturnValue({});
+      let err;
+      try {
+        await introspect(sdk, TokenKind.ACCESS);
+      }
+      catch(e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(AuthSdkError);
+      expect(err.message).toEqual('unable to find accessToken in storage or fn params');
+    });
+  });
+
+  it('introspects access token', async () => {
+    const { sdk, accessToken } = testContext;
+    mocked.getTokens.mockReturnValue({ accessToken });
+    await introspect(sdk, TokenKind.ACCESS, accessToken);
+    expect(mocked.getWellKnown).toHaveBeenCalledWith(sdk, 'sdk.options.issuer');
+    expect(mocked.post).toHaveBeenCalledWith(
+      sdk, 
+      mockIntrospectUrl,
+      'token_type_hint=access_token&token=accessToken',
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': expect.stringContaining('Basic ')
+        }
+      })
+    );
+    expect(mocked.getTokens).not.toHaveBeenCalled();
+    await introspect(sdk, TokenKind.ACCESS);
+    expect(mocked.getTokens).toHaveBeenCalled();
+    expect(mocked.post).toHaveBeenLastCalledWith(
+      sdk, 
+      mockIntrospectUrl,
+      'token_type_hint=access_token&token=accessToken',
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': expect.stringContaining('Basic ')
+        }
+      })
+    );
+  });
+
+  it('introspects id token', async () => {
+    const { sdk, idToken } = testContext;
+    mocked.getTokens.mockReturnValue({ idToken });
+    await introspect(sdk, TokenKind.ID, idToken);
+    expect(mocked.getWellKnown).toHaveBeenCalledWith(sdk, 'sdk.options.issuer');
+    expect(mocked.post).toHaveBeenCalledWith(
+      sdk, 
+      mockIntrospectUrl,
+      'token_type_hint=id_token&token=idToken',
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': expect.stringContaining('Basic ')
+        }
+      })
+    );
+    expect(mocked.getTokens).not.toHaveBeenCalled();
+    await introspect(sdk, TokenKind.ID);
+    expect(mocked.getTokens).toHaveBeenCalled();
+    expect(mocked.post).toHaveBeenLastCalledWith(
+      sdk, 
+      mockIntrospectUrl,
+      'token_type_hint=id_token&token=idToken',
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': expect.stringContaining('Basic ')
+        }
+      })
+    );
+  });
+
+  it('introspects refresh token', async () => {
+    const { sdk, refreshToken } = testContext;
+    mocked.getTokens.mockReturnValue({ refreshToken });
+    await introspect(sdk, TokenKind.REFRESH, refreshToken);
+    expect(mocked.getWellKnown).toHaveBeenCalledWith(sdk, 'sdk.options.issuer');
+    expect(mocked.post).toHaveBeenCalledWith(
+      sdk, 
+      mockIntrospectUrl,
+      'token_type_hint=refresh_token&token=refreshToken',
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': expect.stringContaining('Basic ')
+        }
+      })
+    );
+    expect(mocked.getTokens).not.toHaveBeenCalled();
+    await introspect(sdk, TokenKind.REFRESH);
+    expect(mocked.getTokens).toHaveBeenCalled();
+    expect(mocked.post).toHaveBeenLastCalledWith(
+      sdk, 
+      mockIntrospectUrl,
+      'token_type_hint=refresh_token&token=refreshToken',
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': expect.stringContaining('Basic ')
+        }
+      })
+    );
+  });
+
+});

--- a/test/spec/oidc/renewTokens.ts
+++ b/test/spec/oidc/renewTokens.ts
@@ -59,7 +59,7 @@ describe('token.renewTokens', function() {
 
   describe('using token endpoint', () => {
     it('will renew using refresh token if it exists, passing along options', async () => {
-      const { renewWithRefreshResponse } = testContext;
+      const { renewWithRefreshResponse,  } = testContext;
       const refreshToken = 'fake';
       const tokens = {
         refreshToken
@@ -74,6 +74,22 @@ describe('token.renewTokens', function() {
       const res = await renewTokens(sdk, options);
       expect(res).toBe(renewWithRefreshResponse);
       expect(mocked.renewTokensWithRefresh.renewTokensWithRefresh).toHaveBeenCalledWith(sdk, options, refreshToken);
+
+      // with passing token values directly
+      const accessToken = {
+        accessToken: 'access',
+        scopes: ['access'],
+        authorizeUrl: 'access',
+        userinfoUrl: 'access',
+      } as any;
+      const refresh = {
+        refreshToken
+      } as any;
+      const opts = { tokens: { refreshToken: refresh, accessToken }};
+      const directRes = await renewTokens(sdk, opts);
+      expect(directRes).toBe(renewWithRefreshResponse);
+      expect(mocked.renewTokensWithRefresh.renewTokensWithRefresh).toHaveBeenCalledTimes(2);
+      expect(mocked.renewTokensWithRefresh.renewTokensWithRefresh).toHaveBeenNthCalledWith(2, sdk, opts, refresh);
     });
   });
 
@@ -119,6 +135,16 @@ describe('token.renewTokens', function() {
       getWihoutPromptResponse.tokens = tokens;
       const res = await renewTokens(sdk, {});
       expect(res).toBe(tokens);
+    });
+
+    it('returns tokens without accessing TokenManager', async () => {
+      const { sdk, getWihoutPromptResponse, accessToken } = testContext;
+      const getTokensSpy = jest.spyOn(sdk.tokenManager, 'getTokensSync');
+      const tokens = { fake: true };
+      getWihoutPromptResponse.tokens = tokens;
+      const res = await renewTokens(sdk, { tokens: { accessToken } });
+      expect(res).toBe(tokens);
+      expect(getTokensSpy).not.toHaveBeenCalled();
     });
 
     describe('responseType', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3050,15 +3050,15 @@ ansi-red@^0.1.1:
   dependencies:
     ansi-wrap "0.1.0"
 
-ansi-regex@^2.0.0, ansi-regex@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
-  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
-
-ansi-regex@^4.1.0, ansi-regex@^4.1.1:
+ansi-regex@^2.0.0, ansi-regex@^4.1.0, ansi-regex@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
   integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
+ansi-regex@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
+  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
 
 ansi-regex@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
- adds ouath introspect method
- adds optional param to `renewTokens` to pass tokens in directly, avoiding requesting from TokenManager