### PR TITLE
fix: Adds Cache-Control headers to JWKS endpoint requests

### DIFF
--- a/lib/oidc/endpoints/well-known.ts
+++ b/lib/oidc/endpoints/well-known.ts
@@ -47,7 +47,10 @@ export function getKey(sdk: OktaAuthOAuthInterface, issuer: string, kid: string)
 
     // Pull the latest keys if the key wasn't in the cache
     return get(sdk, jwksUri, {
-      cacheResponse: true
+      cacheResponse: true,
+      headers: {
+        'Cache-Control': 'no-cache, no-store, max-age=0'
+      }
     })
     .then(function(res) {
       var key = find(res.keys, {

--- a/test/spec/oidc/endpoints/well-known.ts
+++ b/test/spec/oidc/endpoints/well-known.ts
@@ -371,7 +371,13 @@ describe('getKey', function() {
         {
           request: {
             method: 'get',
-            uri: '/oauth2/v1/keys'
+            uri: '/oauth2/v1/keys',
+            headers: {
+              'Cache-Control': 'no-cache, no-store, max-age=0',
+              'Accept': 'application/json',
+              "Content-Type": "application/json",
+              'X-Okta-User-Agent-Extended': global['USER_AGENT'],
+            }
           },
           response: 'keys'
         }
@@ -411,7 +417,13 @@ describe('getKey', function() {
         {
           request: {
             method: 'get',
-            uri: '/oauth2/v1/keys'
+            uri: '/oauth2/v1/keys',
+            headers: {
+              'Cache-Control': 'no-cache, no-store, max-age=0',
+              'Accept': 'application/json',
+              "Content-Type": "application/json",
+              'X-Okta-User-Agent-Extended': global['USER_AGENT'],
+            }
           },
           response: 'keys'
         }
@@ -467,7 +479,13 @@ describe('getKey', function() {
         {
           request: {
             method: 'get',
-            uri: '/oauth2/v1/keys'
+            uri: '/oauth2/v1/keys',
+            headers: {
+              'Cache-Control': 'no-cache, no-store, max-age=0',
+              'Accept': 'application/json',
+              "Content-Type": "application/json",
+              'X-Okta-User-Agent-Extended': global['USER_AGENT'],
+            }
           },
           response: 'keys'
         }


### PR DESCRIPTION
## Description  
This PR adds `Cache-Control` headers to JWKS endpoint requests to ensure fresh keys are always fetched from the authorization server instead of potentially stale cached versions from HTTP-level caches (e.g., browser cache, proxies, CDNs), **while preserving application-level caching in `localStorage`**.

## What Problem Does This Solve?  
When keys are rotated at the authorization server, HTTP-level caching can cause the SDK to continue using stale keys, which may lead to token validation failures.

## Changes Made  
- Added `Cache-Control: no-cache, no-store, max-age=0` headers to JWKS endpoint requests  
- Ensured application-level caching in `localStorage` remains unaffected  
- Updated corresponding tests to match the new headers 

## Testing Done  
- Updated unit tests to verify headers are properly sent  
- Manually verified that keys are always fetched fresh from the server  

## Security Impact  
Positive: Reduces the window of vulnerability when keys are rotated by ensuring fresh keys are always used for token validation.
