### PR TITLE
bypassExchangeCodeForTokens for PKCE where multiple clients involved

### DIFF
--- a/README.md
+++ b/README.md
@@ -1435,6 +1435,11 @@ authClient.token.getWithoutPrompt({
 });
 ```
 
+For special PKCE case where the client requesting the "authorization code" and the client owning the "code verifier" are not the same client, passing in `bypassExchangeCodeForTokens` set to true, as an attribute to the tokenParams input object will allow the first client to get the "authorization code" and the second client to exchange the code for tokens.
+
+This is accomplished by not immediately exchanging the "authorization code" for a "token" where it would normally use up the one time code, instead returning back the code to pass along to the other client. e.g: a ChatBot authentication flow, where one client (the main app), and another client (embedded ChatBot) are coordinating the PKCE Code Flow together.
+
+
 #### `token.getWithPopup(options)`
 
 > :link: web browser only <br>

--- a/lib/oidc/handleOAuthResponse.ts
+++ b/lib/oidc/handleOAuthResponse.ts
@@ -51,7 +51,7 @@ export async function handleOAuthResponse(
 
   // The result contains an authorization_code and PKCE is enabled 
   // `exchangeCodeForTokens` will call /token then call `handleOauthResponse` recursively with the result
-  if (pkce && (res.code || res.interaction_code)) {
+  if (pkce && (res.code || res.interaction_code) && !tokenParams.bypassExchangeCodeForTokens) {
     return sdk.token.exchangeCodeForTokens(Object.assign({}, tokenParams, {
       authorizationCode: res.code,
       interactionCode: res.interaction_code

--- a/lib/oidc/types/options.ts
+++ b/lib/oidc/types/options.ts
@@ -55,6 +55,7 @@ export interface TokenParams extends CustomUrls {
   extraParams?: { [propName: string]: string }; // custom authorize query params
   // TODO: remove in the next major version
   popupTitle?: string;
+  bypassExchangeCodeForTokens?: boolean;
 }
 
 export interface TokenManagerOptions {

--- a/test/spec/oidc/getWithoutPrompt.ts
+++ b/test/spec/oidc/getWithoutPrompt.ts
@@ -793,4 +793,45 @@ describe('token.getWithoutPrompt', function() {
     });
   });
 
+  it('returns no access_token using sessionToken with authorization server', function() {
+    return oauthUtil.setupFrame({
+      oktaAuthArgs: {
+        pkce: false,
+        issuer: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7',
+        clientId: 'NPSfOkH5eZrTy8PMDlvx',
+        redirectUri: 'https://example.com/redirect'
+      },
+      getWithoutPromptArgs: {
+        responseType: 'token',
+        sessionToken: 'testSessionToken',
+        bypassExchangeCodeForTokens: true
+      },
+      postMessageSrc: {
+        baseUri: 'https://auth-js-test.okta.com/oauth2/aus8aus76q8iphupD0h7/v1/authorize',
+        queryParams: {
+          'client_id': 'NPSfOkH5eZrTy8PMDlvx',
+          'redirect_uri': 'https://example.com/redirect',
+          'response_type': 'token',
+          'response_mode': 'okta_post_message',
+          'state': oauthUtil.mockedState,
+          'nonce': oauthUtil.mockedNonce,
+          'scope': 'openid email',
+          'prompt': 'none',
+          'sessionToken': 'testSessionToken'
+        }
+      },
+      time: 1449699929,
+      postMessageResp: {
+        'access_token': tokens.authServerAccessToken,
+        'token_type': 'Bearer',
+        'expires_in': 3600,
+        'state': oauthUtil.mockedState
+      },
+      expectedResp: {
+        state: oauthUtil.mockedState,
+        tokens: {
+        },
+      }
+    });
+  });
 });


### PR DESCRIPTION
For special PKCE case where the client requesting the "authorization code" and the client owning the "code verifier" are not the same client, passing in `bypassExchangeCodeForTokens` set to true, as an attribute to the tokenParams input object will allow the first client to get the "authorization code" and the second client to exchange the code for tokens.

This is accomplished by not immediately exchanging the "authorization code" for a "token" where it would normally use up the one time code, instead returning back the code to pass along to the other client. e.g: a ChatBot authentication flow, where one client (the main app), and another client (embedded ChatBot) are coordinating the PKCE Code Flow together.

<img width="984" alt="image" src="https://github.com/okta/okta-auth-js/assets/3489020/6206fb0d-533a-43e8-b13d-6945d31910dc">