### PR TITLE
fix: Allows aud to be an array when validating claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 7.5.1
+
+### Bug Fix
+
+ - [#1482](https://github.com/okta/okta-auth-js/pull/1482) fix: idToken claim validation now accepts `aud` array
+    * Resolves [#1481](https://github.com/okta/okta-auth-js/pull/1481)
+
 ## 7.5.0
 
 ### Bug Fix

--- a/lib/oidc/util/validateClaims.ts
+++ b/lib/oidc/util/validateClaims.ts
@@ -37,7 +37,9 @@ export function validateClaims(sdk: OktaAuthOAuthInterface, claims: UserClaims, 
       'does not match [' + iss + ']');
   }
 
-  if (claims.aud !== aud) {
+  if ((Array.isArray(claims.aud) && claims.aud.indexOf(aud) < 0) ||
+    (!Array.isArray(claims.aud) && claims.aud !== aud))
+  {
     throw new AuthSdkError('The audience [' + claims.aud + '] ' +
       'does not match [' + aud + ']');
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "build/cjs/exports/default.js",

--- a/test/spec/oidc/util/validateClaims.ts
+++ b/test/spec/oidc/util/validateClaims.ts
@@ -78,10 +78,33 @@ describe('validateClaims', function () {
     'does not match [' + validationOptions.issuer + ']'); 
   });
 
-  it('validates audience', function() {
+  it('validates audience when not an array', function() {
     var claims = {
       iss: validationOptions.issuer,
       aud: 'nobody'
+    } as unknown as UserClaims;
+    var fn = function () {
+      validateClaims(sdk, claims, validationOptions);
+    };
+    expect(fn).toThrowError('The audience [' + claims.aud + '] ' +
+      'does not match [' + validationOptions.clientId + ']'); 
+  });
+
+  it('validates audience without error when at least one matches', function() {
+    var claims = {
+      iss: validationOptions.issuer,
+      aud: ['nobody', validationOptions.clientId]
+    } as unknown as UserClaims;
+    var fn = function () {
+      validateClaims(sdk, claims, validationOptions);
+    };
+    expect(fn).not.toThrowError(); 
+  });
+
+  it('validates audience when an array', function() {
+    var claims = {
+      iss: validationOptions.issuer,
+      aud: ['nobody']
     } as unknown as UserClaims;
     var fn = function () {
       validateClaims(sdk, claims, validationOptions);


### PR DESCRIPTION
Per the openid spec, aud can be an array and in special cases a single string.  This fixes a bug where the array case is not handled.  This is a non breaking change.

Tests for the following scenarios:
- aud is an array but does NOT contain the clientId throws an error
- aud is an array and does contain the clientId validates with no error

Resolves: [1480](https://github.com/okta/okta-auth-js/issues/1480)