### PR TITLE
fix: handle auth verification remediations in registration flow

### DIFF
--- a/lib/idx/flow/RegistrationFlow.ts
+++ b/lib/idx/flow/RegistrationFlow.ts
@@ -12,15 +12,19 @@
 
 
 import { RemediationFlow } from './RemediationFlow';
-import { 
+import {
   SelectEnrollProfile,
   EnrollPoll,
   SelectEnrollmentChannel,
   EnrollmentChannelData,
   EnrollProfile,
   SelectAuthenticatorEnroll,
+  SelectAuthenticatorAuthenticate,
   EnrollAuthenticator,
   AuthenticatorEnrollmentData,
+  AuthenticatorVerificationData,
+  ChallengeAuthenticator,
+  ChallengePoll,
   Skip,
 } from '../remediators';
 
@@ -29,9 +33,13 @@ export const RegistrationFlow: RemediationFlow = {
   'enroll-profile': EnrollProfile,
   'authenticator-enrollment-data': AuthenticatorEnrollmentData,
   'select-authenticator-enroll': SelectAuthenticatorEnroll,
+  'select-authenticator-authenticate': SelectAuthenticatorAuthenticate,
   'enroll-poll': EnrollPoll,
   'select-enrollment-channel': SelectEnrollmentChannel,
   'enrollment-channel-data': EnrollmentChannelData,
   'enroll-authenticator': EnrollAuthenticator,
+  'authenticator-verification-data': AuthenticatorVerificationData,
+  'challenge-authenticator': ChallengeAuthenticator,
+  'challenge-poll': ChallengePoll,
   'skip': Skip,
 };

--- a/test/spec/idx/register.ts
+++ b/test/spec/idx/register.ts
@@ -57,7 +57,10 @@ import {
   WebauthnAuthenticatorOptionFactory,
   EnrollWebauthnAuthenticatorRemediationFactory,
   SelectIdentifyRemediationFactory,
-  EnrollProfileWithPasswordRemediationFactory
+  EnrollProfileWithPasswordRemediationFactory,
+  EmailAuthenticatorVerificationDataRemediationFactory,
+  VerifyEmailRemediationFactory,
+  SelectAuthenticatorAuthenticateRemediationFactory,
 } from '@okta/test.support/idx';
 import util from '@okta/test.support/util';
 
@@ -2510,6 +2513,93 @@ describe('idx/register', () => {
         scopes: ['meta']
       }, {
         authorizeUrl: 'meta-authorizeUrl'
+      });
+    });
+  });
+
+  // OKTA-1197302: when the password authenticator policy has the
+  // "Send recovery email to user's primary and secondary email addresses
+  // even when the email authenticator has not been enrolled" recovery
+  // setting on, the IDX server returns auth-style remediations
+  // (authenticator-verification-data, challenge-authenticator,
+  // challenge-poll, select-authenticator-authenticate) during the
+  // registration flow. Without these mappings, RegistrationFlow could not
+  // match them and threw "No remediation can match current flow".
+  describe('post-password recovery-email verification (OKTA-1197302)', () => {
+    it('handles authenticator-verification-data during registration', async () => {
+      const { authClient } = testContext;
+
+      const verificationDataResponse = IdxResponseFactory.build({
+        neededToProceed: [
+          EmailAuthenticatorVerificationDataRemediationFactory.build()
+        ]
+      });
+
+      jest.spyOn(mocked.introspect, 'introspect')
+        .mockResolvedValue(verificationDataResponse);
+
+      const res = await register(authClient, {});
+      expect(res.status).toBe(IdxStatus.PENDING);
+      expect(res.nextStep).toMatchObject({
+        name: 'authenticator-verification-data',
+      });
+    });
+
+    it('proceeds to challenge-authenticator and verifies with code', async () => {
+      const { authClient, successWithInteractionCodeResponse } = testContext;
+
+      const challengeAuthenticatorResponse = IdxResponseFactory.build({
+        neededToProceed: [
+          VerifyEmailRemediationFactory.build()
+        ]
+      });
+
+      chainResponses([
+        challengeAuthenticatorResponse,
+        successWithInteractionCodeResponse
+      ]);
+      jest.spyOn(challengeAuthenticatorResponse, 'proceed');
+      jest.spyOn(mocked.introspect, 'introspect')
+        .mockResolvedValue(challengeAuthenticatorResponse);
+
+      let res = await register(authClient, {});
+      expect(res.status).toBe(IdxStatus.PENDING);
+      expect(res.nextStep).toMatchObject({
+        name: 'challenge-authenticator',
+      });
+
+      const verificationCode = 'test-code';
+      res = await register(authClient, { verificationCode });
+      expect(challengeAuthenticatorResponse.proceed).toHaveBeenCalledWith(
+        'challenge-authenticator',
+        { credentials: { passcode: 'test-code' } }
+      );
+    });
+
+    it('handles select-authenticator-authenticate during registration', async () => {
+      const { authClient } = testContext;
+
+      const selectAuthenticateResponse = IdxResponseFactory.build({
+        neededToProceed: [
+          SelectAuthenticatorAuthenticateRemediationFactory.build({
+            value: [
+              AuthenticatorValueFactory.build({
+                options: [
+                  EmailAuthenticatorOptionFactory.build()
+                ]
+              })
+            ]
+          })
+        ]
+      });
+
+      jest.spyOn(mocked.introspect, 'introspect')
+        .mockResolvedValue(selectAuthenticateResponse);
+
+      const res = await register(authClient, {});
+      expect(res.status).toBe(IdxStatus.PENDING);
+      expect(res.nextStep).toMatchObject({
+        name: 'select-authenticator-authenticate',
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes [OKTA-1197302](https://oktainc.atlassian.net/browse/OKTA-1197302). When an org has the password authenticator's recovery setting **"Send recovery email to user's primary and secondary email addresses even when the email authenticator has not been enrolled"** enabled, signup through the embedded Sign-In Widget fails with:

> AuthSdkError: No remediation can match current flow, check policy settings in your org. Remediations: [authenticator-verification-data]

Reported by client. Password recovery is unaffected; only registration breaks.

## Root cause

The recovery setting causes the IDX server to treat the email authenticator as implicitly enrolled during signup (it appears in `currentAuthenticatorEnrollment` with `allowedFor: "none"`). After password enrollment, the server returns auth-style remediations to drive the email verification step:

- `authenticator-verification-data`
- `challenge-authenticator`
- `challenge-poll`
- `select-authenticator-authenticate`

`AuthenticationFlow` already maps all four. `RegistrationFlow` did not, so the SDK could not match any of them and threw.

## Fix

`lib/idx/flow/RegistrationFlow.ts` — wire the same four remediator names that `AuthenticationFlow` uses. The remediator classes (`SelectAuthenticatorAuthenticate`, `AuthenticatorVerificationData`, `ChallengeAuthenticator`, `ChallengePoll`) already exist and are exercised by the auth flow; this PR only adds the registration-flow entries to the dispatch map.

## Why all four (not just `authenticator-verification-data`)

The captured failing response only contained `authenticator-verification-data` because IDX returns one remediation per response. The flow that follows it (`challenge-authenticator` for the OTP, `challenge-poll` for magic-link variants, `select-authenticator-authenticate` for orgs with multiple recovery factors) would surface the same error class on subsequent steps. Mirroring `AuthenticationFlow` exactly keeps the two flows internally consistent and closes the whole class of failures with one change.

## Captured failing IDX response

<details>
<summary>Snippet of the response that triggered the bug (only <code>authenticator-verification-data</code> in <code>neededToProceed</code>)</summary>

~~~json
{
  "remediation": {
    "type": "array",
    "value": [
      {
        "name": "authenticator-verification-data",
        "relatesTo": ["$.currentAuthenticatorEnrollment"]
      }
    ]
  },
  "currentAuthenticatorEnrollment": {
    "type": "object",
    "value": { "type": "email", "key": "okta_email" }
  },
  "authenticators": {
    "type": "array",
    "value": [
      { "type": "email", "key": "okta_email", "allowedFor": "none" }
    ]
  },
  "authenticatorEnrollments": { "type": "array", "value": [] }
}
~~~

Note `allowedFor: "none"` and the empty `authenticatorEnrollments` — confirms the email authenticator is implicitly enrolled by the recovery policy rather than user-enrolled, which is the bug condition.

</details>

## Tests

`test/spec/idx/register.ts` — new `describe('post-password recovery-email verification (OKTA-1197302)')` block with three cases:

- `handles authenticator-verification-data during registration` — the originally failing IDX response shape now resolves to a `nextStep` instead of throwing.
- `proceeds to challenge-authenticator and verifies with code` — the OTP submission step works during registration.
- `handles select-authenticator-authenticate during registration` — the multi-recovery-factor variant resolves to a `nextStep`.

All 38 tests in `spec/idx/register` pass.

New tests were failing prior to applying the fix.

## Manual verification

Reproduced the bug end-to-end against a test org configured with the affected password recovery policy, using a local build of `okta-signin-widget` linked to this fix. Confirmed:

- **Before fix:** Widget shows "No remediation can match current flow" on the password setup screen. Signup is unrecoverable.
- **After fix:** Widget proceeds to the email verification step, accepts the OTP code, and signup completes.

### Recordings

Before:

https://github.com/user-attachments/assets/f1774996-34e5-498b-863b-b4e46bbcc7e5
 
After: 

https://github.com/user-attachments/assets/080facc4-01f9-4b86-ac3d-d929a2e266d5

