### PR TITLE
fix: use correct return type for `HttpRequestClient`

### DIFF
--- a/lib/http/types.ts
+++ b/lib/http/types.ts
@@ -49,8 +49,6 @@ export interface FetchResponse {
   text(): Promise<string>;
 }
 
-export type HttpRequestClient = (method: string, url: string, options: FetchOptions) => Promise<any>;
-
 export interface HttpResponse {
   responseText: string;
   status: number;
@@ -60,6 +58,8 @@ export interface HttpResponse {
   };
   headers: HeadersInit;
 }
+
+export type HttpRequestClient = (method: string, url: string, options: FetchOptions) => Promise<HttpResponse>;
 
 // HTTP API
 export interface HttpAPI {


### PR DESCRIPTION
Implementers cannot simply return anything and expect the client to work; they need to return a specific object in order for the client to work properly. This fixes the type definition for `HttpRequestClient` to reflect that requirement.