### PR TITLE
OKTA-1184940 webauthn transports string fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 7.14.4
+
+- [#1638](https://github.com/okta/okta-auth-js/pull/1638) fix: handles WebAuthn transports as a comma separated string
+- [#1646](https://github.com/okta/okta-auth-js/pull/1646) fix: handles auth verification remediations in registration flow
+
 # 7.14.3
 
 - [#1635](https://github.com/okta/okta-auth-js/pull/1635) fix: guarantees `state` parameter is validated before token exchange is performed

--- a/lib/idx/webauthn.ts
+++ b/lib/idx/webauthn.ts
@@ -20,6 +20,21 @@ import {
 } from './types';
 
 
+// Coerce a transports value to an array. Accepts either an array (legacy server response)
+// or a JSON-encoded array string (current server response, where profile is Map<String, String>).
+// Returns undefined for any other shape so the caller can omit transports from the descriptor.
+const coerceTransports = (value: unknown): AuthenticatorTransport[] | undefined => {
+  let candidate = value;
+  if (typeof candidate === 'string') {
+    try {
+      candidate = JSON.parse(candidate);
+    } catch {
+      return undefined;
+    }
+  }
+  return Array.isArray(candidate) ? candidate as AuthenticatorTransport[] : undefined;
+};
+
 // Get known credentials from list of enrolled authenticators
 const getEnrolledCredentials = (authenticatorEnrollments: IdxAuthenticator[] = []) => {
   const credentials: PublicKeyCredentialDescriptor[] = [];
@@ -29,11 +44,12 @@ const getEnrolledCredentials = (authenticatorEnrollments: IdxAuthenticator[] = [
         type: 'public-key',
         id: base64UrlToBuffer(enrollement.credentialId),
       };
-      // transports may be at top-level or nested under profile
-      const transports = enrollement.transports
-        ?? (enrollement.profile as Record<string, unknown> | undefined)?.transports;
-      if (Array.isArray(transports)) {
-        credential.transports = transports as AuthenticatorTransport[];
+      // transports may be at top-level or nested under profile, and either side may
+      // arrive as an array or a JSON-encoded string depending on server version.
+      const transports = coerceTransports(enrollement.transports)
+        ?? coerceTransports((enrollement.profile as Record<string, unknown> | undefined)?.transports);
+      if (transports) {
+        credential.transports = transports;
       }
       credentials.push(credential);
     }

--- a/lib/idx/webauthn.ts
+++ b/lib/idx/webauthn.ts
@@ -21,13 +21,13 @@ import {
 
 
 // Coerce a transports value to an array. Accepts either an array (legacy server response)
-// or a JSON-encoded array string (current server response, where profile is Map<String, String>).
+// or a comma separated string (current server response, where profile is Map<String, String>).
 // Returns undefined for any other shape so the caller can omit transports from the descriptor.
 const coerceTransports = (value: unknown): AuthenticatorTransport[] | undefined => {
   let candidate = value;
   if (typeof candidate === 'string') {
     try {
-      candidate = JSON.parse(candidate);
+      candidate = candidate.split(',');
     } catch {
       return undefined;
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-auth-js",
   "description": "The Okta Auth SDK",
-  "version": "7.14.3",
+  "version": "7.14.4",
   "homepage": "https://github.com/okta/okta-auth-js",
   "license": "Apache-2.0",
   "main": "build/cjs/exports/default.js",

--- a/test/spec/crypto/webauthn.ts
+++ b/test/spec/crypto/webauthn.ts
@@ -168,7 +168,7 @@ describe('buildCredentialCreationOptions', () => {
     }]);
   });
 
-  it('parses JSON-encoded string profile.transports in excludeCredentials', () => {
+  it('parses comma separated string profile.transports in excludeCredentials', () => {
     const activationData: ActivationData = {
       rp: { name: 'Test Org' },
       user: { id: '00u123', name: 'user@test.com', displayName: 'User' },
@@ -183,7 +183,7 @@ describe('buildCredentialCreationOptions', () => {
       methods: [{ type: 'webauthn' }],
       credentialId: 'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt',
       // okta-core emits profile.transports as a JSON-encoded string so the entire profile is Map<String,String>
-      profile: { transports: '["usb","nfc"]' },
+      profile: { transports: 'usb,nfc' },
     }];
     const options = buildCredentialCreationOptions(activationData, authenticatorEnrollments);
     expect(options.publicKey!.excludeCredentials).toEqual([{
@@ -282,7 +282,7 @@ describe('buildCredentialRequestOptions', () => {
       methods: [{ type: 'webauthn' }],
       credentialId: 'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt',
       // okta-core emits profile.transports as a JSON-encoded string so the entire profile is Map<String,String>
-      profile: { transports: '["usb","nfc"]' },
+      profile: { transports: 'usb,nfc' },
     }];
     const options = buildCredentialRequestOptions(challengeData, authenticatorEnrollments);
     expect(options.publicKey!.allowCredentials).toEqual([{
@@ -304,7 +304,7 @@ describe('buildCredentialRequestOptions', () => {
       type: 'security_key',
       methods: [{ type: 'webauthn' }],
       credentialId: 'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt',
-      profile: { transports: 'not-json' },
+      profile: { transports: 123 },
     }];
     const options = buildCredentialRequestOptions(challengeData, authenticatorEnrollments);
     expect(options.publicKey!.allowCredentials).toEqual([{

--- a/test/spec/crypto/webauthn.ts
+++ b/test/spec/crypto/webauthn.ts
@@ -167,6 +167,31 @@ describe('buildCredentialCreationOptions', () => {
       transports: ['usb'],
     }]);
   });
+
+  it('parses JSON-encoded string profile.transports in excludeCredentials', () => {
+    const activationData: ActivationData = {
+      rp: { name: 'Test Org' },
+      user: { id: '00u123', name: 'user@test.com', displayName: 'User' },
+      pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      challenge: 'G7bIvwrJJ33WCEp6GGSH',
+    };
+    const authenticatorEnrollments: IdxAuthenticator[] = [{
+      id: 'AUTHENTICATOR-ID-1',
+      displayName: 'MacBook Touch ID',
+      key: 'webauthn',
+      type: 'security_key',
+      methods: [{ type: 'webauthn' }],
+      credentialId: 'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt',
+      // okta-core emits profile.transports as a JSON-encoded string so the entire profile is Map<String,String>
+      profile: { transports: '["usb","nfc"]' },
+    }];
+    const options = buildCredentialCreationOptions(activationData, authenticatorEnrollments);
+    expect(options.publicKey!.excludeCredentials).toEqual([{
+      type: 'public-key',
+      id: base64UrlToBuffer('vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt'),
+      transports: ['usb', 'nfc'],
+    }]);
+  });
 });
 
 describe('buildCredentialRequestOptions', () => {
@@ -241,6 +266,50 @@ describe('buildCredentialRequestOptions', () => {
       type: 'public-key',
       id: base64UrlToBuffer('vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt'),
       transports: ['usb'],
+    }]);
+  });
+
+  it('parses JSON-encoded string profile.transports in allowCredentials', () => {
+    const challengeData: ChallengeData = {
+      challenge: 'G7bIvwrJJ33WCEp6GGSH',
+      userVerification: 'preferred',
+    };
+    const authenticatorEnrollments: IdxAuthenticator[] = [{
+      id: 'AUTHENTICATOR-ID-1',
+      displayName: 'MacBook Touch ID',
+      key: 'webauthn',
+      type: 'security_key',
+      methods: [{ type: 'webauthn' }],
+      credentialId: 'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt',
+      // okta-core emits profile.transports as a JSON-encoded string so the entire profile is Map<String,String>
+      profile: { transports: '["usb","nfc"]' },
+    }];
+    const options = buildCredentialRequestOptions(challengeData, authenticatorEnrollments);
+    expect(options.publicKey!.allowCredentials).toEqual([{
+      type: 'public-key',
+      id: base64UrlToBuffer('vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt'),
+      transports: ['usb', 'nfc'],
+    }]);
+  });
+
+  it('omits transports when profile.transports is malformed JSON', () => {
+    const challengeData: ChallengeData = {
+      challenge: 'G7bIvwrJJ33WCEp6GGSH',
+      userVerification: 'preferred',
+    };
+    const authenticatorEnrollments: IdxAuthenticator[] = [{
+      id: 'AUTHENTICATOR-ID-1',
+      displayName: 'MacBook Touch ID',
+      key: 'webauthn',
+      type: 'security_key',
+      methods: [{ type: 'webauthn' }],
+      credentialId: 'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt',
+      profile: { transports: 'not-json' },
+    }];
+    const options = buildCredentialRequestOptions(challengeData, authenticatorEnrollments);
+    expect(options.publicKey!.allowCredentials).toEqual([{
+      type: 'public-key',
+      id: base64UrlToBuffer('vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt'),
     }]);
   });
 


### PR DESCRIPTION
- okta-core may serialize profile.transports as a comma-separated string (e.g. "usb,nfc") when the profile is represented as Map<String,String>, rather than as a JSON array.
- This PR updates the WebAuthn challenge and enroll views to handle both shapes, splitting the string into an array when needed.
- This helps the webauthn api better suggest which method to use i.e. instead of presenting several options (qr code, security key, etc.), it asks for just security key
- downstream siw build: https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&page=1&pageSize=6&sha=19835cb313f0d0487c794cf9bc74c83cba47d5ba&tab=main
- downstream monolith build: https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&author=tiffany.ng%40okta.com&branch=d16t-okta-signin-widget-19835cb-6a20ce61&page=1&pageSize=6&sha=86a95087b79e34f84a4eeb1fdc5cc70474ea2e61&tab=main

Video with the FF off:

https://github.com/user-attachments/assets/bfd8852e-0617-42fc-a5ac-8a1b04d762de


Video with the FF on:

https://github.com/user-attachments/assets/6554d65c-2974-4404-ae40-ec6ce3754f4a

