### PR TITLE
fix: adds format property to IonField

### DIFF
--- a/lib/idx/types/api.ts
+++ b/lib/idx/types/api.ts
@@ -75,6 +75,8 @@ export enum AuthenticatorKey {
   WEBAUTHN = 'webauthn',
 }
 
+export type InputFormat = 'numeric' | 'alphanumeric';
+
 export type Input = {
   name: string;
   key?: string;
@@ -88,7 +90,8 @@ export type Input = {
   options?: IdxOption[];
   mutable?: boolean;
   visible?: boolean;
-  customLabel?: boolean
+  customLabel?: boolean;
+  format?: InputFormat;
 }
 
 


### PR DESCRIPTION
Adds new `format` property that supports `numeric` and `alphanumeric` values for now.