### PR TITLE
fix: Removes unnecessary await

### DIFF
--- a/lib/core/mixin.ts
+++ b/lib/core/mixin.ts
@@ -68,7 +68,7 @@ export function mixinCore
       } else if (this.isLoginRedirect()) {
         try {
           // For redirect flow, get state from the URL and use it to retrieve the originalUri
-          const oAuthResponse = await parseOAuthResponseFromUrl(this, {});
+          const oAuthResponse = parseOAuthResponseFromUrl(this, {});
           state = oAuthResponse.state;
           originalUri = originalUri || this.getOriginalUri(state);
           await this.storeTokensFromRedirect();


### PR DESCRIPTION
Function parseOAuthResponseFromUrl is not async, so it doesn't need to be awaited.

