### PR TITLE
Remove `isSafari18`. Added `pollDelay` SDK option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 7.11.0
+
+### Features
+
+- [#1571](https://github.com/okta/okta-auth-js/pull/1571) add: `enablePollDelay` option for `OktaAuth` contructor to fix polling issue in Mobile Safari 17.x and 18.x
+
 # 7.10.1
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- [#1571](https://github.com/okta/okta-auth-js/pull/1571) add: `enablePollDelay` option for `OktaAuth` contructor to fix polling issue in Mobile Safari 17.x and 18.x
+- [#1571](https://github.com/okta/okta-auth-js/pull/1571) add: `pollDelay` option for `OktaAuth` contructor to fix polling issue in Mobile Safari 17.x and 18.x
 
 # 7.10.1
 

--- a/lib/authn/util/poll.ts
+++ b/lib/authn/util/poll.ts
@@ -18,7 +18,6 @@ import AuthSdkError from '../../errors/AuthSdkError';
 import AuthPollStopError from '../../errors/AuthPollStopError';
 import { AuthnTransactionState } from '../types';
 import { getStateToken } from './stateToken';
-import { isBrowser } from '../../features';
 
 interface PollOptions {
   delay?: number;
@@ -84,48 +83,6 @@ export function getPollFn(sdk, res: AuthnTransactionState, ref) {
       });
     }
 
-    const delayNextPoll = (ms) => {
-      // no need for extra logic in non-iOS environments, just continue polling
-      if (!isBrowser()) {
-        return delayFn(ms);
-      }
-
-      let timeoutId: ReturnType<typeof setTimeout>;
-      const cancelableDelay = () => {
-        return new Promise((resolve) => {
-          timeoutId = setTimeout(resolve, ms);
-        });
-      };
-
-      const delayForFocus = () => {
-        let pageVisibilityHandler;
-        return new Promise<void>((resolve) => {
-          let pageDidHide = false;
-          pageVisibilityHandler = () => {
-            if (document.hidden) {
-              clearTimeout(timeoutId);
-              pageDidHide = true;
-            }
-            else if (pageDidHide) {
-              resolve();
-            }
-          };
-
-          document.addEventListener('visibilitychange', pageVisibilityHandler);
-        })
-        .then(() => {
-          document.removeEventListener('visibilitychange', pageVisibilityHandler);
-        });
-      };
-
-      return Promise.race([
-        // this function will never resolve if the page changes to hidden because the timeout gets cleared
-        cancelableDelay(),
-        // this function won't resolve until the page becomes visible after being hidden
-        delayForFocus(),
-      ]);
-    };
-
     ref.isPolling = true;
 
     var retryCount = 0;
@@ -133,23 +90,6 @@ export function getPollFn(sdk, res: AuthnTransactionState, ref) {
       // If the poll was manually stopped during the delay
       if (!ref.isPolling) {
         return Promise.reject(new AuthPollStopError());
-      }
-
-      // don't trigger polling request if page is hidden wait until window is visible again
-      if (isBrowser() && document.hidden) {
-        let handler;
-        return new Promise<void>((resolve) => {
-          handler = () => {
-            if (!document.hidden) {
-              resolve();
-            }
-          };
-          document.addEventListener('visibilitychange', handler);
-        })
-        .then(() => {
-          document.removeEventListener('visibilitychange', handler);
-          return recursivePoll();
-        });
       }
 
       return pollFn()
@@ -170,7 +110,7 @@ export function getPollFn(sdk, res: AuthnTransactionState, ref) {
             }
 
             // Continue poll
-            return delayNextPoll(delay).then(recursivePoll);
+            return delayFn(delay).then(recursivePoll);
 
           } else {
             // Any non-waiting result, even if polling was stopped
@@ -186,7 +126,7 @@ export function getPollFn(sdk, res: AuthnTransactionState, ref) {
               retryCount <= 4) {
             var delayLength = Math.pow(2, retryCount) * 1000;
             retryCount++;
-            return delayNextPoll(delayLength)
+            return delayFn(delayLength)
               .then(recursivePoll);
           }
           throw err;

--- a/lib/authn/util/poll.ts
+++ b/lib/authn/util/poll.ts
@@ -18,7 +18,7 @@ import AuthSdkError from '../../errors/AuthSdkError';
 import AuthPollStopError from '../../errors/AuthPollStopError';
 import { AuthnTransactionState } from '../types';
 import { getStateToken } from './stateToken';
-import { isSafari18 } from '../../features';
+import { isBrowser } from '../../features';
 
 interface PollOptions {
   delay?: number;
@@ -86,7 +86,7 @@ export function getPollFn(sdk, res: AuthnTransactionState, ref) {
 
     const delayNextPoll = (ms) => {
       // no need for extra logic in non-iOS environments, just continue polling
-      if (!isSafari18()) {
+      if (!isBrowser()) {
         return delayFn(ms);
       }
 
@@ -136,7 +136,7 @@ export function getPollFn(sdk, res: AuthnTransactionState, ref) {
       }
 
       // don't trigger polling request if page is hidden wait until window is visible again
-      if (isSafari18() && document.hidden) {
+      if (isBrowser() && document.hidden) {
         let handler;
         return new Promise<void>((resolve) => {
           handler = () => {

--- a/lib/base/types.ts
+++ b/lib/base/types.ts
@@ -29,7 +29,7 @@ export interface FeaturesAPI {
   isIE11OrLess(): boolean;
   isDPoPSupported(): boolean;
   isIOS(): boolean;
-  isSafari18(): boolean;
+  isBrowser(): boolean;
 }
 
 

--- a/lib/base/types.ts
+++ b/lib/base/types.ts
@@ -29,7 +29,6 @@ export interface FeaturesAPI {
   isIE11OrLess(): boolean;
   isDPoPSupported(): boolean;
   isIOS(): boolean;
-  isBrowser(): boolean;
 }
 
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -12,7 +12,6 @@
 
 export const STATE_TOKEN_KEY_NAME = 'oktaStateToken';
 export const DEFAULT_POLLING_DELAY = 500;
-export const IOS_PAGE_AWAKEN_TIMEOUT = 500;
 export const IOS_MAX_RETRY_COUNT = 3;
 export const DEFAULT_MAX_CLOCK_SKEW = 300;
 export const DEFAULT_CACHE_DURATION = 86400;

--- a/lib/features.ts
+++ b/lib/features.ts
@@ -95,20 +95,3 @@ export function isIOS () {
     // @ts-expect-error - MSStream is not in `window` type, unsurprisingly
     (/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream);
 }
-
-const isIOSRegex = /iPad|iPhone|iPod/;
-const v18Regex = /Version\/18(\.| |$)/;
-const notSafariRegex = /EdgiOS|CriOS|Chrome/;
-
-/* eslint complexity:[0,8] */
-export function isSafari18 () {
-  if (isBrowser() && typeof navigator !== 'undefined' && typeof navigator.userAgent !== 'undefined') {
-    const isIOS = isIOSRegex.test(navigator.userAgent);
-    // Mobile Safari in desktop mode emulates Macintosh in user agent
-    const isDesktop = navigator.userAgent.includes('Macintosh');
-    const isSafari18 = navigator.userAgent.includes('Safari/') && v18Regex.test(navigator.userAgent);
-    const isOtherBrowser = notSafariRegex.test(navigator.userAgent);
-    return isSafari18 && !isOtherBrowser && (isIOS || isDesktop);
-  }
-  return false;
-}

--- a/lib/http/options.ts
+++ b/lib/http/options.ts
@@ -22,6 +22,7 @@ export function createHttpOptionsConstructor() {
     headers: object;
     httpRequestClient: HttpRequestClient;
     httpRequestInterceptors: ((request: RequestOptions) => void)[];
+    enablePollDelay: boolean;
     
     constructor(args: any) {
       super(args);
@@ -30,6 +31,7 @@ export function createHttpOptionsConstructor() {
       this.headers = args.headers;
       this.httpRequestClient = args.httpRequestClient || fetchRequest;
       this.httpRequestInterceptors = args.httpRequestInterceptors;
+      this.enablePollDelay = !!args.enablePollDelay;
     }
   };
 }

--- a/lib/http/options.ts
+++ b/lib/http/options.ts
@@ -22,7 +22,7 @@ export function createHttpOptionsConstructor() {
     headers: object;
     httpRequestClient: HttpRequestClient;
     httpRequestInterceptors: ((request: RequestOptions) => void)[];
-    enablePollDelay: boolean;
+    pollDelay: number;
     
     constructor(args: any) {
       super(args);
@@ -31,7 +31,7 @@ export function createHttpOptionsConstructor() {
       this.headers = args.headers;
       this.httpRequestClient = args.httpRequestClient || fetchRequest;
       this.httpRequestInterceptors = args.httpRequestInterceptors;
-      this.enablePollDelay = !!args.enablePollDelay;
+      this.pollDelay = args.pollDelay;
     }
   };
 }

--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -134,7 +134,7 @@ export function httpRequest(sdk: OktaAuthHttpInterface, options: RequestOptions)
       storage = storageUtil!.storage,
       httpCache = sdk.storageManager.getHttpCache(sdk.options.cookies),
       pollingIntent = options.pollingIntent,
-      pollDelay = sdk.options.pollDelay;
+      pollDelay = sdk.options.pollDelay ?? 0;
 
   if (options.cacheResponse) {
     var cacheContents = httpCache.getStorage();
@@ -165,7 +165,7 @@ export function httpRequest(sdk: OktaAuthHttpInterface, options: RequestOptions)
 
   var err, res, promise;
 
-  if (pollingIntent && isBrowser() && pollDelay) {
+  if (pollingIntent && isBrowser() && pollDelay > 0) {
     let waitForVisibleAndAwakenDocument: () => Promise<void>;
     let waitForAwakenDocument: () => Promise<void>;
     let recursiveFetch: () => Promise<HttpResponse>;
@@ -176,14 +176,14 @@ export function httpRequest(sdk: OktaAuthHttpInterface, options: RequestOptions)
     // Running fetch after short timeout fixes this issue.
     waitForAwakenDocument = () => {
       const timeSinceDocumentIsVisible = Date.now() - dateDocumentBecameVisible;
-      if (timeSinceDocumentIsVisible < pollDelay!) {
+      if (timeSinceDocumentIsVisible < pollDelay) {
         return new Promise<void>((resolve) => setTimeout(() => {
           if (!document.hidden) {
             resolve();
           } else {
             resolve(waitForVisibleAndAwakenDocument());
           }
-        }, pollDelay! - timeSinceDocumentIsVisible));
+        }, pollDelay - timeSinceDocumentIsVisible));
       } else {
         return Promise.resolve();
       }

--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -134,7 +134,8 @@ export function httpRequest(sdk: OktaAuthHttpInterface, options: RequestOptions)
       storageUtil = sdk.options.storageUtil,
       storage = storageUtil!.storage,
       httpCache = sdk.storageManager.getHttpCache(sdk.options.cookies),
-      pollingIntent = options.pollingIntent;
+      pollingIntent = options.pollingIntent,
+      enablePollDelay = sdk.options.enablePollDelay;
 
   if (options.cacheResponse) {
     var cacheContents = httpCache.getStorage();
@@ -165,7 +166,7 @@ export function httpRequest(sdk: OktaAuthHttpInterface, options: RequestOptions)
 
   var err, res, promise;
 
-  if (pollingIntent && isBrowser()) {
+  if (pollingIntent && isBrowser() && enablePollDelay) {
     let waitForVisibleAndAwakenDocument: () => Promise<void>;
     let waitForAwakenDocument: () => Promise<void>;
     let recursiveFetch: () => Promise<HttpResponse>;

--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -28,13 +28,13 @@ import {
   HttpResponse
 } from './types';
 import { AuthApiError, OAuthError, APIError, WWWAuthError } from '../errors';
-import { isSafari18 } from '../features';
+import { isBrowser } from '../features';
 
 
 // For iOS track last date when document became visible
 let dateDocumentBecameVisible = 0;
 let trackDateDocumentBecameVisible: () => void;
-if (isSafari18()) {
+if (isBrowser()) {
   dateDocumentBecameVisible = Date.now();
   trackDateDocumentBecameVisible = () => {
     if (!document.hidden) {
@@ -165,7 +165,7 @@ export function httpRequest(sdk: OktaAuthHttpInterface, options: RequestOptions)
 
   var err, res, promise;
 
-  if (pollingIntent && isSafari18()) {
+  if (pollingIntent && isBrowser()) {
     let waitForVisibleAndAwakenDocument: () => Promise<void>;
     let waitForAwakenDocument: () => Promise<void>;
     let recursiveFetch: () => Promise<HttpResponse>;

--- a/lib/http/types.ts
+++ b/lib/http/types.ts
@@ -75,7 +75,7 @@ export interface OktaAuthHttpOptions extends OktaAuthStorageOptions
   headers?: object;
   httpRequestClient?: HttpRequestClient;
   httpRequestInterceptors?: ((request: RequestOptions) => void)[];
-  enablePollDelay?: boolean;
+  pollDelay?: number;
 }
 
 // an instance of AuthJS with HTTP capabilities

--- a/lib/http/types.ts
+++ b/lib/http/types.ts
@@ -75,6 +75,7 @@ export interface OktaAuthHttpOptions extends OktaAuthStorageOptions
   headers?: object;
   httpRequestClient?: HttpRequestClient;
   httpRequestInterceptors?: ((request: RequestOptions) => void)[];
+  enablePollDelay?: boolean;
 }
 
 // an instance of AuthJS with HTTP capabilities

--- a/test/spec/OktaAuth/constructor.ts
+++ b/test/spec/OktaAuth/constructor.ts
@@ -61,7 +61,7 @@ describe('OktaAuth (constructor)', () => {
     'pkce',
     'headers',
     'devMode',
-    'enablePollDelay',
+    'pollDelay',
     'ignoreSignature',
     'ignoreLifetime',
     'storageUtil',
@@ -70,7 +70,7 @@ describe('OktaAuth (constructor)', () => {
   it('saves expected options', () => {
     const config: any = {};
     savedOptions.forEach((option) => {
-      let val: string | object | boolean = 'fake_' + option; // default "fake" value
+      let val: string | object | boolean | number = 'fake_' + option; // default "fake" value
       switch (option) { // some types are strictly enforced. These should differ from the default
         case 'issuer':
         case 'redirectUri':
@@ -109,11 +109,13 @@ describe('OktaAuth (constructor)', () => {
         case 'ignoreSignature':
         case 'ignoreLifetime':
         case 'devMode':
-        case 'enablePollDelay':
           val = true;
           break;
         case 'pkce':
           val = false;
+          break;
+        case 'pollDelay':
+          val = 500;
           break;
         case 'scopes':
           val = [val];

--- a/test/spec/OktaAuth/constructor.ts
+++ b/test/spec/OktaAuth/constructor.ts
@@ -61,6 +61,7 @@ describe('OktaAuth (constructor)', () => {
     'pkce',
     'headers',
     'devMode',
+    'enablePollDelay',
     'ignoreSignature',
     'ignoreLifetime',
     'storageUtil',
@@ -108,6 +109,7 @@ describe('OktaAuth (constructor)', () => {
         case 'ignoreSignature':
         case 'ignoreLifetime':
         case 'devMode':
+        case 'enablePollDelay':
           val = true;
           break;
         case 'pkce':

--- a/test/spec/TokenManager/browser.ts
+++ b/test/spec/TokenManager/browser.ts
@@ -21,7 +21,6 @@ const mocked = {
     isIE11OrLess: () => false,
     isLocalhost: () => false,
     isTokenVerifySupported: () => true,
-    isSafari18: () => false
   }
 };
 jest.mock('../../../lib/features', () => {

--- a/test/spec/TokenManager/expireEvents.ts
+++ b/test/spec/TokenManager/expireEvents.ts
@@ -2,6 +2,7 @@ jest.mock('../../../lib/features', () => {
   return {
     isLocalhost: () => true, // to allow configuring expireEarlySeconds
     isIE11OrLess: () => false,
+    isBrowser: () => typeof window !== 'undefined',
   };
 });
 

--- a/test/spec/TokenManager/expireEvents.ts
+++ b/test/spec/TokenManager/expireEvents.ts
@@ -2,7 +2,6 @@ jest.mock('../../../lib/features', () => {
   return {
     isLocalhost: () => true, // to allow configuring expireEarlySeconds
     isIE11OrLess: () => false,
-    isSafari18: () => false
   };
 });
 

--- a/test/spec/authn/mfa-challenge.js
+++ b/test/spec/authn/mfa-challenge.js
@@ -1552,7 +1552,7 @@ describe('MFA_CHALLENGE', function () {
     // OKTA-823470: iOS18 polling issue
     // NOTE: only run these tests in browser environments
     // eslint-disable-next-line no-extra-boolean-cast
-    (!!global.document ? describe : describe.skip)('enablePollDelay', () => {
+    (!!global.document ? describe : describe.skip)('pollDelay', () => {
       const togglePageVisibility = () => {
         document.hidden = !document.hidden;
         document.dispatchEvent(new Event('visibilitychange'));
@@ -1597,7 +1597,7 @@ describe('MFA_CHALLENGE', function () {
         const oktaAuth = new OktaAuth({
           issuer: 'https://auth-js-test.okta.com',
           httpRequestClient: context.httpSpy,
-          enablePollDelay: true
+          pollDelay: 500
         });
 
         context.transaction = oktaAuth.tx.createTransaction(mfaPush.response);

--- a/test/spec/authn/mfa-challenge.js
+++ b/test/spec/authn/mfa-challenge.js
@@ -32,7 +32,6 @@ jest.mock('lib/features', () => {
   const actual = jest.requireActual('../../../lib/features');
   return {
     ...actual,
-    isSafari18: () => false
   };
 });
 import OktaAuth from '@okta/okta-auth-js';
@@ -1579,9 +1578,6 @@ describe('MFA_CHALLENGE', function () {
             setTimeout(resolve, ms);
           });
         });
-
-        // mocks iOS environment
-        jest.spyOn(mocked.features, 'isSafari18').mockReturnValue(true);
 
         const { response: mfaPush } = await util.generateXHRPair({
           uri: 'https://auth-js-test.okta.com'

--- a/test/spec/authn/mfa-challenge.js
+++ b/test/spec/authn/mfa-challenge.js
@@ -1552,7 +1552,7 @@ describe('MFA_CHALLENGE', function () {
     // OKTA-823470: iOS18 polling issue
     // NOTE: only run these tests in browser environments
     // eslint-disable-next-line no-extra-boolean-cast
-    (!!global.document ? describe : describe.skip)('iOS18 polling', () => {
+    (!!global.document ? describe : describe.skip)('enablePollDelay', () => {
       const togglePageVisibility = () => {
         document.hidden = !document.hidden;
         document.dispatchEvent(new Event('visibilitychange'));
@@ -1596,7 +1596,8 @@ describe('MFA_CHALLENGE', function () {
 
         const oktaAuth = new OktaAuth({
           issuer: 'https://auth-js-test.okta.com',
-          httpRequestClient: context.httpSpy
+          httpRequestClient: context.httpSpy,
+          enablePollDelay: true
         });
 
         context.transaction = oktaAuth.tx.createTransaction(mfaPush.response);

--- a/test/spec/features/browser.ts
+++ b/test/spec/features/browser.ts
@@ -64,29 +64,22 @@ describe('features (browser)', function() {
     });
   });
 
-  describe('isIOS, isSafari18', () => {
+  describe('isIOS', () => {
     const iOSAgents = [
       'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/92.0.4515.90 Mobile/15E148 Safari/604.1',
       'Mozilla/5.0 (iPhone; CPU iPhone OS 14_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.1 Mobile/15E148 Safari/604.1',
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/92.0.4515.90 Mobile/15E148 Safari/604.1',
       'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1',
       'Mozilla/5.0 (iPhone; CPU iPhone OS 18_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/130.0.2849.80 Version/18.0 Mobile/15E148 Safari/604.1',
       'Mozilla/5.0 (iPhone; CPU iPhone OS 18_2_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/132.0.2957.32 Version/18.0 Mobile/15E148 Safari/604.1',
-    ];
-    const mobileSafari18Agents = [
       'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1',
       'Mozilla/5.0 (iPhone; CPU iPhone OS 18_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Teak/5.9 Version/18 Mobile/15E148 Safari/604.1',
       'Mozilla/5.0 (iPhone; CPU iPhone OS 18_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Mobile/15E148 Safari/604.1',
       'Mozilla/5.0 (iPad; CPU OS 18_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Mobile/15E148 Safari/604.1',
     ];
-    const desktopSafari18Agents = [
+    const notIOSAgents = [
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15',
-    ];
-    const notSafariAgents = [
       'Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.6778.260 Mobile Safari/537.36',
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/92.0.4515.90 Mobile/15E148 Safari/604.1',
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 18_2_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/132.0.2957.32 Version/18.0 Mobile/15E148 Safari/604.1',
     ];
 
     for (let userAgent of iOSAgents) {
@@ -95,31 +88,22 @@ describe('features (browser)', function() {
         expect(OktaAuth.features.isIOS()).toBe(true);
       });
     }
-    for (let userAgent of [...mobileSafari18Agents, ...desktopSafari18Agents]) {
+    for (let userAgent of notIOSAgents) {
       // eslint-disable-next-line  jasmine/no-spec-dupes
-      it('isSafari18() should be true for ' + userAgent, () => {
+      it('isIOS() should be false for ' + userAgent, () => {
         jest.spyOn(global.navigator, 'userAgent', 'get').mockReturnValue(userAgent);
-        expect(OktaAuth.features.isSafari18()).toBe(true);
-      });
-    }
-    for (let userAgent of notSafariAgents) {
-      // eslint-disable-next-line  jasmine/no-spec-dupes
-      it('isSafari18() should be false for ' + userAgent, () => {
-        jest.spyOn(global.navigator, 'userAgent', 'get').mockReturnValue(userAgent);
-        expect(OktaAuth.features.isSafari18()).toBe(false);
+        expect(OktaAuth.features.isIOS()).toBe(false);
       });
     }
 
     it('returns false if navigator is unavailable', () => {
       jest.spyOn(global, 'navigator', 'get').mockReturnValue(undefined as never);
       expect(OktaAuth.features.isIOS()).toBe(false);
-      expect(OktaAuth.features.isSafari18()).toBe(false);
     });
 
     it('returns false if userAgent is unavailable', () => {
       jest.spyOn(global.navigator, 'userAgent', 'get').mockReturnValue(undefined as never);
       expect(OktaAuth.features.isIOS()).toBe(false);
-      expect(OktaAuth.features.isSafari18()).toBe(false);
     });
   });
 });

--- a/test/spec/http/request.ts
+++ b/test/spec/http/request.ts
@@ -363,7 +363,7 @@ describe('HTTP Requestor', () => {
   // OKTA-823470: iOS18 polling issue
   // NOTE: only run these tests in browser environments
   // eslint-disable-next-line no-extra-boolean-cast
-  (!!global.document ? describe : describe.skip)('iOS18 polling', () => {
+  (!!global.document ? describe : describe.skip)('enablePollDelay', () => {
     beforeEach(() => {
       jest.useFakeTimers();
       jest.resetModules();
@@ -394,7 +394,7 @@ describe('HTTP Requestor', () => {
     };
 
     it('should wait for document to be visible for 500 ms before making request', async () => {
-      createAuthClient();
+      createAuthClient({enablePollDelay: true});
       expect(document.hidden).toBe(false);
 
       // Document is hidden
@@ -433,7 +433,7 @@ describe('HTTP Requestor', () => {
         .mockResolvedValueOnce({
           responseText: JSON.stringify(response1)
         });
-      createAuthClient();
+      createAuthClient({enablePollDelay: true});
       expect(document.hidden).toBe(false);
       const requestPromise = httpRequest(sdk, {
         url,
@@ -463,7 +463,7 @@ describe('HTTP Requestor', () => {
         .mockResolvedValueOnce({
           responseText: JSON.stringify(response1)
         });
-      createAuthClient();
+      createAuthClient({enablePollDelay: true});
       expect(document.hidden).toBe(false);
       let didThrow = false;
       const requestPromise = httpRequest(sdk, {

--- a/test/spec/http/request.ts
+++ b/test/spec/http/request.ts
@@ -496,7 +496,6 @@ describe('HTTP Requestor', () => {
         createAuthClient();
         expect(document.hidden).toBe(false);
   
-        togglePageVisibility();
         const requestPromise = httpRequest(sdk, {
           url,
           pollingIntent: true,

--- a/test/spec/http/request.ts
+++ b/test/spec/http/request.ts
@@ -32,10 +32,6 @@ jest.mock('../../../lib/features', () => {
   };
 });
 
-const mocked = {
-  features: require('../../../lib/features'),
-};
-
 describe('HTTP Requestor', () => {
   let sdk;
   let httpRequest = originalHttpRequest;

--- a/test/spec/http/request.ts
+++ b/test/spec/http/request.ts
@@ -29,7 +29,6 @@ jest.mock('../../../lib/features', () => {
     isIE11OrLess: () => false,
     isLocalhost: () => false,
     isHTTPS: () => false,
-    isSafari18: () => false
   };
 });
 
@@ -371,14 +370,8 @@ describe('HTTP Requestor', () => {
   (!!global.document ? describe : describe.skip)('iOS18 polling', () => {
     beforeEach(() => {
       jest.useFakeTimers();
-      // Simulate iOS and reload `request.ts` module
+      // reload `request.ts` module
       jest.resetModules();
-      jest.mock('../../../lib/features', () => {
-        return {
-          ...mocked.features,
-          isSafari18: () => true 
-        };
-      });
       const { httpRequest: reloadedHttpRequest } = jest.requireActual('../../../lib/http');
       httpRequest = reloadedHttpRequest;
     });
@@ -387,12 +380,6 @@ describe('HTTP Requestor', () => {
       jest.runOnlyPendingTimers();
       jest.useRealTimers();
       httpRequest = originalHttpRequest;
-      jest.mock('../../../lib/features', () => {
-        return {
-          ...mocked.features,
-          isSafari18: () => false 
-        };
-      });
     });
 
     const togglePageVisibility = () => {

--- a/test/spec/http/request.ts
+++ b/test/spec/http/request.ts
@@ -363,7 +363,7 @@ describe('HTTP Requestor', () => {
   // OKTA-823470: iOS18 polling issue
   // NOTE: only run these tests in browser environments
   // eslint-disable-next-line no-extra-boolean-cast
-  (!!global.document ? describe : describe.skip)('enablePollDelay', () => {
+  (!!global.document ? describe : describe.skip)('pollDelay', () => {
     beforeEach(() => {
       jest.useFakeTimers();
       jest.resetModules();
@@ -394,9 +394,9 @@ describe('HTTP Requestor', () => {
       return new Promise(resolve => setImmediate(resolve));
     };
 
-    describe('enablePollDelay = true', () => {
+    describe('pollDelay = 500', () => {
       it('should wait for document to be visible for 500 ms before making request', async () => {
-        createAuthClient({enablePollDelay: true});
+        createAuthClient({pollDelay: 500});
         expect(document.hidden).toBe(false);
   
         // Document is hidden
@@ -435,7 +435,7 @@ describe('HTTP Requestor', () => {
           .mockResolvedValueOnce({
             responseText: JSON.stringify(response1)
           });
-        createAuthClient({enablePollDelay: true});
+        createAuthClient({pollDelay: 500});
         expect(document.hidden).toBe(false);
         const requestPromise = httpRequest(sdk, {
           url,
@@ -465,7 +465,7 @@ describe('HTTP Requestor', () => {
           .mockResolvedValueOnce({
             responseText: JSON.stringify(response1)
           });
-        createAuthClient({enablePollDelay: true});
+        createAuthClient({pollDelay: 500});
         expect(document.hidden).toBe(false);
         let didThrow = false;
         const requestPromise = httpRequest(sdk, {
@@ -491,9 +491,9 @@ describe('HTTP Requestor', () => {
       });
     });
 
-    describe('enablePollDelay = false', () => {
+    describe('pollDelay = 0 (default)', () => {
       it('should NOT wait for document to be visible before making request', async () => {
-        createAuthClient({enablePollDelay: false});
+        createAuthClient();
         expect(document.hidden).toBe(false);
   
         togglePageVisibility();
@@ -522,7 +522,7 @@ describe('HTTP Requestor', () => {
           .mockResolvedValueOnce({
             responseText: JSON.stringify(response1)
           });
-        createAuthClient({enablePollDelay: false});
+        createAuthClient();
         expect(document.hidden).toBe(false);
         let didThrow = false;
         const requestPromise = httpRequest(sdk, {

--- a/test/spec/http/request.ts
+++ b/test/spec/http/request.ts
@@ -370,7 +370,6 @@ describe('HTTP Requestor', () => {
   (!!global.document ? describe : describe.skip)('iOS18 polling', () => {
     beforeEach(() => {
       jest.useFakeTimers();
-      // reload `request.ts` module
       jest.resetModules();
       const { httpRequest: reloadedHttpRequest } = jest.requireActual('../../../lib/http');
       httpRequest = reloadedHttpRequest;

--- a/test/spec/idx/IdxStorageManager.ts
+++ b/test/spec/idx/IdxStorageManager.ts
@@ -29,7 +29,6 @@ jest.mock('../../../lib/util', () => {
 jest.mock('../../../lib/features', () => {
   return {
     isBrowser: () => {},
-    isSafari18: () => false
   };
 });
 

--- a/test/spec/oidc/OAuthStorageManager.ts
+++ b/test/spec/oidc/OAuthStorageManager.ts
@@ -31,7 +31,6 @@ jest.mock('../../../lib/util', () => {
 jest.mock('../../../lib/features', () => {
   return {
     isBrowser: () => {},
-    isSafari18: () => false
   };
 });
 

--- a/test/spec/oidc/endpoints/well-known.ts
+++ b/test/spec/oidc/endpoints/well-known.ts
@@ -18,7 +18,6 @@ const mocked = {
     isBrowser: () => typeof window !== 'undefined',
     isIE11OrLess: () => false,
     isLocalhost: () => false,
-    isSafari18: () => false
   }
 };
 jest.mock('../../../../lib/features', () => {

--- a/test/spec/oidc/util/prepareEnrollAuthenticatorParams.ts
+++ b/test/spec/oidc/util/prepareEnrollAuthenticatorParams.ts
@@ -17,7 +17,6 @@ const mocked = {
     isLocalhost: () => true,
     isHTTPS: () => false,
     isPKCESupported: () => true,
-    isSafari18: () => false,
   },
 };
 jest.mock('../../../../lib/features', () => {

--- a/test/spec/oidc/util/prepareTokenParams.ts
+++ b/test/spec/oidc/util/prepareTokenParams.ts
@@ -20,7 +20,6 @@ const mocked = {
     isPKCESupported: () => true,
     hasTextEncoder: () => true,
     isDPoPSupported: () => true,
-    isSafari18: () => false,
   },
   wellKnown: {
     getWellKnown: (): Promise<unknown> => Promise.resolve()

--- a/test/types/authn.mixin.test-d.ts
+++ b/test/types/authn.mixin.test-d.ts
@@ -47,7 +47,7 @@ const OktaAuthBase = createOktaAuthBase(BaseOptions);
 // Cannot mixin on a Base interface
 expect(mixinAuthn(OktaAuthBase)).type.toRaiseError();
 
-const httpOptions: OktaAuthHttpOptions = { ...baseOptions };
+const httpOptions: OktaAuthHttpOptions = { ...baseOptions, enablePollDelay: true };
 const HttpOptions: OktaAuthOptionsConstructor<OktaAuthHttpOptions> = createHttpOptionsConstructor();
 const OktaAuthWithHttp = mixinHttp(mixinStorage(createOktaAuthBase(HttpOptions), BaseStorageManager));
 

--- a/test/types/authn.mixin.test-d.ts
+++ b/test/types/authn.mixin.test-d.ts
@@ -47,7 +47,7 @@ const OktaAuthBase = createOktaAuthBase(BaseOptions);
 // Cannot mixin on a Base interface
 expect(mixinAuthn(OktaAuthBase)).type.toRaiseError();
 
-const httpOptions: OktaAuthHttpOptions = { ...baseOptions, enablePollDelay: true };
+const httpOptions: OktaAuthHttpOptions = { ...baseOptions, pollDelay: 500 };
 const HttpOptions: OktaAuthOptionsConstructor<OktaAuthHttpOptions> = createHttpOptionsConstructor();
 const OktaAuthWithHttp = mixinHttp(mixinStorage(createOktaAuthBase(HttpOptions), BaseStorageManager));
 

--- a/test/types/config.test-d.ts
+++ b/test/types/config.test-d.ts
@@ -50,7 +50,7 @@ const config: OktaAuthOptions = {
   ignoreSignature: true,
   ignoreLifetime: true,
   maxClockSkew: 10,
-  enablePollDelay: true,
+  pollDelay: 500,
 
   storageManager: {
     token: {

--- a/test/types/config.test-d.ts
+++ b/test/types/config.test-d.ts
@@ -50,6 +50,7 @@ const config: OktaAuthOptions = {
   ignoreSignature: true,
   ignoreLifetime: true,
   maxClockSkew: 10,
+  enablePollDelay: true,
 
   storageManager: {
     token: {

--- a/test/types/idx.mixin.test-d.ts
+++ b/test/types/idx.mixin.test-d.ts
@@ -48,7 +48,7 @@ const OktaAuthBase = createOktaAuthBase(BaseOptions);
 // Cannot mixin on a Base interface
 expect(mixinIdx(OktaAuthBase)).type.toRaiseError();
 
-const oauthOptions: OktaAuthOAuthOptions = { ...baseOptions };
+const oauthOptions: OktaAuthOAuthOptions = { ...baseOptions, enablePollDelay: true };
 const OAuthOptions: OktaAuthOauthOptionsConstructor = createOAuthOptionsConstructor();
 const OAuthStorageManager: OAuthStorageManagerConstructor = createOAuthStorageManager();
 const TransactionManager: TransactionManagerConstructor = createTransactionManager();

--- a/test/types/idx.mixin.test-d.ts
+++ b/test/types/idx.mixin.test-d.ts
@@ -48,7 +48,7 @@ const OktaAuthBase = createOktaAuthBase(BaseOptions);
 // Cannot mixin on a Base interface
 expect(mixinIdx(OktaAuthBase)).type.toRaiseError();
 
-const oauthOptions: OktaAuthOAuthOptions = { ...baseOptions, enablePollDelay: true };
+const oauthOptions: OktaAuthOAuthOptions = { ...baseOptions, pollDelay: 500 };
 const OAuthOptions: OktaAuthOauthOptionsConstructor = createOAuthOptionsConstructor();
 const OAuthStorageManager: OAuthStorageManagerConstructor = createOAuthStorageManager();
 const TransactionManager: TransactionManagerConstructor = createTransactionManager();

--- a/test/types/mixin.test-d.ts
+++ b/test/types/mixin.test-d.ts
@@ -56,7 +56,7 @@ expect<FeaturesAPI>().type.toBeAssignable(baseClient.features);
 
 expect(mixinIdx(OktaAuthBase)).type.toRaiseError();
 
-const oauthOptions: OktaAuthOAuthOptions = { ...baseOptions, enablePollDelay: true };
+const oauthOptions: OktaAuthOAuthOptions = { ...baseOptions, pollDelay: 500 };
 const OAuthOptions: OktaAuthOauthOptionsConstructor = createOAuthOptionsConstructor();
 const OAuthStorageManager: OAuthStorageManagerConstructor = createOAuthStorageManager();
 const TransactionManager: TransactionManagerConstructor = createTransactionManager();

--- a/test/types/mixin.test-d.ts
+++ b/test/types/mixin.test-d.ts
@@ -56,7 +56,7 @@ expect<FeaturesAPI>().type.toBeAssignable(baseClient.features);
 
 expect(mixinIdx(OktaAuthBase)).type.toRaiseError();
 
-const oauthOptions: OktaAuthOAuthOptions = { ...baseOptions };
+const oauthOptions: OktaAuthOAuthOptions = { ...baseOptions, enablePollDelay: true };
 const OAuthOptions: OktaAuthOauthOptionsConstructor = createOAuthOptionsConstructor();
 const OAuthStorageManager: OAuthStorageManagerConstructor = createOAuthStorageManager();
 const TransactionManager: TransactionManagerConstructor = createTransactionManager();


### PR DESCRIPTION
- Remove util `isSafari18` introduced in https://github.com/okta/okta-auth-js/pull/1552 and https://github.com/okta/okta-auth-js/pull/1562
- Add SDK option `pollDelay` to enable polling fix logic (recommended value: 500)

Issue: https://oktainc.atlassian.net/browse/OKTA-865184