### PR TITLE
feat: adds `rpId` to credentials to add support for custom relying party id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# 7.14.0
+
+### Features
+
+- [#1588](https://github.com/okta/okta-auth-js/pull/1588) feat: adds `rpId` to credentials to add support for custom relying party id
+
+### Fixes
+
+- backports [#1601](https://github.com/okta/okta-auth-js/pull/1601) fix: reverses broadcast-channel upgrade that raised minimum node engine requirement
+
 # 7.13.1
 
 ### Fixes

--- a/lib/idx/types/idx-js.ts
+++ b/lib/idx/types/idx-js.ts
@@ -22,11 +22,13 @@ export interface ChallengeData {
   extensions?: {
     appid: string;
   };
+  rpId?: string;
 }
 export interface ActivationData {
   challenge: string;
   rp: {
     name: string;
+    id?: string;
   };
   user: {
     id: string;

--- a/lib/idx/webauthn.ts
+++ b/lib/idx/webauthn.ts
@@ -65,7 +65,7 @@ export const buildCredentialRequestOptions = (
       challenge: base64UrlToBuffer(challengeData.challenge),
       userVerification: challengeData.userVerification,
       allowCredentials: getEnrolledCredentials(authenticatorEnrollments),
-      rpId: challengeData.rpId,
+      ...(challengeData.rpId && { rpId: challengeData.rpId }),
     }
   } as CredentialRequestOptions;
 };

--- a/lib/idx/webauthn.ts
+++ b/lib/idx/webauthn.ts
@@ -65,6 +65,7 @@ export const buildCredentialRequestOptions = (
       challenge: base64UrlToBuffer(challengeData.challenge),
       userVerification: challengeData.userVerification,
       allowCredentials: getEnrolledCredentials(authenticatorEnrollments),
+      rpId: challengeData.rpId,
     }
   } as CredentialRequestOptions;
 };

--- a/test/spec/crypto/webauthn.ts
+++ b/test/spec/crypto/webauthn.ts
@@ -102,7 +102,8 @@ describe('buildCredentialRequestOptions', () => {
   it('builds options for navigator.credentials.get', () => {
     const challengeData: ChallengeData = {
       challenge: 'G7bIvwrJJ33WCEp6GGSH',
-      userVerification: 'preferred'
+      userVerification: 'preferred',
+      rpId: 'acme.com'
     };
     const authenticatorEnrollments: IdxAuthenticator[] = [{
       id: 'AUTHENTICATOR-ID-1',
@@ -119,6 +120,7 @@ describe('buildCredentialRequestOptions', () => {
       publicKey: {
         challenge: base64UrlToBuffer('G7bIvwrJJ33WCEp6GGSH'),
         userVerification: 'preferred',
+        rpId: 'acme.com',
         allowCredentials: [{
           type: 'public-key',
           id: base64UrlToBuffer('vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt')

--- a/test/spec/idx/authenticate.ts
+++ b/test/spec/idx/authenticate.ts
@@ -2475,7 +2475,8 @@ describe('idx/authenticate', () => {
             contextualData: {
               challengeData: {
                 challenge: 'CHALLENGE',
-                userVerification: 'preferred'
+                userVerification: 'preferred',
+                rpId: 'acme.com'
               }
             }
           },

--- a/test/spec/idx/register.ts
+++ b/test/spec/idx/register.ts
@@ -2241,7 +2241,8 @@ describe('idx/register', () => {
           contextualData: {
             activationData: {
               rp: {
-                name: 'Javascript IDX SDK Test Org'
+                name: 'Javascript IDX SDK Test Org',
+                id: 'acme.com'
               },
               user: {
                 id: '000000001',
@@ -2339,7 +2340,8 @@ describe('idx/register', () => {
           contextualData: {
             activationData: {
               rp: {
-                name: 'Javascript IDX SDK Test Org'
+                name: 'Javascript IDX SDK Test Org',
+                id: 'acme.com'
               },
               user: {
                 id: '000000001',
@@ -2400,7 +2402,8 @@ describe('idx/register', () => {
           contextualData: {
             activationData: {
               rp: {
-                name: 'Javascript IDX SDK Test Org'
+                name: 'Javascript IDX SDK Test Org',
+                id: 'acme.com'
               },
               user: {
                 id: '000000001',

--- a/test/support/idx/factories/remediations.ts
+++ b/test/support/idx/factories/remediations.ts
@@ -256,7 +256,8 @@ export const VerifyWebauthnAuthenticatorRemediationFactory = ChallengeAuthentica
       contextualData: {
         challengeData: {
           challenge: 'CHALLENGE',
-          userVerification: 'preferred'
+          userVerification: 'preferred',
+          rpId: 'acme.com'
         }
       }
     })
@@ -270,7 +271,8 @@ export const EnrollWebauthnAuthenticatorRemediationFactory = EnrollAuthenticator
       contextualData: {
         activationData: {
           rp: {
-            name: 'Javascript IDX SDK Test Org'
+            name: 'Javascript IDX SDK Test Org',
+            id: 'acme.com'
           },
           user: {
             id: '000000001',


### PR DESCRIPTION
Updates the WebAuthn library to support Custom RP ID (Relying Party ID).

RP ID is a domain to which the WebAuthn enrollment is attached. It allows for creating an enrollment for a top level domain and having it work across all subdomains.