### PR TITLE
Handle fetch exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - [#1488](https://github.com/okta/okta-auth-js/pull/1488) fix: type `OktaAuthOptions` now requires `issuer`
  - [#1482](https://github.com/okta/okta-auth-js/pull/1482) fix: idToken claim validation now accepts `aud` array
     * Resolves [#1481](https://github.com/okta/okta-auth-js/pull/1481)
+ - [#1487](https://github.com/okta/okta-auth-js/pull/1487) fix: Handle fetch exceptions
 
 ## 7.5.0
 

--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -56,7 +56,9 @@ const formatError = (sdk: OktaAuthHttpInterface, error: HttpResponse | Error): A
   if (error instanceof Error) {
     // fetch() can throw exceptions
     // see https://developer.mozilla.org/en-US/docs/Web/API/fetch#exceptions
-    return new OAuthError('fetch_error', error.message);
+    return new AuthApiError({
+      errorSummary: error.message,
+    });
   }
 
   let resp: HttpResponse = error;

--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -52,7 +52,14 @@ const parseInsufficientAuthenticationError = (
     }, {}) as InsufficientAuthenticationError;
 };
 
-const formatError = (sdk: OktaAuthHttpInterface, resp: HttpResponse): AuthApiError | OAuthError => {
+const formatError = (sdk: OktaAuthHttpInterface, error: HttpResponse | Error): AuthApiError | OAuthError => {
+  if (error instanceof Error) {
+    // fetch() can throw exceptions
+    // see https://developer.mozilla.org/en-US/docs/Web/API/fetch#exceptions
+    return new OAuthError('fetch_error', error.message);
+  }
+
+  let resp: HttpResponse = error;
   let err: AuthApiError | OAuthError;
   let serverErr: Record<string, any> = {};
   if (resp.responseText && isString(resp.responseText)) {

--- a/test/spec/http/request.ts
+++ b/test/spec/http/request.ts
@@ -14,7 +14,8 @@
 declare var USER_AGENT: string; // set in jest config
 
 import { httpRequest } from '../../../lib/http';
-import { 
+import {
+  OAuthError, 
   OktaAuth, 
   DEFAULT_CACHE_DURATION, 
   AuthApiError, 
@@ -244,6 +245,18 @@ describe('HTTP Requestor', () => {
     function initWithErrorResponse(response) {
       httpRequestClient = jest.fn().mockReturnValue(Promise.reject(response));
     }
+    it('can handle Error objects', () => {
+      const errMessage = 'Failed to execute \'fetch\' on \'Window\': Failed to parse URL from http://localhost:3000:1802/some_endpoint';
+      const response = new TypeError(errMessage);
+      initWithErrorResponse(response);
+      createAuthClient();
+      return httpRequest(sdk, { url })
+        .catch(err => {
+          expect(err).toBeInstanceOf(OAuthError);
+          expect(err.errorCode).toBe('fetch_error');
+          expect(err.errorSummary).toEqual(errMessage);
+        });
+    });
     it('handles string errors', () => {
       const response = { responseText: 'fake error', status: 404 };
       initWithErrorResponse(response);

--- a/test/spec/http/request.ts
+++ b/test/spec/http/request.ts
@@ -15,7 +15,6 @@ declare var USER_AGENT: string; // set in jest config
 
 import { httpRequest } from '../../../lib/http';
 import {
-  OAuthError, 
   OktaAuth, 
   DEFAULT_CACHE_DURATION, 
   AuthApiError, 
@@ -252,9 +251,9 @@ describe('HTTP Requestor', () => {
       createAuthClient();
       return httpRequest(sdk, { url })
         .catch(err => {
-          expect(err).toBeInstanceOf(OAuthError);
-          expect(err.errorCode).toBe('fetch_error');
+          expect(err).toBeInstanceOf(AuthApiError);
           expect(err.errorSummary).toEqual(errMessage);
+          expect(err.xhr).toEqual(undefined);
         });
     });
     it('handles string errors', () => {


### PR DESCRIPTION
`fetch` can throw exceptions: https://developer.mozilla.org/en-US/docs/Web/API/fetch#exceptions

[formatError](https://github.com/okta/okta-auth-js/blob/master/lib/http/request.ts#L55) currently will return `AuthApiError` with `xhr` property set to `TypeError` object.
[generateIdxAction](https://github.com/okta/okta-auth-js/blob/master/lib/idx/idxState/v1/generateIdxAction.ts#L55) will try to parse `xhr` as JSON and will trigger error `SyntaxError: "undefined" is not valid JSON`

You can reproduce with SIW playground with mock [authenticator-enroll-select-authenticator-with-skip](https://github.com/okta/okta-signin-widget/blob/master/playground/mocks/data/idp/idx/authenticator-enroll-select-authenticator-with-skip.json#L173) having incorrect url `http://localhost:3000:1802/idp/idx/cancel`. Clicking on `Back to sign in` will trigger error `SyntaxError: "undefined" is not valid JSON` instead of `OAuthError: Failed to execute 'fetch' on 'Window': Failed to parse URL from http://localhost:3000:1802/idp/idx/cancel`

Issue for SIW: OKTA-668419