### PR TITLE
Pass extraParams to token request URL

### DIFF
--- a/lib/oidc/endpoints/token.ts
+++ b/lib/oidc/endpoints/token.ts
@@ -72,7 +72,11 @@ function getPostData(sdk, options: TokenParams): string {
 }
 
 /* eslint complexity: [2, 10] */
-async function makeTokenRequest (sdk, { url, data, nonce, dpopKeyPair }: TokenRequestParams): Promise<OAuthResponse> {
+async function makeTokenRequest(
+  sdk,
+  options: TokenEndpointParams,
+  { url, data, nonce, dpopKeyPair }: TokenRequestParams
+): Promise<OAuthResponse> {
   const method = 'POST';
   const headers: any = {
     'Content-Type': 'application/x-www-form-urlencoded',
@@ -88,8 +92,9 @@ async function makeTokenRequest (sdk, { url, data, nonce, dpopKeyPair }: TokenRe
   }
 
   try {
+    const requestUrl = url + toQueryString(options.extraParams || '');
     const resp = await httpRequest(sdk, {
-      url,
+      url: requestUrl,
       method,
       args: data,
       headers
@@ -106,7 +111,7 @@ async function makeTokenRequest (sdk, { url, data, nonce, dpopKeyPair }: TokenRe
           err.resp ?? undefined    // yay ts
         );
       }
-      return makeTokenRequest(sdk, { url, data, dpopKeyPair, nonce: dpopNonce });
+      return makeTokenRequest(sdk, options, { url, data, dpopKeyPair, nonce: dpopNonce });
     }
     throw err;
   }
@@ -123,7 +128,7 @@ export async function postToTokenEndpoint(sdk, options: TokenEndpointParams, url
     dpopKeyPair: options?.dpopKeyPair
   };
 
-  return makeTokenRequest(sdk, params);
+  return makeTokenRequest(sdk, options, params);
 }
 
 export async function postRefreshToken(
@@ -147,5 +152,5 @@ export async function postRefreshToken(
     dpopKeyPair: options?.dpopKeyPair
   };
 
-  return makeTokenRequest(sdk, params);
+  return makeTokenRequest(sdk, options, params);
 }

--- a/lib/oidc/endpoints/token.ts
+++ b/lib/oidc/endpoints/token.ts
@@ -71,7 +71,7 @@ function getPostData(sdk, options: TokenParams): string {
   return toQueryString(params).slice(1);
 }
 
-/* eslint complexity: [2, 10] */
+/* eslint complexity: [2, 11] */
 async function makeTokenRequest(
   sdk,
   options: TokenEndpointParams,
@@ -92,9 +92,19 @@ async function makeTokenRequest(
   }
 
   try {
-    const requestUrl = url + toQueryString(options.extraParams || '');
+    // URL API has been added to the polyfill
+    // eslint-disable-next-line compat/compat
+    const requestUrl = new URL(url);
+    const { extraParams } = options;
+
+    for (const [key, value] of Object.entries(extraParams ?? {})) {
+      if (!requestUrl.searchParams.has(key)) {
+        requestUrl.searchParams.append(key, value);
+      }
+    }
+
     const resp = await httpRequest(sdk, {
-      url: requestUrl,
+      url: requestUrl.toString(),
       method,
       args: data,
       headers


### PR DESCRIPTION
We have come across an issue where `extraParams` are not passed to the token URL. 
```
await oktaAuth.token.renewTokens({ extraParams: { organizationId: 'test' } });
```
When using the above code the extraParams are not being used but we expect them to do so. The typings are correct this way.

In this PR the `extraParams` will be added to the token URL as query parameters.

An explanation why this would be useful (https://github.com/okta/okta-auth-js/issues/1524#issuecomment-2225705931):
> Our account model is based on organizations. A user can be part of multiple organizations, but claims are dependent of the organization that the token is requested for.
>
>To do this, a token inline hook is configured in the Okta access policy, which is a piece of custom code that reads the organizationId from extraParams and fetches the permissions and settings (from a database) for that user-organization combination. It then applies these to the token so that the JWT will contain the specific claims.
>
> Users in our web app can select the organization they work for from a menu. Then, we signInWithRedirect for that organization and this all works fine. But when we auto-renew the tokens, the extraParams are lost.

See this PR for some more information about the use case: https://github.com/okta/okta-auth-js/issues/1524

Please let me know what you think! 😄 