### PR TITLE
fix: properly handles webauthn transports and hints

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -5,14 +5,14 @@ test_suites:
       timeout: '60'
       script_name: publish
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
     - name: lint
       script_path: ../okta-auth-js/scripts
       sort_order: '2'
       timeout: '60'
       script_name: lint
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
       log_files:
         - build2/reports/lint/eslint-checkstyle-result.xml
 
@@ -22,14 +22,14 @@ test_suites:
       timeout: '20'
       script_name: unit
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
     - name: integration
       script_path: ../okta-auth-js/scripts
       sort_order: '3'
       timeout: '10'
       script_name: integration
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
 
     - name: e2e
       script_path: ../okta-auth-js/scripts/e2e
@@ -37,77 +37,77 @@ test_suites:
       timeout: '20'
       script_name: e2e
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
     - name: e2e-cucumber
       script_path: ../okta-auth-js/scripts/e2e
       sort_order: '4'
       timeout: '20'
       script_name: e2e-cucumber
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
     - name: e2e-mfa
       script_path: ../okta-auth-js/scripts/e2e
       sort_order: '5'
       timeout: '10'
       script_name: e2e-mfa
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
     - name: e2e-dpop
       script_path: ../okta-auth-js/scripts/e2e
       sort_order: '5'
       timeout: '10'
       script_name: e2e-dpop
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
     - name: sample-express-embedded-auth-with-sdk
       script_path: ../okta-auth-js/scripts/samples
       sort_order: '6'
       timeout: '30'
       script_name: e2e-express-embedded-auth-with-sdk
       criteria: OPTIONAL
-      queue_name: small
+      queue_name: al2023
     - name: sample-express-web-no-oidc
       script_path: ../okta-auth-js/scripts/samples
       sort_order: '7'
       timeout: '15'
       script_name: e2e-express-web-no-oidc
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
     - name: sample-express-web-with-oidc
       script_path: ../okta-auth-js/scripts/samples
       sort_order: '8'
       timeout: '15'
       script_name: e2e-express-web-with-oidc
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
     - name: sample-static-spa
       script_path: ../okta-auth-js/scripts/samples
       sort_order: '9'
       timeout: '15'
       script_name: e2e-static-spa
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
     - name: sample-webpack-spa
       script_path: ../okta-auth-js/scripts/samples
       sort_order: '10'
       timeout: '15'
       script_name: e2e-webpack-spa
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
     - name: sample-express-embedded-sign-in-widget
       script_path: ../okta-auth-js/scripts/samples
       sort_order: '11'
       timeout: '15'
       script_name: e2e-express-embedded-sign-in-widget
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
     - name: sample-react-embedded-auth-with-sdk
       script_path: ../okta-auth-js/scripts/samples
       sort_order: '12'
       timeout: '20'
       script_name: e2e-react-embedded-auth-with-sdk
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
 
     - name: verify-registry-install
       prereq_test_suite_name: publish
@@ -116,7 +116,7 @@ test_suites:
       timeout: '20'
       script_name: verify-registry-install
       criteria: MERGE
-      queue_name: small
+      queue_name: al2023
     # Sauce labs tests are flaky due to the free account we are currently using
     # Re-enable this task on bacon once we have an paid account
     # - name: e2e-saucelabs 
@@ -125,4 +125,4 @@ test_suites:
     #   timeout: '60'
     #   script_name: e2e-saucelabs
     #   criteria: MERGE
-    #   queue_name: small
+    #   queue_name: al2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 7.14.2
+
+- [#1629](https://github.com/okta/okta-auth-js/pull/1629) fix: properly handles WebAuthn hints and transports
+
 # 7.14.1
 
 - [#1611](https://github.com/okta/okta-auth-js/pull/1611) fix: improves regex for parsing Authorization Code Flow redirect urls

--- a/lib/idx/authenticator/WebauthnEnrollment.ts
+++ b/lib/idx/authenticator/WebauthnEnrollment.ts
@@ -1,9 +1,11 @@
 import { Authenticator, Credentials } from './Authenticator';
 
 export interface WebauthnEnrollValues {
+  id?: string;
   clientData?: string;
   attestation?: string;
   credentials?: Credentials;
+  transports?: string;
 }
 
 export class WebauthnEnrollment extends Authenticator<WebauthnEnrollValues> {
@@ -15,13 +17,14 @@ export class WebauthnEnrollment extends Authenticator<WebauthnEnrollValues> {
   }
 
   mapCredentials(values: WebauthnEnrollValues): Credentials | undefined {
-    const { credentials, clientData, attestation } = values;
+    const { credentials, clientData, attestation, transports } = values;
     if (!credentials && !clientData && !attestation) {
       return;
     }
     return credentials || ({
       clientData,
-      attestation
+      attestation,
+      ...(transports && { transports }),
     });
   }
 

--- a/lib/idx/authenticator/WebauthnVerification.ts
+++ b/lib/idx/authenticator/WebauthnVerification.ts
@@ -1,6 +1,7 @@
 import { Authenticator, Credentials } from './Authenticator';
 
 export interface WebauthnVerificationValues {
+  id?: string;
   clientData?: string;
   authenticatorData?: string;
   signatureData?: string;

--- a/lib/idx/types/idx-js.ts
+++ b/lib/idx/types/idx-js.ts
@@ -23,6 +23,7 @@ export interface ChallengeData {
     appid: string;
   };
   rpId?: string;
+  hints?: string[];
 }
 export interface ActivationData {
   challenge: string;
@@ -50,6 +51,7 @@ export interface ActivationData {
     id: string;
     type: string;
   }[];
+  hints?: string[];
 }
 export interface IdxAuthenticatorMethod {
   type: string;
@@ -85,6 +87,7 @@ export interface IdxAuthenticator {
     challengeData?: ChallengeData;
   };
   credentialId?: string;
+  transports?: string[];
   enrollmentId?: string;
   profile?: Record<string, unknown>;
   resend?: Record<string, unknown>;

--- a/lib/idx/webauthn.ts
+++ b/lib/idx/webauthn.ts
@@ -15,6 +15,8 @@ import {
   ActivationData,
   ChallengeData,
   IdxAuthenticator,
+  WebauthnEnrollValues,
+  WebauthnVerificationValues,
 } from './types';
 
 
@@ -23,10 +25,17 @@ const getEnrolledCredentials = (authenticatorEnrollments: IdxAuthenticator[] = [
   const credentials: PublicKeyCredentialDescriptor[] = [];
   authenticatorEnrollments.forEach((enrollement) => {
     if (enrollement.key === 'webauthn') {
-      credentials.push({
+      const credential: PublicKeyCredentialDescriptor = {
         type: 'public-key',
         id: base64UrlToBuffer(enrollement.credentialId),
-      });
+      };
+      // transports may be at top-level or nested under profile
+      const transports = enrollement.transports
+        ?? (enrollement.profile as Record<string, unknown> | undefined)?.transports;
+      if (Array.isArray(transports)) {
+        credential.transports = transports as AuthenticatorTransport[];
+      }
+      credentials.push(credential);
     }
   });
   return credentials;
@@ -50,6 +59,7 @@ export const buildCredentialCreationOptions = (
       attestation: activationData.attestation,
       authenticatorSelection: activationData.authenticatorSelection,
       excludeCredentials: getEnrolledCredentials(authenticatorEnrollments),
+      ...(activationData.hints && { hints: activationData.hints }),
     }
   } as CredentialCreationOptions;
 };
@@ -66,27 +76,34 @@ export const buildCredentialRequestOptions = (
       userVerification: challengeData.userVerification,
       allowCredentials: getEnrolledCredentials(authenticatorEnrollments),
       ...(challengeData.rpId && { rpId: challengeData.rpId }),
+      ...(challengeData.hints && { hints: challengeData.hints }),
     }
   } as CredentialRequestOptions;
 };
 
 // Build attestation for webauthn enroll
 // https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse
-export const getAttestation = (credential: PublicKeyCredential) => {
+export const getAttestation = (credential: PublicKeyCredential): WebauthnEnrollValues => {
   const response = credential.response as AuthenticatorAttestationResponse;
   const id = credential.id;
   const clientData = bufferToBase64Url(response.clientDataJSON);
   const attestation = bufferToBase64Url(response.attestationObject);
-  return {
+  // getTransports() is a newer WebAuthn API not yet in all TS type definitions
+  const getTransportsFn = (response as any).getTransports;
+  const result: WebauthnEnrollValues = {
     id,
     clientData,
-    attestation
+    attestation,
   };
+  if (typeof getTransportsFn === 'function') {
+    result.transports = JSON.stringify(getTransportsFn.call(response));
+  }
+  return result;
 };
 
 // Build assertion for webauthn verification
 // https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAssertionResponse
-export const getAssertion = (credential: PublicKeyCredential) => {
+export const getAssertion = (credential: PublicKeyCredential): WebauthnVerificationValues => {
   const response = credential.response as AuthenticatorAssertionResponse;
   const id = credential.id;
   const clientData = bufferToBase64Url(response.clientDataJSON);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "7.14.1",
+  "version": "7.14.2",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "build/cjs/exports/default.js",

--- a/test/spec/crypto/webauthn.ts
+++ b/test/spec/crypto/webauthn.ts
@@ -96,6 +96,77 @@ describe('buildCredentialCreationOptions', () => {
       }
     });
   });
+
+  it('includes hints when present in activationData', () => {
+    const activationData: ActivationData = {
+      rp: { name: 'Test Org' },
+      user: { id: '00u123', name: 'user@test.com', displayName: 'User' },
+      pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      challenge: 'G7bIvwrJJ33WCEp6GGSH',
+      hints: ['security-key'],
+    };
+    const options = buildCredentialCreationOptions(activationData, []);
+    expect((options.publicKey as any).hints).toEqual(['security-key']);
+  });
+
+  it('does not include hints when not present in activationData', () => {
+    const activationData: ActivationData = {
+      rp: { name: 'Test Org' },
+      user: { id: '00u123', name: 'user@test.com', displayName: 'User' },
+      pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      challenge: 'G7bIvwrJJ33WCEp6GGSH',
+    };
+    const options = buildCredentialCreationOptions(activationData, []);
+    expect((options.publicKey as any).hints).toBeUndefined();
+  });
+
+  it('includes transports in excludeCredentials when present on enrollments', () => {
+    const activationData: ActivationData = {
+      rp: { name: 'Test Org' },
+      user: { id: '00u123', name: 'user@test.com', displayName: 'User' },
+      pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      challenge: 'G7bIvwrJJ33WCEp6GGSH',
+    };
+    const authenticatorEnrollments: IdxAuthenticator[] = [{
+      id: 'AUTHENTICATOR-ID-1',
+      displayName: 'MacBook Touch ID',
+      key: 'webauthn',
+      type: 'security_key',
+      methods: [{ type: 'webauthn' }],
+      credentialId: 'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt',
+      transports: ['internal'],
+    }];
+    const options = buildCredentialCreationOptions(activationData, authenticatorEnrollments);
+    expect(options.publicKey!.excludeCredentials).toEqual([{
+      type: 'public-key',
+      id: base64UrlToBuffer('vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt'),
+      transports: ['internal'],
+    }]);
+  });
+
+  it('includes transports from profile in excludeCredentials when not at top-level', () => {
+    const activationData: ActivationData = {
+      rp: { name: 'Test Org' },
+      user: { id: '00u123', name: 'user@test.com', displayName: 'User' },
+      pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      challenge: 'G7bIvwrJJ33WCEp6GGSH',
+    };
+    const authenticatorEnrollments: IdxAuthenticator[] = [{
+      id: 'AUTHENTICATOR-ID-1',
+      displayName: 'MacBook Touch ID',
+      key: 'webauthn',
+      type: 'security_key',
+      methods: [{ type: 'webauthn' }],
+      credentialId: 'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt',
+      profile: { transports: ['usb'] },
+    }];
+    const options = buildCredentialCreationOptions(activationData, authenticatorEnrollments);
+    expect(options.publicKey!.excludeCredentials).toEqual([{
+      type: 'public-key',
+      id: base64UrlToBuffer('vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt'),
+      transports: ['usb'],
+    }]);
+  });
 });
 
 describe('buildCredentialRequestOptions', () => {
@@ -128,6 +199,69 @@ describe('buildCredentialRequestOptions', () => {
       }
     });
   });
+
+  it('includes transports in allowCredentials when present on enrollments', () => {
+    const challengeData: ChallengeData = {
+      challenge: 'G7bIvwrJJ33WCEp6GGSH',
+      userVerification: 'preferred',
+    };
+    const authenticatorEnrollments: IdxAuthenticator[] = [{
+      id: 'AUTHENTICATOR-ID-1',
+      displayName: 'MacBook Touch ID',
+      key: 'webauthn',
+      type: 'security_key',
+      methods: [{ type: 'webauthn' }],
+      credentialId: 'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt',
+      transports: ['internal'],
+    }];
+    const options = buildCredentialRequestOptions(challengeData, authenticatorEnrollments);
+    expect(options.publicKey!.allowCredentials).toEqual([{
+      type: 'public-key',
+      id: base64UrlToBuffer('vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt'),
+      transports: ['internal'],
+    }]);
+  });
+
+  it('includes transports from profile when not at top-level', () => {
+    const challengeData: ChallengeData = {
+      challenge: 'G7bIvwrJJ33WCEp6GGSH',
+      userVerification: 'preferred',
+    };
+    const authenticatorEnrollments: IdxAuthenticator[] = [{
+      id: 'AUTHENTICATOR-ID-1',
+      displayName: 'MacBook Touch ID',
+      key: 'webauthn',
+      type: 'security_key',
+      methods: [{ type: 'webauthn' }],
+      credentialId: 'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt',
+      profile: { transports: ['usb'] },
+    }];
+    const options = buildCredentialRequestOptions(challengeData, authenticatorEnrollments);
+    expect(options.publicKey!.allowCredentials).toEqual([{
+      type: 'public-key',
+      id: base64UrlToBuffer('vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt'),
+      transports: ['usb'],
+    }]);
+  });
+
+  it('includes hints when present in challengeData', () => {
+    const challengeData: ChallengeData = {
+      challenge: 'G7bIvwrJJ33WCEp6GGSH',
+      userVerification: 'preferred',
+      hints: ['client-device'],
+    };
+    const options = buildCredentialRequestOptions(challengeData, []);
+    expect((options.publicKey as any).hints).toEqual(['client-device']);
+  });
+
+  it('does not include hints when not present in challengeData', () => {
+    const challengeData: ChallengeData = {
+      challenge: 'G7bIvwrJJ33WCEp6GGSH',
+      userVerification: 'preferred',
+    };
+    const options = buildCredentialRequestOptions(challengeData, []);
+    expect((options.publicKey as any).hints).toBeUndefined();
+  });
 });
 
 describe('getAttestation', () => {
@@ -135,7 +269,29 @@ describe('getAttestation', () => {
     const response = {
       clientDataJSON: stringToBuffer('{}'),
       attestationObject: stringToBuffer('{}'),
-    } as AuthenticatorResponse;
+      getTransports: () => ['usb', 'nfc'] as AuthenticatorTransport[],
+    } as AuthenticatorAttestationResponse;
+    const credential = {
+      rawId: base64UrlToBuffer('CRED-ID'),
+      id: 'CRED-ID',
+      type: 'public-key',
+      response,
+      getClientExtensionResults: () => ({} as AuthenticationExtensionsClientOutputs)
+    };
+    const attestation = getAttestation(credential as PublicKeyCredential);
+    expect(attestation).toEqual({
+      id: 'CRED-ID',
+      clientData: btoa('{}'),
+      attestation: btoa('{}'),
+      transports: '["usb","nfc"]',
+    });
+  });
+
+  it('omits transports when getTransports is not supported', () => {
+    const response = {
+      clientDataJSON: stringToBuffer('{}'),
+      attestationObject: stringToBuffer('{}'),
+    } as AuthenticatorAttestationResponse;
     const credential = {
       rawId: base64UrlToBuffer('CRED-ID'),
       id: 'CRED-ID',
@@ -149,6 +305,7 @@ describe('getAttestation', () => {
       clientData: btoa('{}'),
       attestation: btoa('{}'),
     });
+    expect(attestation).not.toHaveProperty('transports');
   });
 });
 

--- a/test/spec/idx/authenticator/WebauthnEnrollment.ts
+++ b/test/spec/idx/authenticator/WebauthnEnrollment.ts
@@ -54,6 +54,19 @@ describe('idx/authenticator/WebauthnEnrollment', () => {
         clientData: 'foo'
       });
     });
+    it('includes transports when provided', () => {
+      const { authenticator } = testContext;
+      expect(authenticator.mapCredentials({ attestation: 'foo', clientData: 'foo', transports: '["internal"]' })).toEqual({
+        attestation: 'foo',
+        clientData: 'foo',
+        transports: '["internal"]',
+      });
+    });
+    it('omits transports when not provided', () => {
+      const { authenticator } = testContext;
+      const result = authenticator.mapCredentials({ attestation: 'foo', clientData: 'foo' });
+      expect(result).not.toHaveProperty('transports');
+    });
   });
 
   describe('getInputs', () => {

--- a/webpack.polyfill.config.js
+++ b/webpack.polyfill.config.js
@@ -21,8 +21,8 @@ module.exports = _.extend({}, _.cloneDeep(commonConfig), {
   ]),
   devtool: 'source-map',
   performance: {
-    maxAssetSize: 120000,
-    maxEntrypointSize: 120000,
+    maxAssetSize: 125000,
+    maxEntrypointSize: 125000,
     hints: 'error'
   }
 });


### PR DESCRIPTION
Add WebAuthn Level 3 support: transports, hints, and getTransports()

Adds support for several WebAuthn Level 3 features to improve passkey/security key compatibility:

- `transports` on credential descriptors: `allowCredentials` and `excludeCredentials` now include
  transport hints (e.g. `internal`, `usb`, `nfc`) when available on stored enrollments, both at
  top-level and nested under profile. This allows browsers to show more targeted authenticator
  prompts.

- `hints` support: `buildCredentialCreationOptions` and `buildCredentialRequestOptions` now pass
  through the hints array (e.g. `security-key`, `client-device`) from the IDX response to the
  WebAuthn API, enabling UI hints in supporting browsers.

- `getTransports()` capture on enrollment: `getAttestation()` now calls `response.getTransports()`
  (if available) and includes the result as a JSON-stringified transports field in the returned
  values. This is forwarded through `mapCredentials` so the server can store transport information
  for future authentication calls.

- Return type annotations on `getAttestation()` and `getAssertion()`.

- Polyfill bundle size limit bumped from `120 KB` to `125 KB` to accommodate the slightly larger
  output (actual size: `118 KiB`).

Tests added for all new behavior.

Video
---
Authentication:

https://github.com/user-attachments/assets/f016c662-650d-4f19-83ab-5a123d29fafb



Enrollment:

https://github.com/user-attachments/assets/366299f6-70b5-43be-bfff-451523b15e45


