### PR TITLE
fix: validate state parameter before PKCE code exchange

### DIFF
--- a/lib/oidc/handleOAuthResponse.ts
+++ b/lib/oidc/handleOAuthResponse.ts
@@ -49,9 +49,11 @@ export async function handleOAuthResponse(
 ): Promise<TokenResponse> {
   const pkce = sdk.options.pkce !== false;
 
-  // The result contains an authorization_code and PKCE is enabled 
+  // The result contains an authorization_code and PKCE is enabled
   // `exchangeCodeForTokens` will call /token then call `handleOauthResponse` recursively with the result
   if (pkce && (res.code || res.interaction_code)) {
+    // Validate state BEFORE exchanging code (RFC 6749 section 10.12)
+    validateResponse(res, tokenParams);
     return sdk.token.exchangeCodeForTokens(Object.assign({}, tokenParams, {
       authorizationCode: res.code,
       interactionCode: res.interaction_code


### PR DESCRIPTION
## Summary

`handleOAuthResponse()` bypasses state parameter validation during PKCE authorization code flows. When PKCE is enabled and an authorization code is present, the function returns early at lines 54-59, skipping the `validateResponse()` call at line 78 that checks `res.state !== oauthParams.state`.

This violates RFC 6749 section 10.12, which mandates state parameter validation for CSRF protection.

## Vulnerability

The PKCE code path returns before `validateResponse` runs:


// Lines 54-59: EARLY RETURN - skips validateResponse entirely
if (pkce && (res.code || res.interaction_code)) {
  return sdk.token.exchangeCodeForTokens(...);
}

// Line 78 is NEVER reached for PKCE code flow:
validateResponse(res, tokenParams);


The recursive call to `handleOAuthResponse` from `exchangeCodeForTokens` receives no `state` field, making the validation a vacuous truth (`undefined !== undefined` is `false`).

## Fix

Call `validateResponse()` before the PKCE early return:


if (pkce && (res.code || res.interaction_code)) {
  // Validate state BEFORE exchanging code (RFC 6749 section 10.12)
  validateResponse(res, tokenParams);
  return sdk.token.exchangeCodeForTokens(...);
}


Fixes #1628

## References

- RFC 6749 Section 10.12: https://datatracker.ietf.org/doc/html/rfc6749#section-10.12
- GitHub Issue #1628