### PR TITLE
Issue 1480 fix claims validation aud array

### DIFF
--- a/lib/oidc/util/validateClaims.ts
+++ b/lib/oidc/util/validateClaims.ts
@@ -37,7 +37,7 @@ export function validateClaims(sdk: OktaAuthOAuthInterface, claims: UserClaims, 
       'does not match [' + iss + ']');
   }
 
-  if (claims.aud !== aud) {
+  if (Array.isArray(claims.aud) && claims.aud.indexOf(aud) < 0 || !Array.isArray(claims.aud) && claims.aud !== aud) {
     throw new AuthSdkError('The audience [' + claims.aud + '] ' +
       'does not match [' + aud + ']');
   }

--- a/test/spec/oidc/util/validateClaims.ts
+++ b/test/spec/oidc/util/validateClaims.ts
@@ -78,10 +78,33 @@ describe('validateClaims', function () {
     'does not match [' + validationOptions.issuer + ']'); 
   });
 
-  it('validates audience', function() {
+  it('validates audience when not an array', function() {
     var claims = {
       iss: validationOptions.issuer,
       aud: 'nobody'
+    } as unknown as UserClaims;
+    var fn = function () {
+      validateClaims(sdk, claims, validationOptions);
+    };
+    expect(fn).toThrowError('The audience [' + claims.aud + '] ' +
+      'does not match [' + validationOptions.clientId + ']'); 
+  });
+
+  it('validates audience without error when at least one matches', function() {
+    var claims = {
+      iss: validationOptions.issuer,
+      aud: ['nobody', validationOptions.clientId]
+    } as unknown as UserClaims;
+    var fn = function () {
+      validateClaims(sdk, claims, validationOptions);
+    };
+    expect(fn).not.toThrowError(); 
+  });
+
+  it('validates audience when an array', function() {
+    var claims = {
+      iss: validationOptions.issuer,
+      aud: ['nobody']
     } as unknown as UserClaims;
     var fn = function () {
       validateClaims(sdk, claims, validationOptions);


### PR DESCRIPTION
This addresses issue [#1480 ](https://github.com/okta/okta-auth-js/issues/1480) where claims validation fails when a token has an array of values in the aud claim.  Per the issue, this should be considered valid per the spec and as implemented only the special case is.

I have added unit tests verifying the behavior.  Further this change is backward compatible and does not cause anything that would currently validate to fail