### PR TITLE
.signOut improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Features
 
+- [#1440](https://github.com/okta/okta-auth-js/pull/1440) Fixes type of `tokenManager.getSync`
+
+- [#1439](https://github.com/okta/okta-auth-js/pull/1439) `.signOut` improvements
+  * Passing `postLogoutRedirectUri: null` to `.signOut` now omits the param from `/logout` call and will observe the behavior of `/logout`
+  * `state` is now returned as a query param to the `postLogoutRedirectUri` when `.signOut` falls back to `.closeSession`
+
 - [#1412](https://github.com/okta/okta-auth-js/pull/1412)
   * Adds oauth2 introspect method, exposed as `authClient.token.introspect`
   * Adds optional `tokens` param to `renewTokens`

--- a/README.md
+++ b/README.md
@@ -996,7 +996,7 @@ Signs the user out of their current [Okta session](https://developer.okta.com/do
 
 `signOut` takes the following options:
 
-* `postLogoutRedirectUri` - Setting a value will override the `postLogoutRedirectUri` configured on the SDK.
+* `postLogoutRedirectUri` - Setting a value will override the `postLogoutRedirectUri` configured on the SDK. This will default to `window.location.origin` if no value is provided. To prevent this explicitly pass `null` to leverage the default behavior of `/logout`. If `signOut` falls back to `closeSession` `window.location.origin` will still be used as the default value, even if `null` is passed.
 * `state` - An optional value, used along with `postLogoutRedirectUri`. If set, this value will be returned as a query parameter during the redirect to the `postLogoutRedirectUri`
 * `idToken` - Specifies the ID token object. By default, `signOut` will look for a token object named `idToken` within the `TokenManager`. If you have stored the id token object in a different location, you should retrieve it first and then pass it here.
 * `clearTokensBeforeRedirect` - If `true` (default: `false`) local tokens will be removed before the logout redirect happens. Otherwise a flag (`pendingRemove`) will be added to each local token instead of clearing them immediately. Calling `oktaAuth.start()` after logout redirect will clear local tokens if flags are found. **Use this option with care**: removing local tokens before fully terminating the Okta SSO session can result in logging back in again when using [`@okta/okta-react`](https://www.npmjs.com/package/@okta/okta-react)'s [`SecureRoute`](https://github.com/okta/okta-react#secureroute) component.

--- a/lib/oidc/mixin/index.ts
+++ b/lib/oidc/mixin/index.ts
@@ -329,7 +329,7 @@ export function mixinOAuth
       if (!logoutUri) {
         // local tokens are cleared once session is closed
         const sessionClosed = await this.closeSession();   // can throw if the user cannot be signed out
-        const redirectUri = new URL(postLogoutRedirectUri || defaultUri);   // during fallback, redirectUri cannot be null
+        const redirectUri = new URL(postLogoutRedirectUri || defaultUri); // during fallback, redirectUri cannot be null
         if (state) {
           redirectUri.searchParams.append('state', state);
         }

--- a/lib/oidc/types/api.ts
+++ b/lib/oidc/types/api.ts
@@ -101,7 +101,7 @@ export interface IsAuthenticatedOptions {
 }
 
 export interface SignoutRedirectUrlOptions {
-  postLogoutRedirectUri?: string;
+  postLogoutRedirectUri?: string | null;
   idToken?: IDToken;
   state?: string;
 }


### PR DESCRIPTION
Resolves #1410 and #1433

- allows for `postLogoutRedirectUri` to be `null` to invoke default `/logout` redirect behavior
- returns `state` as query param to redirect uri when `.signOut` falls back to `.closeSession`