### PR TITLE
Add revokeSessions for OktaPassword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 - [#1507](https://github.com/okta/okta-auth-js/pull/1507) add: new method `getOrRenewAccessToken`
+- [#1505](https://github.com/okta/okta-auth-js/pull/1505) add: support of `revokeSessions` param for `OktaPassword` authenticator (can be used in `reset-authenticator` remediation)
 
 ## 7.5.1
 

--- a/lib/idx/authenticator/Authenticator.ts
+++ b/lib/idx/authenticator/Authenticator.ts
@@ -2,7 +2,6 @@ import { IdxAuthenticator, IdxRemediationValue } from '../types/idx-js';
 
 
 export interface Credentials {
-  // except strings there can be additional options like revokeSessions
   [key: string]: string | boolean | number | undefined;
 }
 

--- a/lib/idx/authenticator/Authenticator.ts
+++ b/lib/idx/authenticator/Authenticator.ts
@@ -2,7 +2,8 @@ import { IdxAuthenticator, IdxRemediationValue } from '../types/idx-js';
 
 
 export interface Credentials {
-  [key: string]: string | undefined;
+  // except strings there can be additional options like revokeSessions
+  [key: string]: string | boolean | number | undefined;
 }
 
 export abstract class Authenticator<Values> {

--- a/lib/idx/authenticator/OktaPassword.ts
+++ b/lib/idx/authenticator/OktaPassword.ts
@@ -4,6 +4,7 @@ export interface OktaPasswordInputValues {
   password?: string;
   passcode?: string;
   credentials?: Credentials;
+  revokeSessions?: boolean;
 }
 
 export class OktaPassword extends Authenticator<OktaPasswordInputValues> {
@@ -12,19 +13,22 @@ export class OktaPassword extends Authenticator<OktaPasswordInputValues> {
   }
 
   mapCredentials(values: OktaPasswordInputValues): Credentials | undefined {
-    const { credentials, password, passcode } = values;
+    const { credentials, password, passcode, revokeSessions } = values;
     if (!credentials && !password && !passcode) {
       return;
     }
-    return credentials || { passcode: passcode || password };
+    return credentials || {
+      passcode: passcode || password,
+      revokeSessions,
+    };
   }
 
   getInputs(idxRemediationValue) {
-    return {
+    return [{
       ...idxRemediationValue.form?.value[0],
       name: 'password',
       type: 'string',
-      required: idxRemediationValue.required
-    };
+      required: idxRemediationValue.required,
+    }];
   }
 }

--- a/lib/idx/authenticator/OktaPassword.ts
+++ b/lib/idx/authenticator/OktaPassword.ts
@@ -4,6 +4,7 @@ export interface OktaPasswordInputValues {
   password?: string;
   passcode?: string;
   credentials?: Credentials;
+  // for ResetAuthenticator
   revokeSessions?: boolean;
 }
 
@@ -24,11 +25,23 @@ export class OktaPassword extends Authenticator<OktaPasswordInputValues> {
   }
 
   getInputs(idxRemediationValue) {
-    return [{
+    const inputs = [{
       ...idxRemediationValue.form?.value[0],
       name: 'password',
       type: 'string',
       required: idxRemediationValue.required,
     }];
+    const revokeSessions = idxRemediationValue.form?.value.find(
+      input => input.name === 'revokeSessions'
+    );
+    if (revokeSessions) {
+      inputs.push({
+        name: 'revokeSessions',
+        type: 'boolean',
+        label: 'Sign me out of all other devices',
+        required: false,
+      });
+    }
+    return inputs;
   }
 }

--- a/samples/test/features/basic-auth.feature
+++ b/samples/test/features/basic-auth.feature
@@ -29,7 +29,7 @@ Feature: Direct Auth Basic Login with Password Factor
       When she fills in an incorrect "username" with value "Mory"
         And she fills in her "password"
         And she submits the form
-      Then she should see a message on the Login form "Authentication failed"
+      Then she should see a message on the Login form "There is no account with the Username Mory."
 
     Scenario: Mary doesn't know her password
       Given she has an account with "active" state in the org

--- a/samples/test/features/basic-auth.feature
+++ b/samples/test/features/basic-auth.feature
@@ -29,7 +29,7 @@ Feature: Direct Auth Basic Login with Password Factor
       When she fills in an incorrect "username" with value "Mory"
         And she fills in her "password"
         And she submits the form
-      Then she should see a message on the Login form "There is no account with the Username Mory."
+      Then she should see a message on the Login form "Authentication failed"
 
     Scenario: Mary doesn't know her password
       Given she has an account with "active" state in the org

--- a/test/spec/idx/recoverPassword.ts
+++ b/test/spec/idx/recoverPassword.ts
@@ -328,9 +328,15 @@ describe('idx/recoverPassword', () => {
 
       // Sixth call, submit new password
       jest.spyOn(resetAuthenticatorResponse, 'proceed');
-      res = await recoverPassword(authClient, { password: 'fake_password' });
+      res = await recoverPassword(authClient, {
+        password: 'fake_password',
+        revokeSessions: true,
+      });
       expect(resetAuthenticatorResponse.proceed).toHaveBeenCalledWith('reset-authenticator', { 
-        credentials: { passcode: 'fake_password' }
+        credentials: {
+          passcode: 'fake_password',
+          revokeSessions: true,
+        }
       });
       expect(authClient.token.exchangeCodeForTokens).toHaveBeenCalled();
     });


### PR DESCRIPTION
Adds `revokeSessions` input value for `OktaPassword` authenticator.
Should be mapped to `credentials.revokeSessions` in IDX API request.
`revokeSessions` is an optional parameter used for `ResetAuthenticator` remediator.

Fixes issue https://github.com/okta/okta-auth-js/issues/1453

Internal ref: https://oktainc.atlassian.net/browse/OKTA-645241