### PR TITLE
Use siw-platform-scripts instead of artifactory url

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -34,7 +34,7 @@ test_suites:
     - name: e2e
       script_path: ../okta-auth-js/scripts/e2e
       sort_order: '4'
-      timeout: '15'
+      timeout: '20'
       script_name: e2e
       criteria: MERGE
       queue_name: small
@@ -63,35 +63,35 @@ test_suites:
     - name: sample-express-web-no-oidc
       script_path: ../okta-auth-js/scripts/samples
       sort_order: '7'
-      timeout: '10'
+      timeout: '15'
       script_name: e2e-express-web-no-oidc
       criteria: MERGE
       queue_name: small
     - name: sample-express-web-with-oidc
       script_path: ../okta-auth-js/scripts/samples
       sort_order: '8'
-      timeout: '10'
+      timeout: '15'
       script_name: e2e-express-web-with-oidc
       criteria: MERGE
       queue_name: small
     - name: sample-static-spa
       script_path: ../okta-auth-js/scripts/samples
       sort_order: '9'
-      timeout: '10'
+      timeout: '15'
       script_name: e2e-static-spa
       criteria: MERGE
       queue_name: small
     - name: sample-webpack-spa
       script_path: ../okta-auth-js/scripts/samples
       sort_order: '10'
-      timeout: '10'
+      timeout: '15'
       script_name: e2e-webpack-spa
       criteria: MERGE
       queue_name: small
     - name: sample-express-embedded-sign-in-widget
       script_path: ../okta-auth-js/scripts/samples
       sort_order: '11'
-      timeout: '10'
+      timeout: '15'
       script_name: e2e-express-embedded-sign-in-widget
       criteria: MERGE
       queue_name: small

--- a/samples/generated/react-embedded-auth-with-sdk/package.json
+++ b/samples/generated/react-embedded-auth-with-sdk/package.json
@@ -15,7 +15,7 @@
     "react-router-dom": "^5.2.0",
     "@okta/okta-react": "^6.4.3",
     "@okta/odyssey-react": "0.10.0",
-    "@okta/okta-signin-widget": "^6.8.2",
+    "@okta/okta-signin-widget": "^7.2.1",
     "@okta/okta-auth-js": "*"
   },
   "devDependencies": {

--- a/samples/generated/react-embedded-auth-with-sdk/src/components/WidgetPage.jsx
+++ b/samples/generated/react-embedded-auth-with-sdk/src/components/WidgetPage.jsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import OktaSignIn from '@okta/okta-signin-widget';
 import { useOktaAuth } from '@okta/okta-react';
-import '@okta/okta-signin-widget/dist/css/okta-sign-in.min.css';
+import '@okta/okta-signin-widget/css/okta-sign-in.min.css';
 import oidcConfig from '../config';
 
 const WidgetPage = () => {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -85,9 +85,11 @@ install_siw_platform_scripts () {
   orig_registry=$(yarn config get @okta:registry)
   REGISTRY="${ARTIFACTORY_URL}/api/npm/npm-topic"
   update_yarn_config () {
-    yarn config set @okta:registry ${REGISTRY}
-    yarn config set strict-ssl false
-    trap restore_yarn_config EXIT
+    if [ "$SIW_PLATFORM_ENV" == "local" ] ; then
+      yarn config set @okta:registry ${REGISTRY}
+      yarn config set strict-ssl false
+      trap restore_yarn_config EXIT
+    fi
   }
   restore_yarn_config () {
     if [ "$SIW_PLATFORM_ENV" == "local" ] ; then
@@ -102,14 +104,14 @@ install_siw_platform_scripts () {
 
   update_yarn_config
   if ! yarn global add @okta/siw-platform-scripts ; then
-    echo "siw-platform-scripts could not be installed via artifactory"
+    echo "siw-platform-scripts could not be installed"
     exit ${FAILED_SETUP}
   fi
   restore_yarn_config
 }
 
 artifactory_siw_install () {
-  if ! siw-platform install-artifact -e local -n @okta/okta-signin-widget -v ${WIDGET_VERSION} ; then
+  if ! siw-platform install-artifact -e ${SIW_PLATFORM_ENV} -n @okta/okta-signin-widget -v ${WIDGET_VERSION} ; then
     echo "WIDGET_VERSION could not be installed via siw-platform: ${WIDGET_VERSION}"
     exit ${FAILED_SETUP}
   fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,7 +9,6 @@ if [ -n "${TEST_SUITE_ID}" ]; then
   # This is available from the "downstream artifact" menu on any okta-auth-js build in Bacon.
   # DO NOT MERGE ANY CHANGES TO THIS LINE!!
   export WIDGET_VERSION=""
-  export SIW_PLATFORM_ENV="bacon"
 
   # Add yarn to the $PATH so npm cli commands do not fail
   export PATH="${PATH}:$(yarn global bin)"
@@ -25,7 +24,6 @@ else
   export REPO="."
   export TEST_SUITE_TYPE_FILE=/dev/null
   export TEST_RESULT_FILE_DIR_FILE=/dev/null
-  export SIW_PLATFORM_ENV="local"
 
   ### (known) Bacon exit codes
   # success

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -69,9 +69,6 @@ fi
 
 cd ${OKTA_HOME}/${REPO}
 
-# todo
-export WIDGET_VERSION="7.6.0-g355a6da"
-
 create_log_group "Yarn Install"
 # Install dependencies. --ignore-scripts will prevent chromedriver from attempting to install
 if ! yarn install --frozen-lockfile --ignore-scripts; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -113,7 +113,7 @@ if [ ! -z "$WIDGET_VERSION" ]; then
   else
     # sha found, install from artifactory
     install_siw_platform_scripts
-    use_artifact_in_workspaces @okta/okta-signin-widget "$WIDGET_VERSION"
+    use_beta_pkg @okta/okta-signin-widget "$WIDGET_VERSION"
     install_artifact @okta/okta-signin-widget "$WIDGET_VERSION"
   fi
 

--- a/scripts/utils/install-beta-pkg.sh
+++ b/scripts/utils/install-beta-pkg.sh
@@ -17,38 +17,6 @@ replace_workspace_version () {
   printf '%s\n' "${json}" > $1/package.json
 }
 
-replace_workspace_dev_version () {
-  # $1 = workspace path
-  # $2 = package name
-  # $3 = version
-  # package should be moved to `devDependencies` cause `siw-platform` uses `--dev`
-  json=$(cat $1/package.json |  jq --arg pkg $2 --arg version $3 '
-    if  .dependencies | has("\($pkg)") then
-     del(.dependencies["\($pkg)"]) | .devDependencies["\($pkg)"] = $version
-    elif .devDependencies | has("\($pkg)") then
-     .devDependencies["\($pkg)"] = $version
-    else . end') && \
-  printf '%s\n' "${json}" > $1/package.json
-}
-
-has_package () {
-  # $1 = workspace path
-  # $2 = package name
-  result=$(cat $1/package.json | jq --arg pkg $2 '
-    (.devDependencies | has("\($pkg)")) or (.dependencies | has("\($pkg)"))
-  ')
-  [[ "$result" == "true" ]]
-}
-
-use_artifact () {
-  # $1 = workspace path
-  # $2 = package name
-  # $3 = version
-  if has_package $1 $2; then
-    replace_workspace_dev_version $1 $2 $3
-  fi
-}
-
 install_beta_pkg () {
   # $1 = package name
   # $2 = version
@@ -56,10 +24,10 @@ install_beta_pkg () {
   yarn --ignore-scripts
 }
 
-use_artifact_in_workspaces () {
+use_beta_pkg () {
   # $1 = package name
   # $2 = version
-  foreach_workspace -p use_artifact $1 $2
+  foreach_workspace -p replace_workspace_version $1 $2
 }
 
 if [ $sourced -ne 1 ]; then

--- a/scripts/utils/install-beta-pkg.sh
+++ b/scripts/utils/install-beta-pkg.sh
@@ -40,16 +40,12 @@ has_package () {
   [[ "$result" == "true" ]]
 }
 
-install_artifact () {
+use_artifact () {
   # $1 = workspace path
   # $2 = package name
   # $3 = version
   if has_package $1 $2; then
     replace_workspace_dev_version $1 $2 $3
-    if ! siw-platform install-artifact -e ${SIW_PLATFORM_ENV} -n $2 -v $3 ; then
-      echo "$2 could not be installed via siw-platform: $3"
-      exit ${FAILED_SETUP}
-    fi
   fi
 }
 
@@ -60,10 +56,10 @@ install_beta_pkg () {
   yarn --ignore-scripts
 }
 
-install_artifact_in_workspaces () {
+use_artifact_in_workspaces () {
   # $1 = package name
   # $2 = version
-  foreach_workspace -p install_artifact $1 $2
+  foreach_workspace -p use_artifact $1 $2
 }
 
 if [ $sourced -ne 1 ]; then

--- a/scripts/utils/install-beta-pkg.sh
+++ b/scripts/utils/install-beta-pkg.sh
@@ -21,6 +21,7 @@ replace_workspace_dev_version () {
   # $1 = workspace path
   # $2 = package name
   # $3 = version
+  # package should be moved to `devDependencies` cause `siw-platform` uses `--dev`
   json=$(cat $1/package.json |  jq --arg pkg $2 --arg version $3 '
     if  .dependencies | has("\($pkg)") then
      del(.dependencies["\($pkg)"]) | .devDependencies["\($pkg)"] = $version

--- a/scripts/utils/siw-platform-scripts.sh
+++ b/scripts/utils/siw-platform-scripts.sh
@@ -44,7 +44,7 @@ install_artifact () {
   # $2 = version
   update_yarn_config
   if ! siw-platform install-artifact -e ${SIW_PLATFORM_ENV} -n $1 -v $2 ; then
-    echo "$1 could not be installed via siw-platform: $1"
+    echo "$1 $2 could not be installed via siw-platform"
     exit ${FAILED_SETUP}
   fi
   restore_yarn_config

--- a/scripts/utils/siw-platform-scripts.sh
+++ b/scripts/utils/siw-platform-scripts.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# if running on bacon
+if [ -n "${TEST_SUITE_ID}" ]; then
+  export SIW_PLATFORM_ENV="bacon"
+else
+  export SIW_PLATFORM_ENV="local"
+fi
+
 orig_ssl=$(yarn config get strict-ssl)
 orig_registry=$(yarn config get @okta:registry)
 REGISTRY="${ARTIFACTORY_URL}/api/npm/npm-topic"

--- a/scripts/utils/siw-platform-scripts.sh
+++ b/scripts/utils/siw-platform-scripts.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+orig_ssl=$(yarn config get strict-ssl)
+orig_registry=$(yarn config get @okta:registry)
+REGISTRY="${ARTIFACTORY_URL}/api/npm/npm-topic"
+
+update_yarn_config () {
+  if [ "$SIW_PLATFORM_ENV" == "local" ] ; then
+    yarn config set @okta:registry ${REGISTRY}
+    yarn config set strict-ssl false
+    trap restore_yarn_config EXIT
+  fi
+}
+
+restore_yarn_config () {
+  if [ "$SIW_PLATFORM_ENV" == "local" ] ; then
+    if [ "$orig_registry" == "undefined" ] ; then
+      yarn config delete @okta:registry
+    else
+      yarn config set @okta:registry $orig_registry
+    fi
+    yarn config set strict-ssl $orig_ssl
+  fi
+}
+
+install_siw_platform_scripts () {
+  update_yarn_config
+  if ! yarn global add @okta/siw-platform-scripts ; then
+    echo "siw-platform-scripts could not be installed"
+    exit ${FAILED_SETUP}
+  fi
+  restore_yarn_config
+}
+
+install_artifact () {
+  # $1 = package name
+  # $2 = version
+  update_yarn_config
+  if ! siw-platform install-artifact -e ${SIW_PLATFORM_ENV} -n $1 -v $2 ; then
+    echo "$1 could not be installed via siw-platform: $1"
+    exit ${FAILED_SETUP}
+  fi
+  restore_yarn_config
+}

--- a/scripts/verify-registry-install.sh
+++ b/scripts/verify-registry-install.sh
@@ -3,7 +3,7 @@
 # NOTE: MUST BE RAN *AFTER* THE PUBLISH SUITE
 
 # Install required node version
-export REGISTRY="https://artifacts.aue1d.saasure.com/artifactory/npm-topic"
+export REGISTRY="${ARTIFACTORY_URL}/npm-topic"
 
 cd ${OKTA_HOME}/${REPO}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -979,14 +979,6 @@
     pirates "^4.0.5"
     source-map-support "^0.5.16"
 
-"@babel/runtime-corejs3@^7.17.0":
-  version "7.19.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.19.4.tgz#870dbfd9685b3dad5aeb2d00841bb8b6192e3095"
-  integrity sha512-HzjQ8+dzdx7dmZy4DQ8KV8aHi/74AjEbBGTFutBmg/pd3dY5/q1sfuOGPTFGEytlQhWoeVXqcK5BwMgIkRkNDQ==
-  dependencies:
-    core-js-pure "^3.25.1"
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.0", "@babel/runtime@^7.6.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
@@ -1638,29 +1630,6 @@
     "@okta/odyssey-react-theme" "^0.10.0"
     choices.js "^9.0.1"
 
-"@okta/okta-auth-js@6.9.0":
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-6.9.0.tgz#2b568234f1c2ef203160faa4f4697bb02038ab83"
-  integrity sha512-IAh9mh2iGT4bsGeRMSSGBYoeEJ4f3ABTO+Jf9mYr0MbKgyU+X+7RwYAo/z8JHJ9AW0ynmjERTMOgDJ7/H/N+Dw==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@babel/runtime-corejs3" "^7.17.0"
-    "@peculiar/webcrypto" "^1.4.0"
-    Base64 "1.1.0"
-    atob "^2.1.2"
-    broadcast-channel "~4.17.0"
-    btoa "^1.2.1"
-    core-js "^3.6.5"
-    cross-fetch "^3.1.5"
-    js-cookie "^3.0.1"
-    jsonpath-plus "^6.0.1"
-    node-cache "^5.1.2"
-    p-cancelable "^2.0.0"
-    text-encoding "^0.7.0"
-    tiny-emitter "1.1.0"
-    webcrypto-shim "^0.1.5"
-    xhr2 "0.1.3"
-
 "@okta/okta-auth-js@~7.0.0":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-7.0.2.tgz#cd47008d3a24d3db5c89e0521d5ace5760fe47c7"
@@ -1716,29 +1685,6 @@
     cross-fetch "^3.1.5"
     handlebars "^4.5.3"
     jasmine "^4.0.1"
-    q "1.4.1"
-    u2f-api-polyfill "0.4.3"
-    underscore "1.13.1"
-  optionalDependencies:
-    fsevents "*"
-
-"@okta/okta-signin-widget@^6.8.2":
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-signin-widget/-/okta-signin-widget-6.9.0.tgz#252d939525a422580c51e549a6e4ed4cd20f4765"
-  integrity sha512-UElSmcXRpRmYJqv2mz8IAnEjOK4Nt9fniw89bcmj3BK4q506oVgOheE7dxq5wnHLMYsJuuiDgc3gUrcFsrw+rw==
-  dependencies:
-    "@okta/okta-auth-js" "6.9.0"
-    "@sindresorhus/to-milliseconds" "^1.0.0"
-    "@types/backbone" "^1.4.15"
-    "@types/jquery" "^3.5.14"
-    "@types/jqueryui" "^1.12.16"
-    "@types/q" "^1.5.5"
-    "@types/selectize" "^0.12.35"
-    "@types/underscore" "^1.11.4"
-    clipboard "^1.5.16"
-    cross-fetch "^3.1.5"
-    handlebars "^4.7.7"
-    parse-ms "^2.0.0"
     q "1.4.1"
     u2f-api-polyfill "0.4.3"
     underscore "1.13.1"
@@ -4515,11 +4461,6 @@ core-js-compat@^3.25.1:
   integrity sha512-ovcyhs2DEBUIE0MGEKHP4olCUW/XYte3Vroyxuh38rD1wAO4dHohsovUC4eAOuzFxE6b+RXvBU3UZ9o0YhUTkA==
   dependencies:
     browserslist "^4.21.4"
-
-core-js-pure@^3.25.1:
-  version "3.25.5"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.25.5.tgz#79716ba54240c6aa9ceba6eee08cf79471ba184d"
-  integrity sha512-oml3M22pHM+igfWHDfdLVq2ShWmjM2V4L+dQEBs0DWVIqEm9WHCwGAlZ6BmyBQGy5sFrJmcx+856D9lVKyGWYg==
 
 core-js@^3.1.3, core-js@^3.16.2, core-js@^3.6.5:
   version "3.25.5"


### PR DESCRIPTION
- Use `siw-platform-scripts` to install SIW instead of artifactory url
- Increased timeouts for Bacon tasks
- Upgraded `@okta/okta-signin-widget` from v6 to v7 in sample `react-embedded-auth-with-sdk`


Internal ref: [OKTA-607419](https://oktainc.atlassian.net/browse/OKTA-607419)