### PR TITLE
Detect origin for urls of different forms

### DIFF
--- a/lib/http/mixin.ts
+++ b/lib/http/mixin.ts
@@ -42,7 +42,7 @@ export function mixinHttp
     getIssuerOrigin(): string {
       // Infer the URL from the issuer URL, omitting the /oauth2/{authServerId}
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      return this.options.issuer!.split('/oauth2/')[0];
+      return this.options.issuer!.split('/').slice(0, 3).join('/');
     }
   
     webfinger(opts): Promise<object> {


### PR DESCRIPTION
Currently, origin is detected by taking the part of URL prior to `/oauth2/` and for URLs like this
```
https://www.domain.com/oauth2/{some-client-id}
```
It works as expected. However, when the service that uses OKTA API is behind a multi-tenant proxy and URL will be like

```
https://www.domain.com/{lang}/{tenant-id}/oauth2/{some-client-id}
```
It doesn't work. There is an option to do the same thing using  `(new URL('...')).origin` but that will require to add another polyfill for IE11. This one uses `Array.prototype.split` which is available in IE11 and requires no polyfill.