### PR TITLE
Upgrades `decode-uri-component`, `http-cache-semantics` to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,7 +232,8 @@
   },
   "resolutions": {
     "**/request/qs": "^6.10.5",
-    "**/globule/minimatch": "^3.1.2"
+    "**/globule/minimatch": "^3.1.2",
+    "**/cacheable-request/http-cache-semantics": "^4.0.0"
   },
   "workspaces": {
     "packages": [

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -8,7 +8,7 @@ export TEST_RESULT_FILE_DIR="${REPO}/build2/reports/unit"
 export CI=true
 export ISSUER=https://javascript-idx-sdk-idfirst.okta.com
 export USERNAME=george@acme.com
-get_secret prod/okta-sdk-vars/password PASSWORD
+get_vault_secret_key repo_gh-okta-okta-auth-js/default password PASSWORD
 
 # for myaccount password API testing
 export PASSWORDLESS_USERNAME=password.optional@mailinator.com

--- a/scripts/setup-e2e.sh
+++ b/scripts/setup-e2e.sh
@@ -33,7 +33,7 @@ setup_e2e () {
 
   export ISSUER=https://samples-javascript.okta.com/oauth2/default
   export USERNAME=george@acme.com
-  get_secret prod/okta-sdk-vars/password PASSWORD
+  get_vault_secret_key repo_gh-okta-okta-auth-js/default password PASSWORD
   finish_log_group $?
 }
 
@@ -64,7 +64,7 @@ setup_sample_tests () {
   export TEST_RESULT_FILE_DIR="${REPO}/build2/reports/e2e"
 
   export USERNAME=mary@acme.com
-  get_secret prod/okta-sdk-vars/password PASSWORD
+  get_vault_secret_key repo_gh-okta-okta-auth-js/default password PASSWORD
 
   export ORG_OIE_ENABLED=true
   get_vault_secret_key devex/auth-js-sdk-vars a18n_api_key A18N_API_KEY

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,7 +16,8 @@ if [ -n "${TEST_SUITE_ID}" ]; then
   export NVM_DIR="/root/.nvm"
 
   setup_service node "${1:-v14.18.0}"
-  setup_service yarn-berry 1.21.1
+  # Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
+  setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
 
 else
   # bacon defines OKTA_HOME and REPO, define these relative to this file

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,8 +16,7 @@ if [ -n "${TEST_SUITE_ID}" ]; then
   export NVM_DIR="/root/.nvm"
 
   setup_service node "${1:-v14.18.0}"
-  # Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
-  setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
+  setup_service yarn-berry 1.21.1
 
 else
   # bacon defines OKTA_HOME and REPO, define these relative to this file

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -39,16 +39,12 @@ else
   export PUBLISH_ARTIFACTORY_FAILURE=1
 
   # bacon commands
-  get_secret () {
+  get_vault_secret_key () {
     # ensures the env var is set
-    if [ -z "$(echo "$2")" ]; then
-      echo "$2 is not defined. Exiting..."
+    if [ -z "$(echo "$3")" ]; then
+      echo "$3 is not defined. Exiting..."
       exit 1
     fi
-  }
-
-  get_vault_secret_key () {
-    get_secret $1 $3
   }
 
   junit () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7074,12 +7074,7 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-http-cache-semantics@3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
-  integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
-
-http-cache-semantics@^4.0.0:
+http-cache-semantics@3.8.1, http-cache-semantics@^4, http-cache-semantics@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
   integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4745,9 +4745,9 @@ decimal.js@^10.3.1:
   integrity sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==
 
 decode-uri-component@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.1.tgz#e9d7afd716fc1a7ec6ae7cc0aa3e540a1eac2e9d"
-  integrity sha512-XZHyaFJ6QMWhYmlz+UcmtaLeecNiXwkTGzCqG5WByt+1P1HnU6Siwf0TeP3OsZmlnGqQRSEMIxue0LLCaGY3dw==
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
 decompress-response@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
* Re-resolve `decode-uri-component` version to latest semver
* Forcefully resolve `http-cache-semantics` to `^4.0.0`
* Migrate secrets to Vault