### PR TITLE
Emits error when TokenManager can't find token in renew

### DIFF
--- a/lib/oidc/TokenManager.ts
+++ b/lib/oidc/TokenManager.ts
@@ -425,8 +425,9 @@ export class TokenManager implements TokenManagerInterface {
       if (!token) {
         throw new AuthSdkError('The tokenManager has no token for the key: ' + key);
       }
-    } catch (e) {
-      return Promise.reject(e);
+    } catch (err) {
+      this.emitError(err);
+      return Promise.reject(err);
     }
   
     // Remove existing autoRenew timeout


### PR DESCRIPTION
- Adds missing emitting of error in `renew` function when `getSync` returns an undefined token