### PR TITLE
remove decoding access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Breaking Changes
 
-- [#1607](https://github.com/okta/okta-auth-js/pull/1607) bumps minimum node version to 20
+- [#1607](https://github.com/okta/okta-auth-js/pull/1607) chore: bumps minimum node version to 20
+- [#1609](https://github.com/okta/okta-auth-js/pull/1609) fix: removes `claims` from `AccessToken`. ATs are no longer automatically decoded
 
 # 7.14.0
 

--- a/lib/oidc/handleOAuthResponse.ts
+++ b/lib/oidc/handleOAuthResponse.ts
@@ -96,10 +96,8 @@ export async function handleOAuthResponse(
   const now = Math.floor(Date.now()/1000);
 
   if (accessToken) {
-    // const accessJwt = sdk.token.decode(accessToken);
     tokenDict.accessToken = {
       accessToken: accessToken,
-      // claims: accessJwt.payload,
       expiresAt: Number(expiresIn) + now,
       tokenType: tokenType!,
       scopes: scopes,

--- a/lib/oidc/types/Token.ts
+++ b/lib/oidc/types/Token.ts
@@ -22,7 +22,6 @@ export interface AbstractToken {
 
 export interface AccessToken extends AbstractToken {
   accessToken: string;
-  // claims: UserClaims;
   tokenType: string;
   userinfoUrl: string;
   dpopPairId?: string;

--- a/test/spec/oidc/revokeToken.ts
+++ b/test/spec/oidc/revokeToken.ts
@@ -36,9 +36,6 @@ function setupSync(options?) {
 function createAccessToken(strValue): AccessToken {
   return {
     accessToken: strValue,
-    // claims: {
-    //   sub: ''
-    // },
     userinfoUrl: '',
     authorizeUrl: '',
     tokenType: 'accessToken',

--- a/test/support/tokens.js
+++ b/test/support/tokens.js
@@ -287,7 +287,6 @@ tokens.standardAccessTokenClaims = {
 
 tokens.standardAccessTokenParsed = {
   accessToken: tokens.standardAccessToken,
-  // claims: tokens.standardAccessTokenClaims,
   expiresAt: 1449703529, // assuming time = tokens.time
   scopes: ['openid', 'email'],
   tokenType: 'Bearer',
@@ -327,7 +326,6 @@ tokens.authServerAccessTokenClaims = {
 
 tokens.authServerAccessTokenParsed = {
   accessToken: tokens.authServerAccessToken,
-  // claims: tokens.authServerAccessTokenClaims,
   expiresAt: 1449703529, // assuming time = tokens.time
   scopes: ['openid', 'email'],
   tokenType: 'Bearer',


### PR DESCRIPTION
per spec, Access Tokens are to be treated as opaque tokens. Decoding access tokens on the client should not be encourage. This will also break when using JWEs are used